### PR TITLE
Store scmId additionally when creating pipelines

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -69,6 +69,9 @@ require('../')({
     stats: {
         executor,
         scmPlugin
+    },
+    pipelines: {
+        scmPlugin
     }
 }, (err, server) => {
     if (err) {

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -80,7 +80,7 @@ module.exports = (options) => ({
                                 const pipelineConfig = hoek.applyToDefaults(request.payload, {
                                     admins,
                                     scmUrl,
-                                    scmId: repo.id
+                                    scmRepo: repo
                                 });
 
                                 return pipelineFactory.create(pipelineConfig);

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -15,7 +15,7 @@ const listSecretsRoute = require('./listSecrets');
  */
 exports.register = (server, options, next) => {
     server.route([
-        createRoute(),
+        createRoute(options),
         getRoute(),
         listRoute(),
         updateRoute(),

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -413,7 +413,9 @@ describe('pipeline plugin test', () => {
         let options;
         const unformattedScmUrl = 'git@github.com:screwdriver-cd/data-MODEL.git';
         const scmUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
-        const scmId = 'github.com:123456:master';
+        const scmRepo = {
+            id: 'github.com:123456:master'
+        };
         const token = 'secrettoken';
         const testId = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
         const username = 'd2lam';
@@ -448,7 +450,7 @@ describe('pipeline plugin test', () => {
             pipelineFactoryMock.get.resolves(null);
             pipelineFactoryMock.create.resolves(pipelineMock);
 
-            scmMock.getRepoId.withArgs({ scmUrl, token }).resolves({ id: scmId });
+            scmMock.getRepoId.withArgs({ scmUrl, token }).resolves(scmRepo);
         });
 
         it('returns 201 and correct pipeline data', (done) => {
@@ -469,7 +471,7 @@ describe('pipeline plugin test', () => {
                         d2lam: true
                     },
                     scmUrl,
-                    scmId
+                    scmRepo
                 });
                 done();
             });


### PR DESCRIPTION
This PR implements the main feature described in #160, blocked by screwdriver-cd/scm-github#8.
Needs to change [this](https://github.com/screwdriver-cd/data-schema/blob/master/models/pipeline.js#L88) if this PR works.