### PR TITLE
Fix git tag for docker publish

### DIFF
--- a/ci/publish
+++ b/ci/publish
@@ -25,4 +25,4 @@ DOCKER_URL=https://registry.hub.docker.com/u/screwdrivercd/screwdriver/trigger/$
 # Latest
 curl -H "Content-Type: application/json" --data '{"docker_tag": "master"}' -X POST $DOCKER_URL
 # Recent Tag
-curl -H "Content-Type: application/json" --data '{"source_type": "Tag", "source_name": "${GIT_TAG}"}' -X POST $DOCKER_URL
+curl -H "Content-Type: application/json" --data "{\"source_type\": \"Tag\", \"source_name\": \"${GIT_TAG}\"}" -X POST $DOCKER_URL


### PR DESCRIPTION
Currently, the `ci/publish` script is unable to use the correct tag as the source.

<img width="831" alt="screen shot 2016-09-13 at 2 13 48 pm" src="https://cloud.githubusercontent.com/assets/721148/18491668/50615a44-79bc-11e6-8c77-375b43cb28d2.png">

This PR is to fix this by re-defining the `--data` option.