### PR TITLE
Set common data in build factory

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -70,6 +70,13 @@ module.exports = (config, callback) => {
             return callback(err);
         }
 
+        // Initialize common data in buildFactory
+        if (server.app.buildFactory) {
+            server.app.buildFactory.apiUri = server.info.uri;
+            server.app.buildFactory.tokenGen = (buildId) =>
+                server.plugins.login.generateToken(buildId, ['build']);
+        }
+
         // Start the server
         server.start((error) => { callback(error, server); });
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "screwdriver-datastore-imdb": "^1.0.0",
     "screwdriver-executor-k8s": "^4.0.0",
     "screwdriver-executor-l3l": "^1.0.0",
-    "screwdriver-models": "^9.0.0",
+    "screwdriver-models": "^10.0.0",
     "screwdriver-scm-github": "^1.0.1",
     "verror": "^1.6.1",
     "vision": "^4.1.0",

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -48,10 +48,12 @@ describe('server case', () => {
                 pipelineFactory: 'pipeline',
                 jobFactory: 'job',
                 userFactory: 'user',
-                buildFactory: 'build'
+                buildFactory: {}
             }, (e, s) => {
                 error = e;
                 server = s;
+                // Pretend we actually registered a login plugin
+                server.plugins.login = { generateToken: sinon.stub().returns('foo') };
                 done();
             });
         });
@@ -73,7 +75,10 @@ describe('server case', () => {
             Assert.strictEqual(server.app.pipelineFactory, 'pipeline');
             Assert.strictEqual(server.app.jobFactory, 'job');
             Assert.strictEqual(server.app.userFactory, 'user');
-            Assert.strictEqual(server.app.buildFactory, 'build');
+            Assert.isObject(server.app.buildFactory);
+            Assert.match(server.app.buildFactory.apiUri, /^http(s)?:\/\/[^:]+:12347$/);
+            Assert.isFunction(server.app.buildFactory.tokenGen);
+            Assert.strictEqual(server.app.buildFactory.tokenGen('bar'), 'foo');
         });
     });
 

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -20,7 +20,7 @@ describe('github plugin test', () => {
     let pipelineFactoryMock;
     let plugin;
     let server;
-    let apiUri;
+    const apiUri = 'http://foo.bar:12345';
 
     before(() => {
         mockery.enable({
@@ -58,7 +58,6 @@ describe('github plugin test', () => {
             buildFactory: buildFactoryMock,
             pipelineFactory: pipelineFactoryMock
         };
-        apiUri = 'http://foo.bar:12345';
         server.connection({
             host: 'localhost',
             port: 12345,
@@ -82,6 +81,9 @@ describe('github plugin test', () => {
                 secret: 'secretssecretsarenofun'
             }
         }], (err) => {
+            server.app.buildFactory.apiUri = apiUri;
+            server.app.buildFactory.tokenGen = (buildId) =>
+                server.plugins.login.generateToken(buildId, ['build']);
             done(err);
         });
     });
@@ -98,6 +100,8 @@ describe('github plugin test', () => {
 
     it('registers the plugin', () => {
         assert.isOk(server.registrations.webhooks);
+        assert.equal(server.app.buildFactory.tokenGen('12345'),
+            '{"username":"12345","scope":["build"]}"supersecret"');
     });
 
     describe('POST /webhooks/github', () => {
@@ -210,12 +214,8 @@ describe('github plugin test', () => {
                     assert.calledWith(buildFactoryMock.create, {
                         jobId,
                         username,
-                        sha,
-                        apiUri,
-                        tokenGen: sinon.match.func
+                        sha
                     });
-                    assert.equal(buildFactoryMock.create.getCall(0).args[0].tokenGen('12345'),
-                        '{"username":"12345","scope":["build"]}"supersecret"');
                 })
             ));
 
@@ -287,12 +287,8 @@ describe('github plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId,
                             sha,
-                            apiUri,
-                            username,
-                            tokenGen: sinon.match.func
+                            username
                         });
-                        assert.equal(buildFactoryMock.create.getCall(0).args[0].tokenGen('12345'),
-                            '{"username":"12345","scope":["build"]}"supersecret"');
                     })
                 );
 
@@ -310,12 +306,8 @@ describe('github plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId,
                             sha,
-                            apiUri,
-                            username,
-                            tokenGen: sinon.match.func
+                            username
                         });
-                        assert.equal(buildFactoryMock.create.getCall(0).args[0].tokenGen('12345'),
-                            '{"username":"12345","scope":["build"]}"supersecret"');
                     });
                 });
             });
@@ -333,12 +325,8 @@ describe('github plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId,
                             username,
-                            sha,
-                            apiUri,
-                            tokenGen: sinon.match.func
+                            sha
                         });
-                        assert.equal(buildFactoryMock.create.getCall(0).args[0].tokenGen('12345'),
-                            '{"username":"12345","scope":["build"]}"supersecret"');
                     })
                 ));
 
@@ -358,14 +346,10 @@ describe('github plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId,
                             username,
-                            sha,
-                            apiUri,
-                            tokenGen: sinon.match.func
+                            sha
                         });
                         assert.isOk(model1.stop.calledBefore(buildFactoryMock.create));
                         assert.isOk(model2.stop.calledBefore(buildFactoryMock.create));
-                        assert.equal(buildFactoryMock.create.getCall(0).args[0].tokenGen('12345'),
-                            '{"username":"12345","scope":["build"]}"supersecret"');
                     });
                 });
 


### PR DESCRIPTION
Depends on models-10.0.0

Sets global apiUri and tokenGen functions on server's buildFactory instance, so these values do not need to be retrieved and passed around to all build models later in multiple places.
