### PR TITLE
Add functional test for secrets scenario 1 and 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .*.swp
 database.json
 config/local.*
+.func_config.json

--- a/features/secrets.feature
+++ b/features/secrets.feature
@@ -23,7 +23,7 @@ Feature: Secrets
         - Secrets should be available as environment variables
 
     Background:
-        Given an existing repository with these users and permissions:
+        Given an existing repository for secret with these users and permissions:
             | name          | permission  |
             | calvin        | admin       |
             | hobbes        | contributor |
@@ -36,7 +36,6 @@ Feature: Secrets
         When a secret "foo" is added globally
         And the "main" job is started
         Then the "foo" secret should be available in the build
-        And the build succeeded
         And the "second" job is started
         Then the "foo" secret should be available in the build
 

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -4,11 +4,6 @@ const request = require('../support/request');
 const jwt = require('jsonwebtoken');
 
 module.exports = function server() {
-    // eslint-disable-next-line new-cap
-    this.Before(() => {
-        this.accessKey = process.env.ACCESS_KEY;
-    });
-
     this.Given(/^an existing repository with these users and permissions:$/, (table) => table);
 
     this.Given(/^an existing pipeline with that repository$/, () => null);
@@ -26,6 +21,8 @@ module.exports = function server() {
         }).then((response) => {
             const accessToken = response.body.token;
             const decodedToken = jwt.decode(accessToken);
+
+            this.jwt = accessToken;
 
             Assert.equal(response.statusCode, 200);
 

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -157,7 +157,7 @@ function waitForBuild(screwdriverInstance, desiredSha) {
 module.exports = function server() {
     // eslint-disable-next-line new-cap
     this.Before(() => {
-        this.instance = 'http://api.screwdriver.cd';
+        this.instance = 'https://api.screwdriver.cd';
         this.repositoryOwner = 'screwdriver-cd';
         this.repository = 'garbage-repository-ignore-this';
         this.testBranch = 'testBranch';

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -1,0 +1,84 @@
+'use strict';
+const Assert = require('chai').assert;
+const request = require('../support/request');
+
+module.exports = function server() {
+    this.setDefaultTimeout(60000);
+
+    this.Given(/^an existing repository for secret with these users and permissions:$/, (table) => {
+        this.pipelineId = '4de9888518fd74beb336eb6e36f68b25697c219f';
+
+        return table;
+    });
+
+    this.Given(/^an existing pipeline with that repository with the workflow:$/, (table) => table);
+
+    this.When(/^a secret "foo" is added globally$/, () => {
+        request({
+            uri: `${this.instance}/${this.namespace}/secrets`,
+            method: 'POST',
+            body: {
+                pipelineId: this.pipelineId,
+                name: 'FOO',
+                value: 'secrets',
+                allowInPR: false
+            },
+            auth: {
+                bearer: this.jwt
+            },
+            json: true
+        }).then(response => Assert.equal(response.statusCode, 201));
+    });
+
+    this.When(/^the "main" job is started$/, () =>
+        request({
+            uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/jobs`,
+            method: 'GET',
+            json: true
+        }).then((response) => {
+            this.jobId = response.body[0].id;
+            this.secondJobId = response.body[1].id;
+
+            Assert.equal(response.statusCode, 200);
+        })
+        .then(() =>
+            request({
+                uri: `${this.instance}/${this.namespace}/builds`,
+                method: 'POST',
+                body: {
+                    jobId: this.jobId
+                },
+                auth: {
+                    bearer: this.jwt
+                },
+                json: true
+            }).then((resp) => {
+                this.buildId = resp.body.id;
+
+                Assert.equal(resp.statusCode, 201);
+            })
+        )
+    );
+
+    this.When(/^the "foo" secret should be available in the build$/, () =>
+        this.waitForBuild(this.buildId).then(response => {
+            Assert.equal(response.body.status, 'SUCCESS');
+            Assert.equal(response.statusCode, 200);
+        })
+    );
+
+    this.When(/^the "second" job is started$/, () =>
+        request({
+            uri: `${this.instance}/${this.namespace}/jobs/${this.secondJobId}/builds`,
+            method: 'GET',
+            json: true
+        }).then(response => {
+            this.secondBuildId = response.body[0].id;
+
+            return this.waitForBuild(this.secondBuildId).then(resp => {
+                Assert.equal(resp.body.status, 'SUCCESS');
+                Assert.equal(resp.statusCode, 200);
+            });
+        })
+    );
+};

--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -1,5 +1,18 @@
 'use strict';
 const config = require('../../.func_config');
+const requestretry = require('requestretry');
+
+/**
+ * Retry until the build has finished
+ * @method retryStrategy
+ * @param  {Object}      err
+ * @param  {Object}      response
+ * @param  {Object}      body
+ * @return {Boolean}     Retry the build or not
+ */
+function buildRetryStrategy(err, response, body) {
+    return err || body.status === 'QUEUED' || body.status === 'RUNNING';
+}
 
 /**
  * Before hooks
@@ -10,6 +23,18 @@ function beforeHooks() {
     this.Before((scenario, cb) => {
         this.username = process.env.USERNAME || config.username;
         this.github_token = process.env.ACCESS_TOKEN || config.github_token;
+        this.accessKey = process.env.ACCESS_KEY;
+        this.instance = 'https://api.screwdriver.cd';
+        this.namespace = 'v4';
+        this.waitForBuild = (buildID) =>
+            requestretry({
+                uri: `${this.instance}/${this.namespace}/builds/${buildID}`,
+                method: 'GET',
+                maxAttempts: 10,
+                retryDelay: 5000,
+                retryStrategy: buildRetryStrategy,
+                json: true
+            });
         cb();
     });
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "jsonwebtoken": "^7.1.6",
     "ndjson": "^1.4.3",
     "request": "^2.74.0",
+    "requestretry": "^1.12.0",
     "screwdriver-config-parser": "^2.0.0",
     "screwdriver-data-schema": "^12.0.0",
     "screwdriver-datastore-dynamodb": "^3.0.0",


### PR DESCRIPTION
- Add cucumber test for secrets.feature scenario 1 and 4 (need more users for other scenarios)
- In scenario 1, remove `And the build succeeded` since it is already checked in `Then the "foo" secret should be available in the build`
- PipelineId is hardcoded until we find a better way to do it
- [Repo used for testing](https://github.com/screwdriver-cd-test/functional-secrets)

issue [#148](https://github.com/screwdriver-cd/screwdriver/issues/148)