### PR TITLE
Wrong env name in func test

### DIFF
--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -37,7 +37,6 @@ module.exports = function server() {
             method: 'GET',
             json: true
         }).then((response) => {
-            console.log(response);
             this.jobId = response.body[0].id;
             this.secondJobId = response.body[1].id;
 

--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -21,9 +21,9 @@ function buildRetryStrategy(err, response, body) {
 function beforeHooks() {
     // eslint-disable-next-line new-cap
     this.Before((scenario, cb) => {
-        this.username = process.env.USERNAME || config.username;
+        this.username = process.env.SECRET_ACCESS_USER || config.username;
         this.github_token = process.env.ACCESS_TOKEN || config.github_token;
-        this.accessKey = process.env.ACCESS_KEY;
+        this.accessKey = process.env.SECRET_ACCESS_KEY;
         this.instance = 'https://api.screwdriver.cd';
         this.namespace = 'v4';
         this.waitForBuild = (buildID) =>


### PR DESCRIPTION
They were referred as `SECRET_ACCESS_KEY` and `SECRET_ACCESS_USER` in kubernetes: https://github.com/screwdriver-cd/kubernetes/blob/master/api-beta.yaml#L70-L76

Currently breaking master branch build: https://cd.screwdriver.cd/pipelines/27cec39c9baea6cf64c684479115300d22039b2a

