### PR TITLE
Fix signature for getBuildsForJobId

### DIFF
--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -77,7 +77,7 @@ function pullRequestClosed(options, request, reply) {
 
     // fetch the builds to stop, and the job to update
     return Promise.all([
-        buildFactory.getBuildsForJobId(jobId), // someday this should just be job.builds
+        buildFactory.getBuildsForJobId({ jobId }), // someday this should just be job.builds
         jobFactory.get(jobId)
     ])
     .then(([builds, job]) =>
@@ -123,7 +123,7 @@ function pullRequestSync(options, request, reply) {
     const username = options.username;
     const jobId = options.jobId;
 
-    return buildFactory.getBuildsForJobId(jobId)
+    return buildFactory.getBuildsForJobId({ jobId })
         // stop all running builds
         .then(builds => Promise.all(builds.map(b => b.stop())))
         // log build stoppage

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -279,7 +279,9 @@ describe('github plugin test', () => {
                     const model1 = { id: 1, stop: sinon.stub().resolves(null) };
                     const model2 = { id: 2, stop: sinon.stub().resolves(null) };
 
-                    buildFactoryMock.getBuildsForJobId.resolves([model1, model2]);
+                    buildFactoryMock.getBuildsForJobId.withArgs({ jobId }).resolves(
+                        [model1, model2]
+                    );
 
                     server.inject(options, (reply) => {
                         assert.equal(reply.statusCode, 201);
@@ -324,7 +326,9 @@ describe('github plugin test', () => {
                     const model1 = { id: 1, stop: sinon.stub().resolves(null) };
                     const model2 = { id: 2, stop: sinon.stub().resolves(null) };
 
-                    buildFactoryMock.getBuildsForJobId.resolves([model1, model2]);
+                    buildFactoryMock.getBuildsForJobId.withArgs({ jobId }).resolves(
+                        [model1, model2]
+                    );
 
                     server.inject(options, () => {
                         assert.calledOnce(model1.stop);


### PR DESCRIPTION
getBuildsForJobId expects a config object, instead of just the jobId.