### PR TITLE
PR sync reads from its branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "screwdriver-data-schema": "^12.0.0",
     "screwdriver-datastore-dynamodb": "^3.0.0",
     "screwdriver-executor-k8s": "^8.0.0",
-    "screwdriver-models": "^13.0.0",
+    "screwdriver-models": "^14.0.0",
     "screwdriver-scm-github": "^1.0.1",
     "tinytim": "^0.1.1",
     "verror": "^1.6.1",


### PR DESCRIPTION
- This allows synchronize event to read from PR ref instead of master. 
- Remove `getBuildsForJobsId` and replace with `job.getRunningBuilds()`
- Still need to keep this check: https://github.com/screwdriver-cd/screwdriver/blob/da6cf99d835bc8750fe4e6e6792f1b176cd944d8/plugins/webhooks/github.js#L14-L16 just in case the build finishes in between the time it gets the running builds and time stopRunningBuild is called. 
- Blocked by https://github.com/screwdriver-cd/models/pull/113
- Relates to https://github.com/screwdriver-cd/screwdriver/issues/241