### PR TITLE
Don't say there are more logs when the step hasn't started.

### DIFF
--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -31,10 +31,15 @@ module.exports = (config) => ({
                     }
 
                     const isNotDone = stepModel.code === undefined;
+                    const isNotStarted = stepModel.startTime === undefined;
                     const url = `${config.logBaseUrl}/${buildId}/${stepName}`;
                     const output = [];
 
-                    request
+                    if (isNotStarted) {
+                        return reply(output).header('X-More-Data', 'false');
+                    }
+
+                    return request
                         // Load NDJson from S3 bucket
                         .get(url)
                         .pipe(ndjson.parse({

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -752,7 +752,7 @@ describe('build plugin test', () => {
 
     describe('PUT /builds/{id}/steps/{step}', () => {
         const id = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
-        const step = 'test';
+        const step = 'publish';
         let options;
         let buildMock;
 
@@ -921,19 +921,15 @@ describe('build plugin test', () => {
             });
         });
 
-        it('returns more-data for a step that is not done', () => {
+        it('returns false more-data for a step that is not started', () => {
             const buildMock = getMockBuilds(testBuild);
-
-            nock('http://example.com')
-                .get(`/screwdriver-logs/${id}/test`)
-                .replyWithFile(200, `${__dirname}/data/step.log.ndjson`);
 
             buildFactoryMock.get.withArgs(id).resolves(buildMock);
 
-            return server.inject(`/builds/${id}/steps/test/logs`).then((reply) => {
+            return server.inject(`/builds/${id}/steps/publish/logs`).then((reply) => {
                 assert.equal(reply.statusCode, 200);
-                assert.deepEqual(reply.result, logs);
-                assert.propertyVal(reply.headers, 'x-more-data', 'true');
+                assert.deepEqual(reply.result, []);
+                assert.propertyVal(reply.headers, 'x-more-data', 'false');
             });
         });
 

--- a/test/plugins/data/build.json
+++ b/test/plugins/data/build.json
@@ -22,16 +22,11 @@
             "endTime": "2038-01-19T03:15:09.114Z"
         },
         {
+            "startTime": "2038-01-19T03:15:09.114Z",
             "name": "test"
         },
         {
             "name": "publish"
-        },
-        {
-            "name": "sd-cleanup",
-            "code": 0,
-            "startTime": "2038-01-19T03:15:09.115Z",
-            "endTime": "2038-01-19T03:15:10.130Z"
         }
     ],
     "status": "FAILURE"


### PR DESCRIPTION
This fixes log requests returning a header indicating that there are more logs for a step that never started.