### PR TITLE
 Add update secret route

### DIFF
--- a/plugins/builds/listSecrets.js
+++ b/plugins/builds/listSecrets.js
@@ -38,7 +38,7 @@ module.exports = () => ({
                         return reply([]);
                     }
 
-                    return canAccess(credentials, secrets[0]).then((showSecret) =>
+                    return canAccess(credentials, secrets[0], 'push').then((showSecret) =>
                         reply(secrets.map(s => {
                             const output = s.toJson();
 

--- a/plugins/pipelines/listSecrets.js
+++ b/plugins/pipelines/listSecrets.js
@@ -33,7 +33,7 @@ module.exports = () => ({
                         return reply([]);
                     }
 
-                    return canAccess(credentials, secrets[0])
+                    return canAccess(credentials, secrets[0], 'push')
                         .then(() => reply(secrets.map(s => {
                             const output = s.toJson();
 

--- a/plugins/secrets/README.md
+++ b/plugins/secrets/README.md
@@ -26,7 +26,11 @@ server.register({
 ```
 
 ### Routes
-#### Get a single secret
+`Get` requires **write** permission to the repository.
+
+`Create`, `Remove` and `Update` require **admin** permission to the repository.
+
+#### Get a secret
 
 `GET /secrets/{id}`
 
@@ -46,6 +50,28 @@ Example payload:
 {
   "pipelineId": "d398fb192747c9a0124e9e5b4e6e8e841cf8c71c",
   "name": "NPM_TOKEN",
+  "value": "batman",
+  "allowInPR": true
+}
+```
+#### Remove a secret
+
+`DELETE /secrets/{id}`
+
+#### Update a secret
+
+`PUT /secrets/{id}`
+
+**Arguments**
+
+Only `value` and `allowInPR` can be updated.
+
+* `value` - Value of the secret.
+* `allowInPR` - Flag to denote if this secret can be shown in PR builds.
+
+Example payload:
+```json
+{
   "value": "batman",
   "allowInPR": true
 }

--- a/plugins/secrets/get.js
+++ b/plugins/secrets/get.js
@@ -32,7 +32,7 @@ module.exports = () => ({
                         throw boom.notFound('Secret does not exist');
                     }
 
-                    return canAccess(credentials, secret).then((showSecret) => {
+                    return canAccess(credentials, secret, 'push').then((showSecret) => {
                         const output = secret.toJson();
 
                         if (!showSecret) {


### PR DESCRIPTION
- Add `update` route for secrets
- Only user can `update` a secret
- Modify `canAccess` helper function to take in required permission
- Update README


Issue #232