### PR TITLE
Integrate E2E cucumber tests in prod job

### DIFF
--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -8,9 +8,8 @@ const config = require('../../.func_config');
 function beforeHooks() {
     // eslint-disable-next-line new-cap
     this.Before((scenario, cb) => {
-        this.username = config.username;
-        this.github_token = config.github_token;
-        this.jwt = config.jwt;
+        this.username = process.env.USERNAME || config.username;
+        this.github_token = process.env.ACCESS_TOKEN || config.github_token;
         cb();
     });
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pretest": "eslint . && snyk test",
     "test": "jenkins-mocha --recursive",
     "start": "./bin/server",
-    "functional": "cucumber-js --format=pretty"
+    "functional": "cucumber-js --format=pretty ./features/server.feature"
   },
   "bin": {
     "screwdriver-api": "./bin/server"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -39,7 +39,7 @@ jobs:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
             - wait-docker: DOCKER_TAG=`git describe --abbrev=0 --tags` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`git describe --abbrev=0 --tags` ./ci/k8s-deploy.sh
-            - test: echo Put cucumber tests here
+            - test: npm install && npm run functional
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
             K8S_CONTAINER: screwdriver-api


### PR DESCRIPTION
We have parallel tasks happening with integrating our cucumber-js tests in our pipeline. Since not all the tests are defined and some are being re-written, it introduces a lot of risk with integrating them into the pipeline at the end.

This PR aims to hook in the most simple of cucumber tests to sanity check our release flow. As more features are defined, we'll slowly expand the `npm run functional` command to target them.