### PR TITLE
Pass in apiUri and tokenGen for sync event

### DIFF
--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -122,6 +122,9 @@ function pullRequestSync(options, request, reply) {
     const name = options.name;
     const username = options.username;
     const jobId = options.jobId;
+    const apiUri = API_URI || request.server.info.uri;
+    const tokenGen = (buildId) =>
+        request.server.plugins.login.generateToken(buildId, ['build']);
 
     return buildFactory.getBuildsForJobId({ jobId })
         // stop all running builds
@@ -131,7 +134,7 @@ function pullRequestSync(options, request, reply) {
             request.log(['webhook-github', eventId, jobId], `${name} stopped`);
         })
         // create a new build
-        .then(() => buildFactory.create({ jobId, username }))
+        .then(() => buildFactory.create({ jobId, username, apiUri, tokenGen }))
         // log build created
         .then(build => {
             request.log(['webhook-github', eventId, jobId, build.id],

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -277,7 +277,14 @@ describe('github plugin test', () => {
                         assert.equal(reply.statusCode, 201);
                         assert.calledOnce(pipelineMock.sync);
                         assert.calledOnce(buildMock.stop);
-                        assert.calledWith(buildFactoryMock.create, { jobId, username });
+                        assert.calledWith(buildFactoryMock.create, {
+                            jobId,
+                            username,
+                            apiUri,
+                            tokenGen: sinon.match.func
+                        });
+                        assert.equal(buildFactoryMock.create.getCall(0).args[0].tokenGen('12345'),
+                            '{"username":"12345","scope":["build"]}"supersecret"');
                         done();
                     });
                 });
@@ -295,9 +302,16 @@ describe('github plugin test', () => {
                         assert.calledOnce(model1.stop);
                         assert.calledOnce(model2.stop);
                         assert.calledOnce(buildFactoryMock.create);
-                        assert.calledWith(buildFactoryMock.create, { jobId, username });
+                        assert.calledWith(buildFactoryMock.create, {
+                            jobId,
+                            username,
+                            apiUri,
+                            tokenGen: sinon.match.func
+                        });
                         assert.isOk(model1.stop.calledBefore(buildFactoryMock.create));
                         assert.isOk(model2.stop.calledBefore(buildFactoryMock.create));
+                        assert.equal(buildFactoryMock.create.getCall(0).args[0].tokenGen('12345'),
+                            '{"username":"12345","scope":["build"]}"supersecret"');
                         done();
                     });
                 });


### PR DESCRIPTION
Resolves https://github.com/screwdriver-cd/screwdriver/issues/109
Sync is not passing in apiUri and tokenGen. 
Error from the screwdriver build log comes from launcher problems, not this PR. 