### PR TITLE
Add settings for ecosystem

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/bin/server
+++ b/bin/server
@@ -34,6 +34,9 @@ const logBaseUrl = config.get('logging.baseUrl');
 // Setup GitHub Webhooks
 const gitHubSecret = config.get('webhooks.github.secret');
 
+// Special urls for things like the UI
+const ecosystem = config.get('ecosystem');
+
 // Setup Model Factories
 const Models = require('screwdriver-models');
 const pipelineFactory = Models.PipelineFactory.getInstance({ datastore, scmPlugin });
@@ -41,7 +44,12 @@ const jobFactory = Models.JobFactory.getInstance({ datastore, scmPlugin });
 const userFactory = Models.UserFactory.getInstance({
     datastore, scmPlugin, password: loginConfig.password
 });
-const buildFactory = Models.BuildFactory.getInstance({ datastore, scmPlugin, executor });
+const buildFactory = Models.BuildFactory.getInstance({
+    datastore,
+    scmPlugin,
+    executor,
+    uiUrl: ecosystem.ui
+});
 
 require('../')({
     httpd: httpdConfig,

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -106,3 +106,6 @@ webhooks:
 logging:
     # Base URL for accessing logs
     baseUrl: https://s3-us-west-2.amazonaws.com/logs.screwdriver.cd
+
+ecosystem:
+    ui: http://cd.screwdriver.cd


### PR DESCRIPTION
Need to pass ui url to build models for target_url configs.
Also add editor config to define how editors should behave:
http://editorconfig.org/
https://atom.io/packages/editorconfig