### PR TITLE
[stop:2] Using new build.stop feature and migrating scmRepo to models

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -69,9 +69,6 @@ require('../')({
     stats: {
         executor,
         scmPlugin
-    },
-    pipelines: {
-        scmPlugin
     }
 }, (err, server) => {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "screwdriver-datastore-dynamodb": "^2.1.0",
     "screwdriver-datastore-imdb": "^1.0.0",
     "screwdriver-executor-k8s": "^8.0.0",
-    "screwdriver-models": "^11.0.0",
+    "screwdriver-models": "^12.0.0",
     "screwdriver-scm-github": "^1.0.1",
     "tinytim": "^0.1.1",
     "verror": "^1.6.1",

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -16,7 +16,7 @@ const listSecretsRoute = require('./listSecrets');
  */
 exports.register = (server, options, next) => {
     server.route([
-        createRoute(options),
+        createRoute(),
         getRoute(),
         listRoute(),
         updateRoute(),

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -30,9 +30,9 @@ module.exports = () => ({
                         pipeline[key] = request.payload[key];
                     });
 
-                    return pipeline.update();
+                    return pipeline.sync()
+                        .then(() => reply(pipeline.toJson()).code(200));
                 })
-                .then(pipeline => reply(pipeline.toJson()).code(200))
                 .catch(err => reply(boom.wrap(err)));
         },
         validate: {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -466,6 +466,7 @@ describe('pipeline plugin test', () => {
         beforeEach(() => {
             pipelineMock = getPipelineMocks(testPipeline);
             pipelineMock.update.resolves(pipelineMock);
+            pipelineMock.sync.resolves();
             pipelineFactoryMock.get.resolves(pipelineMock);
         });
 
@@ -523,7 +524,7 @@ describe('pipeline plugin test', () => {
                 }
             };
 
-            pipelineMock.update.rejects(new Error('icantdothatdave'));
+            pipelineMock.sync.rejects(new Error('icantdothatdave'));
 
             server.inject(options, (reply) => {
                 assert.equal(reply.statusCode, 500);
@@ -593,8 +594,7 @@ describe('pipeline plugin test', () => {
                     admins: {
                         d2lam: true
                     },
-                    scmUrl,
-                    scmRepo
+                    scmUrl
                 });
                 done();
             });


### PR DESCRIPTION
This enables scmRepo to be updated from the model on `sync` instead of only on create. Also migrates stop to `update` instead.

Depends on https://github.com/screwdriver-cd/models/pull/106