### PR TITLE
Attempting to build docker using tags instead of source code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
 FROM node:6
 
+# Screwdriver Version
+ARG VERSION=latest
+
 # Create our application directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Copy and install dependencies
-COPY package.json /usr/src/app/
-RUN npm install --production
-
-# Copy everything else
-COPY . /usr/src/app
-
-# Setup configuration folder
-RUN ln -s /usr/src/app/config /config
+# Install Screwdriver API
+RUN npm install screwdriver-api@$VERSION
+WORKDIR /usr/src/app/node_modules/screwdriver-api
 
 # Expose the web service port
 EXPOSE 8080

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+docker build --build-arg=VERSION=$DOCKER_TAG -t $IMAGE_NAME .

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "start": "./bin/server",
     "functional": "cucumber-js --format=pretty"
   },
+  "bin": {
+    "screwdriver-api": "./bin/server"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:screwdriver-cd/screwdriver.git"


### PR DESCRIPTION
This uses the undocumented hook feature of Docker Hub to install from a specific version.

Hint here: https://github.com/docker/hub-feedback/issues/508#issuecomment-240616319

This will give us the correct version number when starting these containers.

