### PR TITLE
Adding support for badges per pipeline

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -61,3 +61,5 @@ webhooks:
 ecosystem:
     # URL for the User Interface
     ui: ECOSYSTEM_UI
+    # Badge service (needs to add a status and color)
+    badges: ECOSYSTEM_BADGES

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -114,3 +114,5 @@ logging:
 ecosystem:
     # URL for the User Interface
     ui: https://cd.screwdriver.cd
+    # Badge service (needs to add a status and color)
+    badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,7 +81,8 @@ module.exports = (config, callback) => {
         jobFactory: config.jobFactory,
         userFactory: config.userFactory,
         buildFactory: config.buildFactory,
-        secretFactory: config.secretFactory
+        secretFactory: config.secretFactory,
+        ecosystem: config.ecosystem
     };
 
     // Initialize server connections

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "screwdriver-executor-l3l": "^1.0.0",
     "screwdriver-models": "^10.3.0",
     "screwdriver-scm-github": "^1.0.1",
+    "tinytim": "^0.1.1",
     "verror": "^1.6.1",
     "vision": "^4.1.0",
     "winston": "^2.2.0"

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -1,0 +1,76 @@
+'use strict';
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const tinytim = require('tinytim');
+const idSchema = joi.reach(schema.models.pipeline.base, 'id');
+
+/**
+ * Generate Badge URL
+ * @method getUrl
+ * @param  {string}  badgeService    Template URL for badges - needs {{status}} and {{color}}
+ * @param  {string}  [currentStatus] Current Build Status
+ * @return {string}                  URL to redirect to
+ */
+function getUrl(badgeService, currentStatus) {
+    const status = (currentStatus || 'UNKNOWN').toLowerCase();
+    const statusColor = {
+        unknown: 'lightgrey',
+        success: 'green',
+        failure: 'red',
+        aborted: 'red',
+        queued: 'blue',
+        running: 'blue'
+    };
+    const color = statusColor[status];
+
+    return tinytim.tim(badgeService, {
+        status, color
+    });
+}
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipelines/{id}/badge',
+    config: {
+        description: 'Get a badge for the pipeline',
+        notes: 'Redirects to the badge service',
+        tags: ['api', 'pipelines', 'badge'],
+        handler: (request, reply) => {
+            const factory = request.server.app.pipelineFactory;
+            const badgeService = request.server.app.ecosystem.badges;
+
+            return factory.get(request.params.id)
+                .then(pipeline => {
+                    if (!pipeline) {
+                        return reply.redirect(getUrl(request.server.app.ecosystem.badges));
+                    }
+
+                    return pipeline.jobs.then(jobs => {
+                        const main = jobs.filter(job => job.name === 'main').pop();
+
+                        if (!main) {
+                            return reply.redirect(getUrl(badgeService));
+                        }
+
+                        return main.getBuilds({
+                            paginate: {
+                                page: 1,
+                                count: 1
+                            },
+                            sort: 'descending'
+                        }).then(builds => {
+                            const build = builds.pop();
+
+                            return reply.redirect(getUrl(badgeService, build && build.status));
+                        });
+                    });
+                })
+                .catch(() => reply.redirect(getUrl(badgeService)));
+        },
+        validate: {
+            params: {
+                id: idSchema
+            }
+        }
+    }
+});

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -3,6 +3,7 @@ const createRoute = require('./create');
 const getRoute = require('./get');
 const listRoute = require('./list');
 const updateRoute = require('./update');
+const badgeRoute = require('./badge');
 const listJobsRoute = require('./listJobs');
 const listSecretsRoute = require('./listSecrets');
 
@@ -19,6 +20,7 @@ exports.register = (server, options, next) => {
         getRoute(),
         listRoute(),
         updateRoute(),
+        badgeRoute(),
         listJobsRoute(),
         listSecretsRoute()
     ]);

--- a/test/plugins/data/jobs.json
+++ b/test/plugins/data/jobs.json
@@ -2,7 +2,7 @@
     {
         "id": "d398fb192747c9a0124e9e5b4e6e8e841cf8c71c",
         "pipelineId": "76723e832f764a5fcea4ca412c54135d0e041613",
-        "name": "component",
+        "name": "main",
         "state": "ENABLED"
     },
     {


### PR DESCRIPTION
This adds simple badges per pipeline.  It will only show the last build from the `main` job right now.

Looks something like this ![](https://img.shields.io/badge/build-success-green.svg) and can use alternative badge services other than shields.io.