### PR TITLE
Get jobs for pipeline

### DIFF
--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -3,6 +3,7 @@ const createRoute = require('./create');
 const getRoute = require('./get');
 const listRoute = require('./list');
 const updateRoute = require('./update');
+const listJobsRoute = require('./listJobs');
 
 /**
  * Pipeline API Plugin
@@ -17,7 +18,8 @@ exports.register = (server, options, next) => {
         createRoute(),
         getRoute(),
         listRoute(),
-        updateRoute()
+        updateRoute(),
+        listJobsRoute()
     ]);
 
     next();

--- a/plugins/pipelines/listJobs.js
+++ b/plugins/pipelines/listJobs.js
@@ -1,0 +1,32 @@
+'use strict';
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const listSchema = joi.array().items(schema.models.job.get).label('List of jobs');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipelines/{id}/jobs',
+    config: {
+        description: 'Get all jobs jobs for a given pipelines',
+        notes: 'Returns all jobs for a given pipeline',
+        tags: ['api', 'pipelines', 'jobs'],
+        handler: (request, reply) => {
+            const factory = request.server.app.pipelineFactory;
+
+            return factory.get(request.params.id)
+              .then(pipeline => {
+                  if (!pipeline) {
+                      throw boom.notFound('Pipeline does not exist');
+                  }
+
+                  return pipeline.jobs;
+              })
+              .then(jobs => reply(jobs.map(j => j.toJson())))
+              .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: listSchema
+        }
+    }
+});


### PR DESCRIPTION
This PR adds in a route to get all jobs for a given pipeline.

It will return 404 when the pipeline does not exist, and will return an array of all jobs.

There isn't any pagination for the route which should be added, but pipeline.jobs only will return 25 jobs (including those that are disabled). 

We need to find a way to filter out all disabled jobs