### PR TITLE
Enabling credentials to be passed (like cookies + stuff)

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -58,7 +58,8 @@ module.exports = (config, callback) => {
         ],
         additionalExposedHeaders: [
             'x-more-data'
-        ]
+        ],
+        credentials: true
     };
     // Create a server with a host and port
     const server = new Hapi.Server({


### PR DESCRIPTION
Specifically this field: `Access-Control-Allow-Credentials`

So the UI can pass the logged in cookie to the API.