### PR TITLE
Fixing the externally routable URI so it can be used easily

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -27,7 +27,6 @@ const httpdConfig = config.get('httpd');
 
 // Setup GitHub Webhooks
 const gitHubSecret = config.get('webhooks.github.secret');
-const apiUri = executorConfig.apiUri;
 
 // Setup Model Factories
 const Models = require('screwdriver-models');
@@ -52,7 +51,6 @@ require('../')({
         password: loginConfig.password
     },
     webhooks: {
-        apiUri,
         secret: gitHubSecret,
         password: loginConfig.password
     },

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -14,8 +14,12 @@ login:
     password: SECRET_PASSWORD
 
 httpd:
+    # Port to listen on
     port: PORT
+    # Host to listen on (set to 0.0.0.0 to accept all connections)
     host: HOST
+    # Externally routable URI (usually your load balancer or CNAME)
+    uri: URI
 
 datastore:
     plugin: DATASTORE_PLUGIN
@@ -29,7 +33,6 @@ datastore:
         secretAccessKey: DATASTORE_DYNAMODB_SECRET
 
 executor:
-    apiUri: API_URI
     k8s:
         # The host or IP of the kubernetes cluster
         host: K8S_HOST

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,8 +15,13 @@ login:
     https: false
 
 httpd:
+    # Port to listen on
     port: 8080
-    host: localhost
+    # Host to listen on (set to localhost to only accept connections from this machine)
+    host: 0.0.0.0
+    # Externally routable URI (usually your load balancer or CNAME)
+    uri: http://localhost:8080
+    # SSL Support
     tls: false
         # If you want SSL, you can easily add it by replacing `tls: false` with an object that
         # provides the options required by `tls.createServer`
@@ -40,7 +45,6 @@ datastore:
 
 executor:
     plugin: k8s
-    apiUri: http://0.0.0.0:8080
     k8s:
         # The host or IP of the kubernetes cluster
         host: kubernetes

--- a/kubernetes/api_deployment.yaml
+++ b/kubernetes/api_deployment.yaml
@@ -19,12 +19,8 @@ spec:
         env:
           - name: DATASTORE_PLUGIN
             value: dynamodb
-          - name: HOST
-            value: 0.0.0.0
-          - name: API_URI
-            value: http://a4677c9873c9611e6aa7102b92f75d5c-1135862614.us-west-2.elb.amazonaws.com
-          - name: DATA_DIR
-            value: /opt/screwdriver/data
+          - name: URI
+            value: http://api.screwdriver.cd
           - name: SECRET_JWT_PRIVATE_KEY
             valueFrom:
               secretKeyRef:

--- a/lib/server.js
+++ b/lib/server.js
@@ -35,7 +35,8 @@ function prettyPrintErrors(request, reply) {
  * @param  {Object}      config
  * @param  {Object}      config.httpd
  * @param  {Integer}     config.httpd.port          Port number to listen to
- * @param  {String}      config.httpd.host          Public hostname
+ * @param  {String}      config.httpd.host          Host to listen on
+ * @param  {String}      config.httpd.uri           Public routable address
  * @param  {Object}      config.httpd.tls           TLS Configuration
  * @param  {Factory}     config.pipelineFactory     Pipeline Factory instance
  * @param  {Factory}     config.jobFactory          Job Factory instance

--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -3,7 +3,6 @@
 const githubWebhooks = require('hapi-github-webhooks');
 const hoek = require('hoek');
 const boom = require('boom');
-let API_URI;
 
 /**
  * Create a new job and start the build for an opened pull-request
@@ -42,7 +41,7 @@ function pullRequestOpened(options, request, reply) {
         })
         // create a build
         .then(jobId => {
-            const apiUri = API_URI || request.server.info.uri;
+            const apiUri = request.server.info.uri;
             const tokenGen = (buildId) =>
                 request.server.plugins.login.generateToken(buildId, ['build']);
 
@@ -122,7 +121,7 @@ function pullRequestSync(options, request, reply) {
     const name = options.name;
     const username = options.username;
     const jobId = options.jobId;
-    const apiUri = API_URI || request.server.info.uri;
+    const apiUri = request.server.info.uri;
     const tokenGen = (buildId) =>
         request.server.plugins.login.generateToken(buildId, ['build']);
 
@@ -237,7 +236,6 @@ function pullRequestEvent(request, reply) {
  * @param  {Object}         options
  * @param  {String}         options.secret    GitHub Webhook secret to sign payloads with
  * @param  {String}         options.password  Login password
- * @param  {String}         options.apiUri    Server to contact for notifications
  * @param  {Function}       next
  */
 module.exports = (server, options) => {
@@ -247,7 +245,6 @@ module.exports = (server, options) => {
     server.auth.strategy('githubwebhook', 'githubwebhook', {
         secret: options.secret
     });
-    API_URI = options.apiUri;
 
     // Now use it
     return {

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -55,11 +55,12 @@ describe('github plugin test', () => {
             buildFactory: buildFactoryMock,
             pipelineFactory: pipelineFactoryMock
         };
+        apiUri = 'http://foo.bar:12345';
         server.connection({
             host: 'localhost',
-            port: 12345
+            port: 12345,
+            uri: apiUri
         });
-        apiUri = 'http://foo.bar:12345';
 
         server.register([{
             // eslint-disable-next-line global-require
@@ -75,7 +76,6 @@ describe('github plugin test', () => {
         {
             register: plugin,
             options: {
-                apiUri,
                 secret: 'secretssecretsarenofun'
             }
         }], (err) => {


### PR DESCRIPTION
Now `server.info.uri` will be correct.