### PR TITLE
Fix a bug with writing exit code 0

### DIFF
--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -37,7 +37,7 @@ module.exports = () => ({
                         throw boom.notFound('Step does not exist');
                     }
 
-                    if (request.payload.code) {
+                    if (request.payload.code !== undefined) {
                         steps[stepIndex].code = request.payload.code;
                         steps[stepIndex].endTime = request.payload.endTime || now;
                     } else {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -409,7 +409,7 @@ describe('build plugin test', () => {
                 method: 'PUT',
                 url: `/builds/${id}/steps/${step}`,
                 payload: {
-                    code: 10,
+                    code: 0,
                     startTime: '2038-01-19T03:13:08.532Z',
                     endTime: '2038-01-19T03:15:08.532Z'
                 },
@@ -426,7 +426,7 @@ describe('build plugin test', () => {
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepProperty(reply.result, 'name', 'test');
-                assert.deepProperty(reply.result, 'code', 10);
+                assert.deepProperty(reply.result, 'code', 0);
                 assert.deepProperty(reply.result, 'endTime', options.payload.endTime);
                 assert.notDeepProperty(reply.result, 'startTime');
             });
@@ -440,7 +440,7 @@ describe('build plugin test', () => {
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepProperty(reply.result, 'name', 'test');
-                assert.deepProperty(reply.result, 'code', 10);
+                assert.deepProperty(reply.result, 'code', 0);
                 assert.match(reply.result.endTime, /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
                 assert.notDeepProperty(reply.result, 'startTime');
             });


### PR DESCRIPTION
When a build updates the step status with code 0, it was not writing the end time.  This fixes that bug.

Required for https://github.com/screwdriver-cd/launcher/pull/63 to work