### PR TITLE
Add stack trace on 500

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,10 @@ function prettyPrintErrors(request, reply) {
         const errMessage = err.message;
         const statusCode = err.output.payload.statusCode;
 
+        if (statusCode === 500) {
+            request.log(['server'], err.stack);
+        }
+
         return reply({
             statusCode,
             error: errName,


### PR DESCRIPTION
Hard to debug errors when 500 as there is no stack trace in the logs. This PR aims to fix that.