### PR TITLE
Register webhooks correctly

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -31,7 +31,7 @@ require('../')({
     pipelines: {
         password: loginConfig.password
     },
-    github: {
+    webhooks: {
         secret: gitHubSecret
     }
 }, (err, server) => {

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -41,7 +41,7 @@ function registerResourcePlugins(server, config, callback) {
         'builds',
         'jobs',
         'pipelines',
-        'github'
+        'webhooks'
     ];
 
     async.eachSeries(plugins, (pluginName, next) => {

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -19,7 +19,7 @@ describe('Register Unit Test Case', () => {
         '../plugins/builds',
         '../plugins/jobs',
         '../plugins/pipelines',
-        '../plugins/github'
+        '../plugins/webhooks'
     ];
     const pluginLength = expectedPlugins.length + resourcePlugins.length;
     const mocks = {};


### PR DESCRIPTION
`npm start` is not working because the plugin is called `webhooks`, not `github`
@stjohnjohnson 