### PR TITLE
User's username to start the build

### DIFF
--- a/test/plugins/github.test.js
+++ b/test/plugins/github.test.js
@@ -170,6 +170,7 @@ describe('github plugin test', () => {
                     const name = 'PR-1';
                     const buildNumber = '12345';
                     const sha = '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c';
+                    const username = 'baxterthehacker';
 
                     options.payload = testPayloadOpen;
 
@@ -188,7 +189,7 @@ describe('github plugin test', () => {
                         assert.calledWith(pipelineMock.generateId, { scmUrl });
                         assert.calledWith(jobMock.create, { pipelineId, name });
                         assert.calledWith(jobMock.generateId, { pipelineId, name });
-                        assert.calledWith(buildMock.create, { jobId, sha });
+                        assert.calledWith(buildMock.create, { jobId, sha, username });
                         done();
                     });
                 });
@@ -199,6 +200,7 @@ describe('github plugin test', () => {
                     const jobId = 'jobHash';
                     const name = 'PR-1';
                     const sha = '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c';
+                    const username = 'baxterthehacker';
 
                     options.payload = testPayloadOpen;
 
@@ -214,7 +216,7 @@ describe('github plugin test', () => {
                         assert.calledWith(pipelineMock.generateId, { scmUrl });
                         assert.calledWith(jobMock.create, { pipelineId, name });
                         assert.calledWith(jobMock.generateId, { pipelineId, name });
-                        assert.calledWith(buildMock.create, { jobId, sha });
+                        assert.calledWith(buildMock.create, { jobId, sha, username });
                         done();
                     });
                 });


### PR DESCRIPTION
There is a fundamental gap where we do not have a headless user that acts on behalf of the system. In lieu of that, we need the a user to update the PR status.

This PR is to utilize the user who opened the PR. This will allow us to make status changes to the given PR.