### PR TITLE
Add auth/login/web route

### DIFF
--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -11,7 +11,7 @@ const boom = require('boom');
  */
 module.exports = (config) => ({
     method: ['GET', 'POST'],
-    path: '/auth/login',
+    path: '/auth/login/{web?}',
     config: {
         description: 'login using github',
         notes: 'Authenticate user with github oauth provider',
@@ -57,7 +57,13 @@ module.exports = (config) => ({
 
                     return model.update();
                 })
-                .then(() => reply().redirect('/v3/auth/token'))
+                .then(() => {
+                    if (request.params.web === 'web') {
+                        return reply('<script>window.close();</script>');
+                    }
+
+                    return reply().redirect('/v3/auth/token');
+                })
                 .catch(err => reply(boom.wrap(err)));
         }
     }

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -5,6 +5,7 @@ const expect = chai.expect;
 const hapi = require('hapi');
 const sinon = require('sinon');
 const fs = require('fs');
+const hoek = require('hoek');
 
 chai.use(require('chai-jwt'));
 chai.use(require('chai-as-promised'));
@@ -259,6 +260,28 @@ describe('auth plugin test', () => {
                 return server.inject(options).then((reply) => {
                     assert.equal(reply.statusCode, 302, 'Login route should be available');
                     assert.isOk(reply.headers.location.match(/auth\/token/), 'Redirects to token');
+                    assert.calledWith(userFactoryMock.get, { username });
+                    assert.calledWith(userFactoryMock.create, {
+                        username,
+                        token,
+                        password
+                    });
+                });
+            });
+
+            it('creates a user tries to close a window', () => {
+                userFactoryMock.get.resolves(null);
+                const webOptions = hoek.clone(options);
+
+                webOptions.url = '/auth/login/web';
+
+                return server.inject(webOptions).then((reply) => {
+                    assert.equal(reply.statusCode, 200, 'Login/web route should be available');
+                    assert.equal(
+                        reply.result,
+                        '<script>window.close();</script>',
+                        'add script to close window'
+                    );
                     assert.calledWith(userFactoryMock.get, { username });
                     assert.calledWith(userFactoryMock.create, {
                         username,


### PR DESCRIPTION
CORS does not handle redirects well, and javascript is unable to talk to child windows easily. This adds an optional parameter to /auth/login to cause the api to send code to close the window instead of redirecting to /auth/token. The UI can watch for the child window to close, then make an ajax call to /auth/token to get the jwt.