### PR TITLE
No longer return 404 if pipeline doesn't exist

### DIFF
--- a/plugins/webhooks/github.js
+++ b/plugins/webhooks/github.js
@@ -174,7 +174,6 @@ function pullRequestEvent(request, reply) {
     // Possible actions
     // "opened", "closed", "reopened", "synchronize",
     // "assigned", "unassigned", "labeled", "unlabeled", "edited"
-
     if (!['opened', 'reopened', 'synchronize', 'closed'].includes(action)) {
         return reply().code(204);
     }
@@ -183,7 +182,10 @@ function pullRequestEvent(request, reply) {
     return pipelineFactory.get({ scmUrl })
         .then(pipeline => {
             if (!pipeline) {
-                throw boom.notFound('Pipeline does not exist');
+                request.log(['webhook-github', eventId],
+                    `Skipping since Pipeline ${scmUrl} does not exist`);
+
+                return reply().code(204);
             }
 
             // sync the pipeline ... reasons why will become clear later???
@@ -255,7 +257,10 @@ function pushEvent(request, reply) {
     return pipelineFactory.get({ scmUrl })
         .then(pipeline => {
             if (!pipeline) {
-                throw boom.notFound('Pipeline does not exist');
+                request.log(['webhook-github', eventId],
+                    `Skipping since Pipeline ${scmUrl} does not exist`);
+
+                return reply().code(204);
             }
 
             // sync the pipeline to get the latest jobs

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -14,6 +14,8 @@ const PARSED_CONFIG = require('../data/github.parsedyaml.json');
 
 sinon.assert.expose(assert, { prefix: '' });
 
+require('sinon-as-promised');
+
 describe('github plugin test', () => {
     let jobFactoryMock;
     let buildFactoryMock;
@@ -218,11 +220,11 @@ describe('github plugin test', () => {
                 })
             ));
 
-            it('returns 404 when no pipeline', () => {
+            it('returns 204 when no pipeline', () => {
                 pipelineFactoryMock.get.resolves(null);
 
                 return server.inject(options).then((reply) => {
-                    assert.equal(reply.statusCode, 404);
+                    assert.equal(reply.statusCode, 204);
                 });
             });
 
@@ -249,12 +251,12 @@ describe('github plugin test', () => {
                 name = 'PR-1';
             });
 
-            it('returns 404 when pipeline does not exist', () => {
+            it('returns 204 when pipeline does not exist', () => {
                 pipelineFactoryMock.get.resolves(null);
                 options.payload = testPayloadOpen;
 
                 return server.inject(options).then((reply) => {
-                    assert.equal(reply.statusCode, 404);
+                    assert.equal(reply.statusCode, 204);
                 });
             });
 


### PR DESCRIPTION
This fixes the constant error state that the webhooks are in:

![screen shot 2016-09-19 at 9 45 09 am](https://cloud.githubusercontent.com/assets/622065/18640631/cb43e9c6-7e4d-11e6-963b-47dc3b12258b.png)
