### PR TITLE
Add configurable API_URI to github webhook

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -22,6 +22,7 @@ const httpdConfig = config.get('httpd');
 
 // Setup GitHub Webhooks
 const gitHubSecret = config.get('webhooks.github.secret');
+const apiUri = executorConfig.apiUri;
 
 // Setup Model Factories
 const Models = require('screwdriver-models');
@@ -44,6 +45,7 @@ require('../')({
         password: loginConfig.password
     },
     webhooks: {
+        apiUri,
         secret: gitHubSecret,
         password: loginConfig.password
     }

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -29,6 +29,7 @@ datastore:
         secretAccessKey: DATASTORE_DYNAMODB_SECRET
 
 executor:
+    apiUri: API_URI
     k8s:
         # The host or IP of the kubernetes cluster
         host: K8S_HOST

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -40,6 +40,7 @@ datastore:
 
 executor:
     plugin: k8s
+    apiUri: http://0.0.0.0:8080
     k8s:
         # The host or IP of the kubernetes cluster
         host: kubernetes

--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -3,6 +3,7 @@
 const githubWebhooks = require('hapi-github-webhooks');
 const hoek = require('hoek');
 const boom = require('boom');
+let API_URI;
 
 /**
  * Create a new job and start the build for an opened pull-request
@@ -41,7 +42,7 @@ function pullRequestOpened(options, request, reply) {
         })
         // create a build
         .then(jobId => {
-            const apiUri = request.server.info.uri;
+            const apiUri = API_URI || request.server.info.uri;
             const tokenGen = (buildId) =>
                 request.server.plugins.login.generateToken(buildId, ['build']);
 
@@ -233,6 +234,7 @@ function pullRequestEvent(request, reply) {
  * @param  {Object}         options
  * @param  {String}         options.secret    GitHub Webhook secret to sign payloads with
  * @param  {String}         options.password  Login password
+ * @param  {String}         options.apiUri    Server to contact for notifications
  * @param  {Function}       next
  */
 module.exports = (server, options) => {
@@ -242,6 +244,7 @@ module.exports = (server, options) => {
     server.auth.strategy('githubwebhook', 'githubwebhook', {
         secret: options.secret
     });
+    API_URI = options.apiUri;
 
     // Now use it
     return {

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -60,7 +60,7 @@ describe('github plugin test', () => {
             host: 'localhost',
             port: 12345
         });
-        apiUri = 'http://localhost:12345';
+        apiUri = 'http://foo.bar:12345';
 
         server.register([{
             // eslint-disable-next-line global-require
@@ -76,6 +76,7 @@ describe('github plugin test', () => {
         {
             register: plugin,
             options: {
+                apiUri,
                 secret: 'secretssecretsarenofun'
             }
         }], (err) => {


### PR DESCRIPTION
Aimed at fixing `500` errors when doing github notifications.