### PR TITLE
Simplify secret environment variables in Kubernetes deployment YAML

### DIFF
--- a/kubernetes/api_deployment.yaml
+++ b/kubernetes/api_deployment.yaml
@@ -15,6 +15,7 @@ spec:
         image: screwdrivercd/screwdriver
         ports:
         - containerPort: 8080
+        # Environment variables that point to your secrets in your secrets.yaml
         env:
           - name: DATASTORE_PLUGIN
             value: dynamodb
@@ -25,35 +26,35 @@ spec:
           - name: SECRET_JWT_PRIVATE_KEY
             valueFrom:
               secretKeyRef:
-                name: plugin-login-secrets
+                name: secrets
                 key: jwtprivatekey
           - name: SECRET_OAUTH_CLIENT_ID
             valueFrom:
               secretKeyRef:
-                name: plugin-login-secrets
+                name: secrets
                 key: oauthclientid
           - name: SECRET_OAUTH_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: plugin-login-secrets
+                name: secrets
                 key: oauthclientsecret
           - name: SECRET_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: plugin-login-secrets
+                name: secrets
                 key: password
           - name: K8S_TOKEN
             valueFrom:
               secretKeyRef:
-                name: default-token-sw0ar
+                name: default-token-sw0ar     # insert your Kubernetes <DEFAULT_TOKEN_NAME> here
                 key: token
           - name: DATASTORE_DYNAMODB_ID
             valueFrom:
               secretKeyRef:
-                name: datastore-dynamodb
-                key: id
+                name: secrets
+                key: dynamodbid
           - name: DATASTORE_DYNAMODB_SECRET
             valueFrom:
               secretKeyRef:
-                name: datastore-dynamodb
-                key: secret
+                name: secrets
+                key: dynamodbsecret


### PR DESCRIPTION
Created a `secrets.yaml` file in Kubernetes to include all secrets used in the deployment instead of having them scattered in separate files. This change was done to make the environment variable section in the `api_deployment.yaml` more clear for users.

This pull request covers the changes made in the `api_deployment.yaml` to use the new secrets in `secrets.yaml`.