### PR TITLE
Stop build on PR sync

### DIFF
--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -125,10 +125,7 @@ function pullRequestSync(options, request, reply) {
         (builds, next) => {
             async.each(
                 builds,
-                (buildObj, cb) => {
-                    // TODO: add in stopping of job
-                    cb();
-                },
+                (buildObj, cb) => build.stop({ buildId: buildObj.id }, cb),
                 next
             );
         },


### PR DESCRIPTION
This PR is tying together the `buildModel.stop` function into the github sync webhook

Dependent on: https://github.com/screwdriver-cd/models/pull/34

One thing I'm wondering is if we should refactor the `getBuildsByJobId` and `buildModel.stop` into a `jobModel.stop` method

Feature: https://github.com/screwdriver-cd/screwdriver/issues/79