### PR TITLE
Fixes Job creation during PR open

### DIFF
--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -30,10 +30,10 @@ function pullRequestOpened(options, request, reply) {
     const pipeline = options.pipeline;
 
     return pipeline.getConfiguration(ref)
-        // get image(s) for "main" job
-        .then(config => config.jobs.main.map(b => b.image))
+        // get permutations(s) for "main" job
+        .then(config => config.jobs.main)
         // create a new job
-        .then(containers => jobFactory.create({ pipelineId, name, containers }))
+        .then(permutations => jobFactory.create({ pipelineId, name, permutations }))
         // log stuff
         .then(job => {
             request.log(['webhook-github', eventId, job.id], `${job.name} created`);

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -282,7 +282,28 @@ describe('github plugin test', () => {
                         assert.calledWith(jobFactoryMock.create, {
                             pipelineId,
                             name,
-                            containers: ['node:4', 'node:5', 'node:6']
+                            permutations: [{
+                                commands: [
+                                    { command: 'npm install', name: 'init' },
+                                    { command: 'npm test', name: 'test' }
+                                ],
+                                environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
+                                image: 'node:4'
+                            }, {
+                                commands: [
+                                    { command: 'npm install', name: 'init' },
+                                    { command: 'npm test', name: 'test' }
+                                ],
+                                environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
+                                image: 'node:5'
+                            }, {
+                                commands: [
+                                    { command: 'npm install', name: 'init' },
+                                    { command: 'npm test', name: 'test' }
+                                ],
+                                environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
+                                image: 'node:6'
+                            }]
                         });
                         assert.calledWith(buildFactoryMock.create, {
                             jobId,
@@ -301,7 +322,28 @@ describe('github plugin test', () => {
                         assert.calledWith(jobFactoryMock.create, {
                             pipelineId,
                             name,
-                            containers: ['node:4', 'node:5', 'node:6']
+                            permutations: [{
+                                commands: [
+                                    { command: 'npm install', name: 'init' },
+                                    { command: 'npm test', name: 'test' }
+                                ],
+                                environment: { NODE_ENV: 'test', NODE_VERSION: '4' },
+                                image: 'node:4'
+                            }, {
+                                commands: [
+                                    { command: 'npm install', name: 'init' },
+                                    { command: 'npm test', name: 'test' }
+                                ],
+                                environment: { NODE_ENV: 'test', NODE_VERSION: '5' },
+                                image: 'node:5'
+                            }, {
+                                commands: [
+                                    { command: 'npm install', name: 'init' },
+                                    { command: 'npm test', name: 'test' }
+                                ],
+                                environment: { NODE_ENV: 'test', NODE_VERSION: '6' },
+                                image: 'node:6'
+                            }]
                         });
                         assert.calledWith(buildFactoryMock.create, {
                             jobId,


### PR DESCRIPTION
Apparently we create Jobs in the GitHub PR event as well as in pipeline.sync, we should centralize this sooner rather then later