### PR TITLE
Defaulting to the latest job-tools image instead of 1.0.3

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -47,7 +47,7 @@ executor:
         # The jwt token used for authenticating kubernetes requests
         token: NOT-A-REAL-JWT-TOKEN
         # Container tag to use
-        version: v1.0.3
+        version: latest
 
 scm:
     plugin: github

--- a/kubernetes/api_deployment.yaml
+++ b/kubernetes/api_deployment.yaml
@@ -21,6 +21,8 @@ spec:
             value: dynamodb
           - name: HOST
             value: 0.0.0.0
+          - name: API_URI
+            value: http://a4677c9873c9611e6aa7102b92f75d5c-1135862614.us-west-2.elb.amazonaws.com
           - name: DATA_DIR
             value: /opt/screwdriver/data
           - name: SECRET_JWT_PRIVATE_KEY


### PR DESCRIPTION
Also setting the API_URI in the kubernetes deployment config. We should
change this to the CNAME ASAP