### PR TITLE
Allow auth_token login alternative

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -15,6 +15,12 @@ auth:
     oauthClientId: SECRET_OAUTH_CLIENT_ID
     # The client secret used for OAuth with github
     oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
+    # The access token to use on behalf of a user to access the API. Used as
+    # an alternative to the OAuth flow
+    temporaryAccessKey: SECRET_ACCESS_KEY
+    # The user name associated with the temproary access token. Used as a
+    # means of functionally testing the API
+    temporaryAccessUser: SECRET_ACCESS_USER
     # A password used for encrypting session, and OAuth data.
     # **Needs to be minimum 32 characters**
     password: SECRET_PASSWORD

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,6 +22,10 @@ auth:
     # A password used for encrypting session, and OAuth data.
     # **Needs to be minimum 32 characters**
     password: WOW-ANOTHER-INSECURE-PASSWORD!!!
+    # A single access token used as an alternative to the Oauth login flow
+    temporaryAccessKey: someAccessTokenThatIsTemporaryForUsingInTheMeantime
+    # User name that is associated with the temporary access key
+    temporaryAccessUser: quality_automation
     # A flag to set if the server is running over https.
     # Used as a flag for the OAuth flow
     https: false

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "good-console": "^6.1.1",
     "good-squeeze": "^5.0.0",
     "hapi": "^15.0.0",
+    "hapi-auth-bearer-token": "^4.3.0",
     "hapi-auth-cookie": "^6.1.1",
     "hapi-auth-jwt": "^4.0.0",
     "hapi-github-webhooks": "^1.0.1",

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -16,7 +16,7 @@ module.exports = () => ({
         notes: 'Generate a JWT for use throughout Screwdriver',
         tags: ['api', 'auth', 'token'],
         auth: {
-            strategies: ['token', 'session'],
+            strategies: ['token', 'session', 'auth_token'],
             scope: ['user']
         },
         handler: (request, reply) => {


### PR DESCRIPTION
Enable an alternative to the OAuth flow for acquiring a valid JWT. This PR is a start, where there is only a single `access_token`. Ideally, we want to allocate `access token`s per user.

Looking for feedback on the direction of the work. This is a frankenstein of a couple of PoCs, so it's rough on a few details.