### PR TITLE
Bump k8s version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "screwdriver-data-schema": "^10.1.1",
     "screwdriver-datastore-dynamodb": "^2.0.0",
     "screwdriver-datastore-imdb": "^1.0.0",
-    "screwdriver-executor-k8s": "^5.0.0",
+    "screwdriver-executor-k8s": "^6.0.0",
     "screwdriver-executor-l3l": "^1.0.0",
     "screwdriver-models": "^10.1.0",
     "screwdriver-scm-github": "^1.0.1",


### PR DESCRIPTION
Forgot to pull in new version of k8s after removing streaming (https://github.com/screwdriver-cd/executor-k8s/pull/35)