### PR TITLE
Add /GET secrets/{id} route

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ndjson": "^1.4.3",
     "request": "^2.74.0",
     "screwdriver-config-parser": "^2.0.0",
-    "screwdriver-data-schema": "^10.4.0",
+    "screwdriver-data-schema": "^11.0.0",
     "screwdriver-datastore-dynamodb": "^2.0.0",
     "screwdriver-datastore-imdb": "^1.0.0",
     "screwdriver-executor-k8s": "^7.0.0",

--- a/plugins/secrets/README.md
+++ b/plugins/secrets/README.md
@@ -26,6 +26,10 @@ server.register({
 ```
 
 ### Routes
+#### Get a single secret
+
+`GET /secrets/{id}`
+
 #### Create a secret
 
 `POST /secrets`

--- a/plugins/secrets/create.js
+++ b/plugins/secrets/create.js
@@ -52,8 +52,11 @@ module.exports = () => ({
                             protocol: request.server.info.protocol,
                             pathname: `${request.path}/${secret.id}`
                         });
+                        const output = secret.toJson();
 
-                        return reply(secret.toJson()).header('Location', location).code(201);
+                        delete output.value;
+
+                        return reply(output).header('Location', location).code(201);
                     });
             })
             // something broke, respond with error

--- a/plugins/secrets/get.js
+++ b/plugins/secrets/get.js
@@ -1,0 +1,56 @@
+'use strict';
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const getSchema = schema.models.secret.get;
+const idSchema = joi.reach(schema.models.secret.base, 'id');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/secrets/{id}',
+    config: {
+        description: 'Get a single secret',
+        notes: 'Returns a secret record',
+        tags: ['api', 'secrets'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const secretFactory = request.server.app.secretFactory;
+            const credentials = request.auth.credentials;
+            const canAccess = request.server.plugins.secrets.canAccess;
+
+            return secretFactory.get(request.params.id)
+                .then(secret => {
+                    if (!secret) {
+                        throw boom.notFound('Secret does not exist');
+                    }
+
+                    return canAccess(credentials, secret).then((showSecret) => {
+                        const output = secret.toJson();
+
+                        if (!showSecret) {
+                            delete output.value;
+                        }
+
+                        return reply(output);
+                    });
+                })
+                .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: getSchema
+        },
+        validate: {
+            params: {
+                id: idSchema
+            }
+        }
+    }
+});

--- a/plugins/secrets/index.js
+++ b/plugins/secrets/index.js
@@ -1,5 +1,7 @@
 'use strict';
 const createRoute = require('./create');
+const getRoute = require('./get');
+const boom = require('boom');
 
 /**
  * Secrets API Plugin
@@ -9,8 +11,61 @@ const createRoute = require('./create');
  * @param  {Function} next              Function to call when done
  */
 exports.register = (server, options, next) => {
+    /**
+     * Throws error if a credential does not have access to a secret
+     * If credential has access, returns whether secret value will be shown
+     * @method canAccess
+     * @param {Object}  credentials              Credential object from Hapi
+     * @param {String}  credentials.username     Username of the person logged in (or build ID)
+     * @param {Array}   credentials.scope        Scope of the credential (user, build, admin)
+     * @param {String}  [credentials.pipelineId] If credential is a build, this is the pipeline ID
+     * @param {String}  [credentials.jobId]      If credential is a build, this is the job ID
+     * @param {String}  [credentials.isPR]       If credential is a build, this is true if a PR
+     * @return {Promise}
+     */
+    server.expose('canAccess', (credentials, secret) => {
+        const userFactory = server.root.app.userFactory;
+        const pipelineFactory = server.root.app.pipelineFactory;
+        const username = credentials.username;
+        const scope = credentials.scope;
+
+        return pipelineFactory.get(secret.pipelineId).then(pipeline => {
+            if (!pipeline) {
+                throw boom.notFound(`Pipeline ${secret.pipelineId} does not exist`);
+            }
+
+            if (scope.includes('user')) {
+                return userFactory.get({ username }).then(user => {
+                    if (!user) {
+                        throw boom.notFound(`User ${username} does not exist`);
+                    }
+
+                    return user.getPermissions(pipeline.scmUrl).then(permissions => {
+                        if (!permissions.push) {
+                            throw boom.forbidden(`User ${username} does not have `
+                                + 'write access to this repository');
+                        }
+
+                        return false;
+                    });
+                });
+            }
+
+            if (secret.pipelineId !== credentials.pipelineId) {
+                throw boom.forbidden(`${username} is not allowed to access this secret`);
+            }
+
+            if (!secret.allowInPR && credentials.isPR) {
+                throw boom.forbidden('This secret is not allowed in pull requests');
+            }
+
+            return true;
+        });
+    });
+
     server.route([
-        createRoute()
+        createRoute(),
+        getRoute()
     ]);
 
     next();

--- a/test/plugins/data/secret.json
+++ b/test/plugins/data/secret.json
@@ -3,5 +3,5 @@
   "pipelineId": "d398fb192747c9a0124e9e5b4e6e8e841cf8c71c",
   "name": "NPM_TOKEN",
   "value": "batman",
-  "allowInPR": true
+  "allowInPR": false
 }


### PR DESCRIPTION
- Add /GET secrets/{id} route
- Only users with write permissions can GET all properties of the secret except the value
- Add helper.js with helper functions `userPermission` and `buildPermission`
- The `buildPermission` will be needed later for list

#148 feature