### PR TITLE
Allow trailing slashes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -52,6 +52,9 @@ module.exports = (config, callback) => {
         connections: {
             routes: {
                 cors: config.cors
+            },
+            router: {
+                stripTrailingSlash: true
             }
         }
     });


### PR DESCRIPTION
This means `/v3/builds/` and `/v3/builds` are equivalent. Applies to all routes.