### PR TITLE
Fixing label for list responses (fixes Swagger validation)

### DIFF
--- a/plugins/builds/list.js
+++ b/plugins/builds/list.js
@@ -1,7 +1,7 @@
 'use strict';
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.build.get);
+const listSchema = joi.array().items(schema.models.build.get).label('List of Builds');
 const Model = require('screwdriver-models');
 
 module.exports = (datastore, executor) => ({

--- a/plugins/jobs/list.js
+++ b/plugins/jobs/list.js
@@ -1,7 +1,7 @@
 'use strict';
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.job.get);
+const listSchema = joi.array().items(schema.models.job.get).label('List of Jobs');
 const Model = require('screwdriver-models');
 
 module.exports = (datastore) => ({

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -1,7 +1,7 @@
 'use strict';
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.pipeline.get);
+const listSchema = joi.array().items(schema.models.pipeline.get).label('List of Pipelines');
 const Model = require('screwdriver-models');
 
 module.exports = (datastore) => ({

--- a/plugins/platforms/list.js
+++ b/plugins/platforms/list.js
@@ -1,7 +1,7 @@
 'use strict';
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.platform.get);
+const listSchema = joi.array().items(schema.models.platform.get).label('List of Platforms');
 const Model = require('screwdriver-models');
 
 module.exports = (datastore) => ({


### PR DESCRIPTION
According to http://bigstickcarpet.com/swagger-parser/www/index.html, our validation failed because all the `list` APIs had a schema with a `null` title.

Adding `label` fixes this title.

Before:
```
"responses": {
  "200": {
    "schema": {
      "$ref": "#/definitions/Model 4",
      "title": null
    },
    "description": "Successful"
  }
}
```

After:
```
"responses": {
  "200": {
    "schema": {
      "$ref": "#/definitions/List of Builds",
      "title": "List of Builds"
    },
    "description": "Successful"
  }
}
```