### PR TITLE
Outputting stats for the scm plugin (merge #3)

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -55,7 +55,8 @@ require('../')({
         password: loginConfig.password
     },
     stats: {
-        executor
+        executor,
+        scmPlugin
     }
 }, (err, server) => {
     if (err) {

--- a/plugins/stats.js
+++ b/plugins/stats.js
@@ -8,6 +8,7 @@
  */
 exports.register = (server, options, next) => {
     const executor = options.executor;
+    const scmPlugin = options.scmPlugin;
 
     server.route({
         method: 'GET',
@@ -18,7 +19,8 @@ exports.register = (server, options, next) => {
             tags: ['api', 'stats']
         },
         handler: (request, reply) => reply({
-            executor: executor.stats()
+            executor: executor.stats(),
+            scm: scmPlugin.stats()
         })
     });
     next();

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -9,7 +9,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('stats plugin test', () => {
     let plugin;
     let server;
-    let mockExecutor;
+    let mockStats;
 
     before(() => {
         mockery.enable({
@@ -19,7 +19,7 @@ describe('stats plugin test', () => {
     });
 
     beforeEach((done) => {
-        mockExecutor = {
+        mockStats = {
             stats: sinon.stub()
         };
 
@@ -35,7 +35,8 @@ describe('stats plugin test', () => {
         server.register([{
             register: plugin,
             options: {
-                executor: mockExecutor
+                executor: mockStats,
+                scmPlugin: mockStats
             }
         }], (err) => {
             done(err);
@@ -62,14 +63,15 @@ describe('stats plugin test', () => {
                 foo: 'bar'
             };
 
-            mockExecutor.stats.returns(mockReturn);
+            mockStats.stats.returns(mockReturn);
 
             return server.inject({
                 url: '/stats'
             }).then(reply => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, {
-                    executor: mockReturn
+                    executor: mockReturn,
+                    scm: mockReturn
                 });
             });
         });


### PR DESCRIPTION
This PR is adding the scmPlugin to the /stats plugin

This will make it possible to have a look into how the scm plugin is performing