### PR TITLE
Route for returning statistics

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -46,6 +46,9 @@ require('../')({
     webhooks: {
         secret: gitHubSecret,
         password: loginConfig.password
+    },
+    stats: {
+        executor
     }
 }, (err, server) => {
     if (err) {

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -41,7 +41,8 @@ function registerResourcePlugins(server, config, callback) {
         'builds',
         'jobs',
         'pipelines',
-        'webhooks'
+        'webhooks',
+        'stats'
     ];
 
     async.eachSeries(plugins, (pluginName, next) => {

--- a/plugins/stats.js
+++ b/plugins/stats.js
@@ -1,0 +1,30 @@
+'use strict';
+/**
+ * Hapi interface for plugin to set up status endpoint (see Hapi docs)
+ * @method register
+ * @param  {Hapi.Server}    server
+ * @param  {Object}         options
+ * @param  {Function} next
+ */
+exports.register = (server, options, next) => {
+    const executor = options.executor;
+
+    server.route({
+        method: 'GET',
+        path: '/stats',
+        config: {
+            description: 'API stats',
+            notes: 'Should return statistics for the entire system',
+            tags: ['api', 'stats']
+        },
+        handler: (request, reply) => reply({
+            executor: executor.stats()
+        })
+    });
+    next();
+};
+
+exports.register.attributes = {
+    name: 'stats',
+    version: '1.0.0'
+};

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -19,7 +19,8 @@ describe('Register Unit Test Case', () => {
         '../plugins/builds',
         '../plugins/jobs',
         '../plugins/pipelines',
-        '../plugins/webhooks'
+        '../plugins/webhooks',
+        '../plugins/stats'
     ];
     const pluginLength = expectedPlugins.length + resourcePlugins.length;
     const mocks = {};

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -1,0 +1,77 @@
+'use strict';
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const hapi = require('hapi');
+const mockery = require('mockery');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('stats plugin test', () => {
+    let plugin;
+    let server;
+    let mockExecutor;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach((done) => {
+        mockExecutor = {
+            stats: sinon.stub()
+        };
+
+        /* eslint-disable global-require */
+        plugin = require('../../plugins/stats');
+        /* eslint-enable global-require */
+
+        server = new hapi.Server();
+        server.connection({
+            port: 1234
+        });
+
+        server.register([{
+            register: plugin,
+            options: {
+                executor: mockExecutor
+            }
+        }], (err) => {
+            done(err);
+        });
+    });
+
+    afterEach(() => {
+        server = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('registers the plugin', () => {
+        assert.isOk(server.registrations.stats);
+    });
+
+    describe('GET /stats', () => {
+        it('returns 200 for a successful yaml', () => {
+            const mockReturn = {
+                foo: 'bar'
+            };
+
+            mockExecutor.stats.returns(mockReturn);
+
+            return server.inject({
+                url: '/stats'
+            }).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, {
+                    executor: mockReturn
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Creating a new plugin that can be used for exposing statistics about the entire system. 

Right now there are only executor statistics but eventually there could be a plethora of statistics we want to expose about the system