### PR TITLE
Fixes #189 by skipping workflow trigger if in PR

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -76,7 +76,8 @@ module.exports = () => ({
                     return build.job.then((job) => job.pipeline.then((pipeline) => {
                         const workflow = pipeline.workflow;
 
-                        if (!workflow) {  // No workflow to follow
+                        // No workflow to follow
+                        if (!workflow) {
                             return null;
                         }
 
@@ -84,6 +85,11 @@ module.exports = () => ({
 
                         // Current build is the last job in the workflow
                         if (workflowIndex === workflow.length - 1) {
+                            return null;
+                        }
+
+                        // Skip if not in the workflow (like PRs)
+                        if (workflowIndex === -1) {
                             return null;
                         }
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -490,7 +490,7 @@ describe('build plugin test', () => {
                         pipelineId
                     };
 
-                    pipelineMock.workflow = ['publish', 'nerf_fight'];
+                    pipelineMock.workflow = ['main', 'publish', 'nerf_fight'];
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'publish' })
                         .resolves(publishJobMock);
                     buildFactoryMock.create.withArgs({
@@ -545,6 +545,30 @@ describe('build plugin test', () => {
                     };
 
                     pipelineMock.workflow = ['main'];
+
+                    return server.inject(options).then((reply) => {
+                        assert.equal(reply.statusCode, 200);
+                        assert.notCalled(buildFactoryMock.create);
+                    });
+                });
+
+                it('skips triggering if the job is a PR', () => {
+                    const status = 'SUCCESS';
+                    const options = {
+                        method: 'PUT',
+                        url: `/builds/${id}`,
+                        credentials: {
+                            username: id,
+                            scope: ['build']
+                        },
+                        payload: {
+                            status
+                        }
+                    };
+
+                    jobMock.name = 'PR-15';
+
+                    pipelineMock.workflow = ['main', 'publish'];
 
                     return server.inject(options).then((reply) => {
                         assert.equal(reply.statusCode, 200);


### PR DESCRIPTION
The bug @petey reported #189 is caused by not checking if the completed build is actually a PR or not.  This resolves that by checking for missing from workflow.