### PR TITLE
Pass Factories via server.app

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -46,14 +46,16 @@ function prettyPrintErrors(request, reply) {
  */
 module.exports = (config, callback) => {
     // Create a server with a host and port
-    const server = new Hapi.Server({
-        app: {
-            pipelineFactory: config.pipelineFactory,
-            jobFactory: config.jobFactory,
-            userFactory: config.userFactory,
-            buildFactory: config.buildFactory
-        }
-    });
+    const server = new Hapi.Server();
+
+    // Set the factorys within server.app
+    // Instantiating the server with the factories will apply a shallow copy
+    server.app = {
+        pipelineFactory: config.pipelineFactory,
+        jobFactory: config.jobFactory,
+        userFactory: config.userFactory,
+        buildFactory: config.buildFactory
+    };
 
     // Initialize server connections
     server.connection(config.httpd);

--- a/plugins/builds/README.md
+++ b/plugins/builds/README.md
@@ -57,12 +57,12 @@ Example payload:
 ```
 
 ### Access to Factory methods
-The server supplies factories to plugins in the form of server settings:
+The server supplies factories to plugins in the form of server app values:
 
 ```js
-// buildsPlugin.js
-module.exports = (server) => {
-    const factory = server.settings.app.buildFactory;
+// handler in buildsPlugin.js
+handler: (request, reply) => {
+    const factory = request.server.app.buildFactory;
 
     // ...
 }

--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -3,7 +3,7 @@ const boom = require('boom');
 const urlLib = require('url');
 const validationSchema = require('screwdriver-data-schema');
 
-module.exports = (server, options) => ({
+module.exports = (options) => ({
     method: 'POST',
     path: '/builds',
     config: {
@@ -15,9 +15,9 @@ module.exports = (server, options) => ({
             scope: ['user']
         },
         handler: (request, reply) => {
-            const jobFactory = server.settings.app.jobFactory;
-            const buildFactory = server.settings.app.buildFactory;
-            const userFactory = server.settings.app.userFactory;
+            const jobFactory = request.server.app.jobFactory;
+            const buildFactory = request.server.app.buildFactory;
+            const userFactory = request.server.app.userFactory;
             const username = request.auth.credentials.username;
             const payload = {
                 jobId: request.payload.jobId,

--- a/plugins/builds/get.js
+++ b/plugins/builds/get.js
@@ -5,7 +5,7 @@ const schema = require('screwdriver-data-schema');
 const getSchema = schema.models.build.get;
 const idSchema = joi.reach(schema.models.build.base, 'id');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'GET',
     path: '/builds/{id}',
     config: {
@@ -13,7 +13,7 @@ module.exports = (server) => ({
         notes: 'Returns a build record',
         tags: ['api', 'builds'],
         handler: (request, reply) => {
-            const factory = server.settings.app.buildFactory;
+            const factory = request.server.app.buildFactory;
 
             factory.get(request.params.id)
                 .then(model => {

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -15,11 +15,11 @@ const streamLogsRoute = require('./stream');
  */
 exports.register = (server, options, next) => {
     server.route([
-        listRoute(server),
-        getRoute(server),
-        streamLogsRoute(server),
-        updateRoute(server),
-        createRoute(server, options)
+        listRoute(),
+        getRoute(),
+        streamLogsRoute(),
+        updateRoute(),
+        createRoute(options)
     ]);
 
     next();

--- a/plugins/builds/list.js
+++ b/plugins/builds/list.js
@@ -4,7 +4,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const listSchema = joi.array().items(schema.models.build.get).label('List of Builds');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'GET',
     path: '/builds',
     config: {
@@ -12,7 +12,7 @@ module.exports = (server) => ({
         notes: 'Returns all build records',
         tags: ['api', 'builds'],
         handler: (request, reply) => {
-            const factory = server.settings.app.buildFactory;
+            const factory = request.server.app.buildFactory;
 
             return factory.list({
                 paginate: request.query

--- a/plugins/builds/stream.js
+++ b/plugins/builds/stream.js
@@ -4,7 +4,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.build.base, 'id');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'GET',
     path: '/builds/{id}/logs',
     config: {
@@ -16,7 +16,7 @@ module.exports = (server) => ({
             scope: ['user']
         },
         handler: (request, reply) => {
-            const factory = server.settings.app.buildFactory;
+            const factory = request.server.app.buildFactory;
             const id = request.params.id;
 
             return factory.get(id)

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -5,7 +5,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.job.base, 'id');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'PUT',
     path: '/builds/{id}',
     config: {
@@ -17,7 +17,7 @@ module.exports = (server) => ({
             scope: ['user']
         },
         handler: (request, reply) => {
-            const factory = server.settings.app.buildFactory;
+            const factory = request.server.app.buildFactory;
             const id = request.params.id;
 
             return factory.get(id)

--- a/plugins/jobs/README.md
+++ b/plugins/jobs/README.md
@@ -48,12 +48,12 @@ Example payload:
 ```
 
 ### Access to Factory methods
-The server supplies factories to plugins in the form of server settings:
+The server supplies factories to plugins in the form of server app values:
 
 ```js
-// jobsPlugin.js
-module.exports = (server) => {
-    const factory = server.settings.app.jobFactory;
+// handler jobsPlugin.js
+handler: (request, reply) => {
+    const factory = request.server.app.jobFactory;
 
     // ...
 }

--- a/plugins/jobs/get.js
+++ b/plugins/jobs/get.js
@@ -5,7 +5,7 @@ const schema = require('screwdriver-data-schema');
 const getSchema = schema.models.job.get;
 const idSchema = joi.reach(schema.models.job.base, 'id');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'GET',
     path: '/jobs/{id}',
     config: {
@@ -13,7 +13,7 @@ module.exports = (server) => ({
         notes: 'Returns a job record',
         tags: ['api', 'jobs'],
         handler: (request, reply) => {
-            const factory = server.settings.app.jobFactory;
+            const factory = request.server.app.jobFactory;
 
             return factory.get(request.params.id)
                 .then(job => {

--- a/plugins/jobs/index.js
+++ b/plugins/jobs/index.js
@@ -13,9 +13,9 @@ const updateRoute = require('./update');
  */
 exports.register = (server, options, next) => {
     server.route([
-        listRoute(server),
-        getRoute(server),
-        updateRoute(server)
+        listRoute(),
+        getRoute(),
+        updateRoute()
     ]);
 
     next();

--- a/plugins/jobs/list.js
+++ b/plugins/jobs/list.js
@@ -4,7 +4,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const listSchema = joi.array().items(schema.models.job.get).label('List of Jobs');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'GET',
     path: '/jobs',
     config: {
@@ -12,7 +12,7 @@ module.exports = (server) => ({
         notes: 'Returns all jobs records',
         tags: ['api', 'jobs'],
         handler: (request, reply) => {
-            const factory = server.settings.app.jobFactory;
+            const factory = request.server.app.jobFactory;
 
             return factory.list({
                 paginate: request.query

--- a/plugins/jobs/update.js
+++ b/plugins/jobs/update.js
@@ -5,7 +5,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.job.base, 'id');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'PUT',
     path: '/jobs/{id}',
     config: {
@@ -17,7 +17,7 @@ module.exports = (server) => ({
             scope: ['user']
         },
         handler: (request, reply) => {
-            const factory = server.settings.app.jobFactory;
+            const factory = request.server.app.jobFactory;
             const id = request.params.id;
 
             return factory.get(id)

--- a/plugins/login/index.js
+++ b/plugins/login/index.js
@@ -64,7 +64,7 @@ exports.register = (server, options, next) => {
         });
 
         server.route([
-            login(server, options),
+            login(options),
             logout()
         ]);
 

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -81,9 +81,9 @@ Example payload:
 The server supplies factories to plugins in the form of server settings:
 
 ```js
-// pipelinePlugin.js
-module.exports = (server) => {
-    const factory = server.settings.app.pipelineFactory;
+// handler pipelinePlugin.js
+handler: (request, reply) => {
+    const factory = request.server.app.pipelineFactory;
 
     // ...
 }

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -27,7 +27,7 @@ const formatScmUrl = (scmUrl) => {
     return result;
 };
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'POST',
     path: '/pipelines',
     config: {
@@ -39,8 +39,8 @@ module.exports = (server) => ({
             scope: ['user']
         },
         handler: (request, reply) => {
-            const pipelineFactory = server.settings.app.pipelineFactory;
-            const userFactory = server.settings.app.userFactory;
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const userFactory = request.server.app.userFactory;
             const scmUrl = formatScmUrl(request.payload.scmUrl);
             const username = request.auth.credentials.username;
 

--- a/plugins/pipelines/get.js
+++ b/plugins/pipelines/get.js
@@ -5,7 +5,7 @@ const schema = require('screwdriver-data-schema');
 const getSchema = schema.models.pipeline.get;
 const idSchema = joi.reach(schema.models.pipeline.base, 'id');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'GET',
     path: '/pipelines/{id}',
     config: {
@@ -13,7 +13,7 @@ module.exports = (server) => ({
         notes: 'Returns a pipeline record',
         tags: ['api', 'pipelines'],
         handler: (request, reply) => {
-            const factory = server.settings.app.pipelineFactory;
+            const factory = request.server.app.pipelineFactory;
 
             return factory.get(request.params.id)
                 .then(pipeline => {

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -15,10 +15,10 @@ const updateRoute = require('./update');
  */
 exports.register = (server, options, next) => {
     server.route([
-        createRoute(server, options),
-        getRoute(server),
-        listRoute(server),
-        updateRoute(server)
+        createRoute(),
+        getRoute(),
+        listRoute(),
+        updateRoute()
     ]);
 
     next();

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -4,7 +4,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const listSchema = joi.array().items(schema.models.pipeline.get).label('List of Pipelines');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'GET',
     path: '/pipelines',
     config: {
@@ -12,7 +12,7 @@ module.exports = (server) => ({
         notes: 'Returns all pipeline records',
         tags: ['api', 'pipelines'],
         handler: (request, reply) => {
-            const factory = server.settings.app.pipelineFactory;
+            const factory = request.server.app.pipelineFactory;
 
             return factory.list({ paginate: request.query })
                 .then(pipelines => reply(pipelines.map(p => p.toJson())))

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -5,7 +5,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.pipeline.base, 'id');
 
-module.exports = (server) => ({
+module.exports = () => ({
     method: 'PUT',
     path: '/pipelines/{id}',
     config: {
@@ -17,7 +17,7 @@ module.exports = (server) => ({
             scope: ['user']
         },
         handler: (request, reply) => {
-            const factory = server.settings.app.pipelineFactory;
+            const factory = request.server.app.pipelineFactory;
             const id = request.params.id;
 
             return factory.get(id)

--- a/plugins/webhooks/build.js
+++ b/plugins/webhooks/build.js
@@ -5,56 +5,53 @@ const schema = require('screwdriver-data-schema');
 const buildWebhookSchema = schema.api.webhooks.build;
 
 /**
- * Build Webhook Plugin
- *  - Updates the Meta, Status, and Stop Time of a given build
- * @method build
- * @param  {Hapi.Server}    server
- * @param  {Function}       next
- */
-module.exports = (server) => {
-    const factory = server.settings.app.buildFactory;
+* Build Webhook Plugin
+*  - Updates the Meta, Status, and Stop Time of a given build
+* @method build
+* @param  {Hapi.Server}    server
+* @param  {Function}       next
+*/
+module.exports = () => ({
+    method: 'POST',
+    path: '/webhooks/build',
+    config: {
+        description: 'Handle events from Launcher',
+        notes: 'Updates the status of the build',
+        tags: ['api', 'build', 'webhook'],
+        auth: {
+            strategies: ['token'],
+            scope: ['build']
+        },
+        handler: (request, reply) => {
+            const id = request.auth.credentials.username;
+            const status = request.payload.status;
+            const factory = request.server.app.buildFactory;
 
-    return {
-        method: 'POST',
-        path: '/webhooks/build',
-        config: {
-            description: 'Handle events from Launcher',
-            notes: 'Updates the status of the build',
-            tags: ['api', 'build', 'webhook'],
-            auth: {
-                strategies: ['token'],
-                scope: ['build']
-            },
-            handler: (request, reply) => {
-                const id = request.auth.credentials.username;
-                const status = request.payload.status;
+            request.log(['webhook-build', id], `Received status update to ${status}`);
 
-                request.log(['webhook-build', id], `Received status update to ${status}`);
+            return factory.get(id)
+            .then(build => {
+                // can't update a build that does not exist
+                if (!build) {
+                    throw boom.notFound('Build does not exist');
+                }
 
-                return factory.get(id)
-                    .then(build => {
-                        // can't update a build that does not exist
-                        if (!build) {
-                            throw boom.notFound('Build does not exist');
-                        }
+                // set new values
+                build.status = status;
 
-                        // set new values
-                        build.status = status;
+                if (['SUCCESS', 'FAILURE', 'ABORTED'].indexOf(status) > -1) {
+                    build.meta = request.payload.meta || {};
+                    build.endTime = (new Date()).toISOString();
+                }
 
-                        if (['SUCCESS', 'FAILURE', 'ABORTED'].indexOf(status) > -1) {
-                            build.meta = request.payload.meta || {};
-                            build.endTime = (new Date()).toISOString();
-                        }
-
-                        // update the model in datastore
-                        return build.update();
-                    })
-                    .then(() => reply().code(204))
-                    .catch(err => reply(boom.wrap(err)));
-            },
-            validate: {
-                payload: buildWebhookSchema
-            }
+                // update the model in datastore
+                return build.update();
+            })
+            .then(() => reply().code(204))
+            .catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            payload: buildWebhookSchema
         }
-    };
-};
+    }
+});

--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -18,8 +18,8 @@ let API_URI;
  * @param  {Hapi.reply}   reply   Reply to user
  */
 function pullRequestOpened(options, request, reply) {
-    const jobFactory = request.server.settings.app.jobFactory;
-    const buildFactory = request.server.settings.app.buildFactory;
+    const jobFactory = request.server.app.jobFactory;
+    const buildFactory = request.server.app.buildFactory;
     const eventId = options.eventId;
     const pipelineId = options.pipelineId;
     const name = options.name;
@@ -69,8 +69,8 @@ function pullRequestOpened(options, request, reply) {
  * @param  {Hapi.reply}   reply   Reply to user
  */
 function pullRequestClosed(options, request, reply) {
-    const jobFactory = request.server.settings.app.jobFactory;
-    const buildFactory = request.server.settings.app.buildFactory;
+    const jobFactory = request.server.app.jobFactory;
+    const buildFactory = request.server.app.buildFactory;
     const eventId = options.eventId;
     const jobId = options.jobId;
     const name = options.name;
@@ -117,7 +117,7 @@ function pullRequestClosed(options, request, reply) {
  * @param  {Hapi.reply}   reply   Reply to user
  */
 function pullRequestSync(options, request, reply) {
-    const buildFactory = request.server.settings.app.buildFactory;
+    const buildFactory = request.server.app.buildFactory;
     const eventId = options.eventId;
     const name = options.name;
     const username = options.username;
@@ -154,8 +154,8 @@ function pullRequestSync(options, request, reply) {
  * @param  {Hapi.reply}         reply   Reply to user
  */
 function pullRequestEvent(request, reply) {
-    const pipelineFactory = request.server.settings.app.pipelineFactory;
-    const jobFactory = request.server.settings.app.jobFactory;
+    const pipelineFactory = request.server.app.pipelineFactory;
+    const jobFactory = request.server.app.jobFactory;
     const eventId = request.headers['x-github-delivery'];
     const payload = request.payload;
     const action = hoek.reach(payload, 'action');

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -14,7 +14,7 @@ const buildRoute = require('./build');
 exports.register = (server, options, next) => {
     server.route([
         githubRoute(server, options),
-        buildRoute(server, options)
+        buildRoute()
     ]);
 
     next();

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -69,11 +69,11 @@ describe('server case', () => {
         });
 
         it('populates server.app values', () => {
-            Assert.isObject(server.settings.app);
-            Assert.strictEqual(server.settings.app.pipelineFactory, 'pipeline');
-            Assert.strictEqual(server.settings.app.jobFactory, 'job');
-            Assert.strictEqual(server.settings.app.userFactory, 'user');
-            Assert.strictEqual(server.settings.app.buildFactory, 'build');
+            Assert.isObject(server.app);
+            Assert.strictEqual(server.app.pipelineFactory, 'pipeline');
+            Assert.strictEqual(server.app.jobFactory, 'job');
+            Assert.strictEqual(server.app.userFactory, 'user');
+            Assert.strictEqual(server.app.buildFactory, 'build');
         });
     });
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -76,14 +76,13 @@ describe('build plugin test', () => {
         /* eslint-disable global-require */
         plugin = require('../../plugins/builds');
         /* eslint-enable global-require */
-        server = new hapi.Server({
-            app: {
-                buildFactory: buildFactoryMock,
-                pipelineFactory: pipelineFactoryMock,
-                jobFactory: jobFactoryMock,
-                userFactory: userFactoryMock
-            }
-        });
+        server = new hapi.Server();
+        server.app = {
+            buildFactory: buildFactoryMock,
+            pipelineFactory: pipelineFactoryMock,
+            jobFactory: jobFactoryMock,
+            userFactory: userFactoryMock
+        };
         server.connection({
             port: 12345,
             host: 'localhost'

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -47,11 +47,10 @@ describe('job plugin test', () => {
         plugin = require('../../plugins/jobs');
         /* eslint-enable global-require */
 
-        server = new hapi.Server({
-            app: {
-                jobFactory: factoryMock
-            }
-        });
+        server = new hapi.Server();
+        server.app = {
+            jobFactory: factoryMock
+        };
         server.connection({
             port: 1234
         });

--- a/test/plugins/login.test.js
+++ b/test/plugins/login.test.js
@@ -49,11 +49,8 @@ describe('login plugin test', () => {
         /* eslint-disable global-require */
         plugin = require('../../plugins/login');
         /* eslint-enable global-require */
-        server = new hapi.Server({
-            app: {
-                userFactory: userFactoryMock
-            }
-        });
+        server = new hapi.Server();
+        server.app.userFactory = userFactoryMock;
         server.connection({
             port: 1234
         });
@@ -154,7 +151,7 @@ describe('login plugin test', () => {
             });
 
             it('creates a user and returns token', (done) => {
-                userFactoryMock.get.rejects(new Error('not found'));
+                userFactoryMock.get.resolves(null);
 
                 server.inject(options, (reply) => {
                     assert.equal(reply.statusCode, 200, 'Login route should be available');
@@ -170,7 +167,7 @@ describe('login plugin test', () => {
             });
 
             it('returns error if fails to create user', (done) => {
-                userFactoryMock.get.rejects(new Error('getError'));
+                userFactoryMock.get.resolves(null);
                 userFactoryMock.create.rejects(new Error('createError'));
 
                 server.inject(options, (reply) => {
@@ -279,7 +276,7 @@ describe('login plugin test', () => {
         });
 
         it('accepts token', (done) => {
-            userFactoryMock.get.rejects(new Error('not found'));
+            userFactoryMock.get.resolves(null);
             userFactoryMock.create.resolves({});
 
             server.route({

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -67,12 +67,11 @@ describe('pipeline plugin test', () => {
         /* eslint-disable global-require */
         plugin = require('../../plugins/pipelines');
         /* eslint-enable global-require */
-        server = new hapi.Server({
-            app: {
-                pipelineFactory: pipelineFactoryMock,
-                userFactory: userFactoryMock
-            }
-        });
+        server = new hapi.Server();
+        server.app = {
+            pipelineFactory: pipelineFactoryMock,
+            userFactory: userFactoryMock
+        };
         server.connection({
             port: 1234
         });

--- a/test/plugins/webhooks/build.test.js
+++ b/test/plugins/webhooks/build.test.js
@@ -40,11 +40,10 @@ describe('build webhook plugin test', () => {
         // eslint-disable-next-line global-require
         plugin = require('../../../plugins/webhooks');
 
-        server = new hapi.Server({
-            app: {
-                buildFactory: buildFactoryMock
-            }
-        });
+        server = new hapi.Server();
+        server.app = {
+            buildFactory: buildFactoryMock
+        };
         server.connection({
             host: 'localhost',
             port: 12345

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -49,13 +49,12 @@ describe('github plugin test', () => {
         plugin = require('../../../plugins/webhooks');
         /* eslint-enable global-require */
 
-        server = new hapi.Server({
-            app: {
-                jobFactory: jobFactoryMock,
-                buildFactory: buildFactoryMock,
-                pipelineFactory: pipelineFactoryMock
-            }
-        });
+        server = new hapi.Server();
+        server.app = {
+            jobFactory: jobFactoryMock,
+            buildFactory: buildFactoryMock,
+            pipelineFactory: pipelineFactoryMock
+        };
         server.connection({
             host: 'localhost',
             port: 12345


### PR DESCRIPTION
This PR changes how we pass the factories to the plugins, this is because the old way, via the instantiation of the server, actually sets the values via a shallow copy (as seen https://github.com/hapijs/hapi/blob/master/lib/server.js#L34)

Instead, we are going to pass them via server.app settings, which are available wherever there is a server object. 
https://github.com/hapijs/hapi/blob/master/API.md#serverapp

This fixes a bug where the factories do not contain the instance variables that are set