### PR TITLE
Validation route to parse/translate screwdriver.yamls

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -13,7 +13,8 @@ function registerDefaultPlugins(server, callback) {
         'vision',
         '../plugins/status',
         '../plugins/logging',
-        '../plugins/swagger'
+        '../plugins/swagger',
+        '../plugins/validator'
     /* eslint-disable global-require */
     ].map((plugin) => require(plugin));
     /* eslint-enable global-require */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "API server for the Screwdriver CD service",
   "main": "index.js",
   "scripts": {
@@ -49,6 +49,7 @@
     "joi": "^9.0.1",
     "js-yaml": "^3.6.1",
     "jsonwebtoken": "^7.1.6",
+    "screwdriver-config-parser": "^1.0.0",
     "screwdriver-data-schema": "^5.0.3",
     "screwdriver-datastore-imdb": "^1.0.0",
     "screwdriver-executor-k8s": "^2.0.0",

--- a/plugins/validator.js
+++ b/plugins/validator.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const parser = require('screwdriver-config-parser');
+const schema = require('screwdriver-data-schema');
+const validatorSchema = schema.api.validator;
+const boom = require('boom');
+
+/**
+ * Hapi Validator Plugin
+ *  - Validates screwdriver.yaml and returns the expected execution steps
+ * @method register
+ * @param  {Hapi.Server}    server
+ * @param  {Object}         options
+ * @param  {Function} next
+ */
+exports.register = (server, options, next) => {
+    server.route({
+        method: 'POST',
+        path: '/validator',
+        config: {
+            description: 'Validate a given screwdriver.yaml',
+            notes: 'Returns the parsed config or validation errors',
+            tags: ['api', 'validation', 'yaml'],
+            handler: (request, reply) => {
+                parser(request.payload.yaml, (err, pipeline) => {
+                    if (err) {
+                        return reply(boom.badRequest(err.message));
+                    }
+
+                    return reply(pipeline);
+                });
+            },
+            validate: {
+                payload: validatorSchema.input
+            },
+            response: {
+                schema: validatorSchema.output
+            }
+        }
+    });
+    next();
+};
+
+exports.register.attributes = {
+    name: 'validator'
+};

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -11,7 +11,8 @@ describe('Register Unit Test Case', () => {
         'vision',
         '../plugins/status',
         '../plugins/logging',
-        '../plugins/swagger'
+        '../plugins/swagger',
+        '../plugins/validator'
     ];
     const resourcePlugins = [
         '../plugins/login',

--- a/test/plugins/data/validator.input.json
+++ b/test/plugins/data/validator.input.json
@@ -1,0 +1,1 @@
+{"yaml":"jobs:\n    main:\n        image: node:{{NODE_VERSION}}\n        matrix:\n            NODE_VERSION: [4,6]\n        steps:\n            install: npm install\n            test: npm test\n            build: npm run build\n\n    publish:\n        image: node:4\n        steps:\n            install: npm publish\n"}

--- a/test/plugins/data/validator.output.json
+++ b/test/plugins/data/validator.output.json
@@ -1,0 +1,40 @@
+{
+  "jobs": {
+    "main": [
+      {
+        "image": "node:4",
+        "steps": {
+          "install": "npm install",
+          "test": "npm test",
+          "build": "npm run build"
+        },
+        "environment": {
+          "NODE_VERSION": 4
+        }
+      },
+      {
+        "image": "node:6",
+        "steps": {
+          "install": "npm install",
+          "test": "npm test",
+          "build": "npm run build"
+        },
+        "environment": {
+          "NODE_VERSION": 6
+        }
+      }
+    ],
+    "publish": [
+      {
+        "image": "node:4",
+        "steps": {
+          "install": "npm publish"
+        },
+        "environment": {}
+      }
+    ]
+  },
+  "workflow": [
+    "publish"
+  ]
+}

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -3,7 +3,6 @@ const assert = require('chai').assert;
 const sinon = require('sinon');
 const hapi = require('hapi');
 const mockery = require('mockery');
-// const urlLib = require('url');
 
 const testJob = require('./data/job.json');
 const testJobs = require('./data/jobs.json');

--- a/test/plugins/validator.test.js
+++ b/test/plugins/validator.test.js
@@ -1,0 +1,81 @@
+'use strict';
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const hapi = require('hapi');
+const mockery = require('mockery');
+
+const testInput = require('./data/validator.input.json');
+const testOutput = require('./data/validator.output.json');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('validator plugin test', () => {
+    let plugin;
+    let server;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach((done) => {
+        /* eslint-disable global-require */
+        plugin = require('../../plugins/validator');
+        /* eslint-enable global-require */
+
+        server = new hapi.Server();
+        server.connection({
+            port: 1234
+        });
+
+        server.register([{
+            register: plugin
+        }], (err) => {
+            done(err);
+        });
+    });
+
+    afterEach(() => {
+        server = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('registers the plugin', () => {
+        assert.isOk(server.registrations.validator);
+    });
+
+    describe('POST /validator', () => {
+        it('returns 200 for a successful yaml', (done) => {
+            server.inject({
+                method: 'POST',
+                url: '/validator',
+                payload: testInput
+            }, (reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testOutput);
+                done();
+            });
+        });
+
+        it('returns 400 for bad yaml', (done) => {
+            server.inject({
+                method: 'POST',
+                url: '/validator',
+                payload: {
+                    yaml: 'jobs: {}'
+                }
+            }, (reply) => {
+                assert.equal(reply.statusCode, 400);
+                assert.match(reply.result.message, /"main" is required/);
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
This adds a new route `/v3/validate` that passes a given yaml file through the [config-parser](https://github.com/screwdriver-cd/config-parser).  This way we don't need to install the config-parser locally in the launcher AND we can start a validate page.