### PR TITLE
Fixing HTTPS with OAuth flow by passing another flag

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -100,7 +100,8 @@ exports.register = (server, options, next) => {
             clientId: pluginOptions.oauthClientId,
             clientSecret: pluginOptions.oauthClientSecret,
             scope: ['admin:repo_hook', 'read:org', 'repo:status'],
-            isSecure: pluginOptions.https
+            isSecure: pluginOptions.https,
+            forceHttps: pluginOptions.https
         });
 
         server.auth.strategy('token', 'jwt', {


### PR DESCRIPTION
Without this, bell tries to read the server protocol (which is http because we have https on the ingress).  And we end up with this error:

> Authentication failed due to: Invalid setting  - isSecure must be set to false for non-https server