### PR TITLE
[F1] Using new Executor Format (with tokens and API URI) (5th)

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -45,6 +45,8 @@ executor:
         host: kubernetes
         # The jwt token used for authenticating kubernetes requests
         token: NOT-A-REAL-JWT-TOKEN
+        # Container tag to use
+        version: v1.0.2
 
 webhooks:
     github:

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "screwdriver-data-schema": "^9.0.0",
     "screwdriver-datastore-dynamodb": "^1.0.0",
     "screwdriver-datastore-imdb": "^1.0.0",
-    "screwdriver-executor-k8s": "^3.0.0",
-    "screwdriver-models": "^6.0.0",
+    "screwdriver-executor-k8s": "^4.0.0",
+    "screwdriver-models": "^7.0.0",
     "verror": "^1.6.1",
     "vision": "^4.1.0",
     "winston": "^2.2.0"


### PR DESCRIPTION
[Feature](https://github.com/screwdriver-cd/screwdriver/issues/77)

Passing:
 - buildId - Build Identifier (to look up stuff)
 - container - Container to start in
 - apiUri - URI to hit our API
 - token - Token to be able to read/write from the API

executor `version` is the job-tools version to be used here https://github.com/screwdriver-cd/executor-k8s/blob/master/config/job.yaml.tim#L17