### PR TITLE
Remove overuse of bind/apply in waterfalls.

### DIFF
--- a/plugins/github.js
+++ b/plugins/github.js
@@ -4,9 +4,9 @@ const hoek = require('hoek');
 const async = require('async');
 const boom = require('boom');
 const Models = require('screwdriver-models');
-let Pipeline;
-let Job;
-let Build;
+let pipeline;
+let job;
+let build;
 
 /**
  * Create a new job and start the build for an opened pull-request
@@ -29,13 +29,13 @@ function pullRequestOpened(options, request, reply) {
 
     async.waterfall([
         // Create job
-        async.apply(Job.create.bind(Job), { pipelineId, name }),
+        (next) => job.create({ pipelineId, name }, next),
         // Log it
-        (job, next) => {
-            request.log(['webhook-github', eventId, jobId], `${job.name} created`);
+        (jobData, next) => {
+            request.log(['webhook-github', eventId, jobId], `${jobData.name} created`);
             next();
         },
-        async.apply(Pipeline.get.bind(Pipeline), pipelineId),
+        (next) => pipeline.get(pipelineId, next),
         // Log it
         (pipelineData, next) => {
             const username = Object.keys(pipelineData.admins)[0];
@@ -54,12 +54,12 @@ function pullRequestOpened(options, request, reply) {
             const tokenGen = (buildId) =>
                 request.server.plugins.login.generateToken(buildId, ['build']);
 
-            Build.create({ jobId, sha, username, apiUri, tokenGen }, next);
+            build.create({ jobId, sha, username, apiUri, tokenGen }, next);
         },
         // Log it
-        (build, next) => {
-            request.log(['webhook-github', eventId, jobId, build.id], `${name} started `
-                + `${build.number}`);
+        (buildData, next) => {
+            request.log(['webhook-github', eventId, jobId, buildData.id], `${name} started `
+                + `${buildData.number}`);
             next();
         }
     ], (waterfallError) => {
@@ -88,7 +88,7 @@ function pullRequestClosed(options, request, reply) {
     const name = options.name;
 
     // @TODO stop running build
-    Job.update({
+    job.update({
         id: jobId,
         data: {
             state: 'DISABLED'
@@ -127,16 +127,16 @@ function pullRequestEvent(request, reply) {
     // Possible actions
     // "opened", "closed", "reopened", "synchronize",
     // "assigned", "unassigned", "labeled", "unlabeled", "edited"
-    Pipeline.sync({ scmUrl }, (err, data) => {
+    pipeline.sync({ scmUrl }, (err, data) => {
         if (err) {
             return reply(boom.wrap(err));
         }
         if (!data) {
             return reply(boom.notFound('Pipeline does not exist'));
         }
-        const pipelineId = Pipeline.generateId({ scmUrl });
+        const pipelineId = pipeline.generateId({ scmUrl });
         const name = `PR-${prNumber}`;
-        const jobId = Job.generateId({ pipelineId, name });
+        const jobId = job.generateId({ pipelineId, name });
 
         switch (action) {
         case 'opened':
@@ -179,9 +179,9 @@ function pullRequestEvent(request, reply) {
  */
 exports.register = (server, options, next) => {
     // Do some silly setup of stuff
-    Pipeline = new Models.Pipeline(server.settings.app.datastore);
-    Job = new Models.Job(server.settings.app.datastore);
-    Build = new Models.Build(server.settings.app.datastore, server.settings.app.executor);
+    pipeline = new Models.Pipeline(server.settings.app.datastore);
+    job = new Models.Job(server.settings.app.datastore);
+    build = new Models.Build(server.settings.app.datastore, server.settings.app.executor);
 
     // Register the hook interface
     server.register(githubWebhooks);

--- a/plugins/login/login.js
+++ b/plugins/login/login.js
@@ -53,23 +53,23 @@ module.exports = (server, config) => ({
 
             request.cookieAuth.set(profile);
 
-            const User = new Model.User(server.settings.app.datastore, config.password);
-            const id = User.generateId({ username });
+            const user = new Model.User(server.settings.app.datastore, config.password);
+            const id = user.generateId({ username });
             const githubToken = request.auth.credentials.token;
 
-            User.sealToken(githubToken, (err, sealed) => {
+            user.sealToken(githubToken, (err, sealed) => {
                 async.waterfall([
-                    async.apply(User.get.bind(User), id),
-                    (user, cb) => {
-                        if (!user) {
-                            return User.create({
+                    (next) => user.get(id, next),
+                    (userData, cb) => {
+                        if (!userData) {
+                            return user.create({
                                 username,
                                 token: sealed
                             }, cb);
                         }
 
-                        return User.update({
-                            id: user.id,
+                        return user.update({
+                            id: userData.id,
                             data: {
                                 token: sealed
                             }


### PR DESCRIPTION
Both bind and async.apply produce anonymous functions. Function.prototype.apply normally takes a context, but async.apply uses `null` for this context, thus requiring a class method to be bound. We don't need to do any of this since we can create a simple ES6 style anonymous function that executes the original function properly, without needing to insert a context at all, while being just as readable.

I've also fixed the caps on the "instanceOf" variables so they don't look like their respective classes.