### PR TITLE
Support overriding the dynamodb prefix via environment variables

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -42,6 +42,8 @@ datastore:
         # File to read/write the database to
         filename: DATASTORE_IMDB_FILENAME
     dynamodb:
+        # Prefix to the table names
+        prefix: DATASTORE_DYNAMODB_PREFIX
         # AWS Access Key ID
         accessKeyId: DATASTORE_DYNAMODB_ID
         # AWS Secret Access Key

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -86,7 +86,7 @@ datastore:
         filename: ./database.json
     dynamodb:
         # Prefix to table names
-        # prefix: prod_
+        prefix: ""
         # AWS Access Key ID
         accessKeyId: WHAT-A-LEGITIMATE-LOOKING-KEY-ID
         # AWS Secret Access Key


### PR DESCRIPTION
This allows us to use `beta_` for our beta environment