### PR TITLE
Use new Datastore setup as well as no `plugin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
-database.json
+database.*
 config/local.*
 .func_config.json

--- a/bin/server
+++ b/bin/server
@@ -3,30 +3,28 @@
 
 const winston = require('winston');
 const config = require('config');
+const server = require('../');
 
 // Setup Datastore
 const datastoreConfig = config.get('datastore');
 const DatastorePlugin = require(`screwdriver-datastore-${datastoreConfig.plugin}`);
-const datastore = new DatastorePlugin(datastoreConfig[datastoreConfig.plugin]);
+const datastore = new DatastorePlugin(datastoreConfig[datastoreConfig.plugin] || {});
 
 // Setup Executor
 const executorConfig = config.get('executor');
 const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
-const executor = new ExecutorPlugin(executorConfig[executorConfig.plugin]);
+const executor = new ExecutorPlugin(executorConfig[executorConfig.plugin] || {});
 
-// scm Plugin
+// Source Code Plugin
 const scmConfig = config.get('scm');
 const ScmPlugin = require(`screwdriver-scm-${scmConfig.plugin}`);
-const scmPlugin = new ScmPlugin({});
+const scm = new ScmPlugin(scmConfig[scmConfig.plugin] || {});
 
 // Setup Authentication
 const authConfig = config.get('auth');
 
 // Setup HTTPd
 const httpdConfig = config.get('httpd');
-
-// Setup Logging
-const logBaseUrl = config.get('logging.baseUrl');
 
 // Setup GitHub Webhooks
 const gitHubSecret = config.get('webhooks.github.secret');
@@ -36,14 +34,18 @@ const ecosystem = config.get('ecosystem');
 
 // Setup Model Factories
 const Models = require('screwdriver-models');
-const pipelineFactory = Models.PipelineFactory.getInstance({ datastore, scmPlugin });
-const jobFactory = Models.JobFactory.getInstance({ datastore });
+const pipelineFactory = Models.PipelineFactory.getInstance({
+    datastore, scm
+});
+const jobFactory = Models.JobFactory.getInstance({
+    datastore
+});
 const userFactory = Models.UserFactory.getInstance({
-    datastore, scmPlugin, password: authConfig.password
+    datastore, scm, password: authConfig.password
 });
 const buildFactory = Models.BuildFactory.getInstance({
     datastore,
-    scmPlugin,
+    scm,
     executor,
     uiUri: ecosystem.ui
 });
@@ -51,31 +53,29 @@ const secretFactory = Models.SecretFactory.getInstance({
     datastore, password: authConfig.password
 });
 
-require('../')({
-    httpd: httpdConfig,
-    auth: authConfig,
-    ecosystem,
-    pipelineFactory,
-    jobFactory,
-    userFactory,
-    buildFactory,
-    secretFactory,
-    builds: {
-        logBaseUrl
-    },
-    webhooks: {
-        secret: gitHubSecret
-    },
-    stats: {
-        executor,
-        scmPlugin
-    }
-}, (err, server) => {
-    if (err) {
+// @TODO run setup for SCM and Executor
+datastore.setup()
+    .then(() => server({
+        httpd: httpdConfig,
+        auth: authConfig,
+        ecosystem,
+        pipelineFactory,
+        jobFactory,
+        userFactory,
+        buildFactory,
+        secretFactory,
+        builds: {
+            ecosystem
+        },
+        webhooks: {
+            secret: gitHubSecret
+        },
+        stats: {
+            executor, scm
+        }
+    }))
+    .then(instance => winston.info('Server running at %s', instance.info.uri))
+    .catch(err => {
         winston.error(err);
-
-        return process.exit(1);
-    }
-
-    return winston.info('Server running at %s', server.info.uri);
-});
+        process.exit(1);
+    });

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -112,12 +112,10 @@ webhooks:
         # Secret to add to GitHub webhooks so that we can validate them
         secret: SUPER-SECRET-SIGNING-THING
 
-logging:
-    # Base URL for accessing logs
-    baseUrl: https://s3-us-west-2.amazonaws.com/logs.screwdriver.cd
-
 ecosystem:
     # URL for the User Interface
     ui: https://cd.screwdriver.cd
+    # URL for the Artifact Store
+    store: https://s3-us-west-2.amazonaws.com/logs.screwdriver.cd
     # Badge service (needs to add a status and color)
     badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 const server = require('./lib/server');
 
-module.exports = (config, callback) => server(config, callback);
+module.exports = (config) => server(config);

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -60,9 +60,17 @@ function registerResourcePlugins(server, config, callback) {
     }, callback);
 }
 
-module.exports = (server, config, callback) => {
-    async.series([
-        async.apply(registerDefaultPlugins, server),
-        async.apply(registerResourcePlugins, server, config)
-    ], callback);
-};
+module.exports = (server, config) => (
+    new Promise((resolve, reject) => {
+        async.series([
+            async.apply(registerDefaultPlugins, server),
+            async.apply(registerResourcePlugins, server, config)
+        ], (err) => {
+            if (err) {
+                return reject(err);
+            }
+
+            return resolve();
+        });
+    })
+);

--- a/lib/server.js
+++ b/lib/server.js
@@ -49,7 +49,7 @@ function prettyPrintErrors(request, reply) {
  * @param  {Function}    callback                   Callback to invoke when server has started.
  * @return {http.Server}                            A listener: NodeJS http.Server object
  */
-module.exports = (config, callback) => {
+module.exports = (config) => {
     // Hapi Cross-origin resource sharing configuration
     // See http://hapijs.com/api for available options
     const cors = {
@@ -91,23 +91,18 @@ module.exports = (config, callback) => {
     server.ext('onPreResponse', prettyPrintErrors);
 
     // Register plugins
-    registrationMan(server, config, (err) => {
-        if (err) {
-            return callback(err);
-        }
+    return registrationMan(server, config)
+        .then(() => {
+            // Initialize common data in buildFactory
+            if (server.app.buildFactory) {
+                server.app.buildFactory.apiUri = server.info.uri;
+                server.app.buildFactory.tokenGen = (buildId, metadata) =>
+                    server.plugins.auth.generateToken(
+                        server.plugins.auth.generateProfile(buildId, ['build'], metadata)
+                    );
+            }
 
-        // Initialize common data in buildFactory
-        if (server.app.buildFactory) {
-            server.app.buildFactory.apiUri = server.info.uri;
-            server.app.buildFactory.tokenGen = (buildId, metadata) =>
-                server.plugins.auth.generateToken(
-                    server.plugins.auth.generateProfile(buildId, ['build'], metadata)
-                );
-        }
-
-        // Start the server
-        server.start((error) => { callback(error, server); });
-
-        return 0;
-    });
+            // Start the server
+            return server.start().then(() => server);
+        });
 };

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "screwdriver-datastore-dynamodb": "^3.0.0",
     "screwdriver-datastore-imdb": "^1.0.15",
     "screwdriver-executor-k8s": "^8.0.0",
-    "screwdriver-models": "^14.0.0",
+    "screwdriver-models": "^15.0.0",
     "screwdriver-scm-github": "^1.0.1",
     "tinytim": "^0.1.1",
     "verror": "^1.6.1",

--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -32,7 +32,7 @@ module.exports = (config) => ({
 
                     const isNotDone = stepModel.code === undefined;
                     const isNotStarted = stepModel.startTime === undefined;
-                    const url = `${config.logBaseUrl}/${buildId}/${stepName}`;
+                    const url = `${config.ecosystem.store}/${buildId}/${stepName}`;
                     const output = [];
 
                     if (isNotStarted) {

--- a/plugins/stats.js
+++ b/plugins/stats.js
@@ -8,7 +8,7 @@
  */
 exports.register = (server, options, next) => {
     const executor = options.executor;
-    const scmPlugin = options.scmPlugin;
+    const scm = options.scm;
 
     server.route({
         method: 'GET',
@@ -20,7 +20,7 @@ exports.register = (server, options, next) => {
         },
         handler: (request, reply) => reply({
             executor: executor.stats(),
-            scm: scmPlugin.stats()
+            scm: scm.stats()
         })
     });
     next();

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -65,10 +65,10 @@ describe('Register Unit Test Case', () => {
         mockery.disable();
     });
 
-    it('registered all the default plugins', (done) => {
+    it('registered all the default plugins', () => {
         serverMock.register.callsArgAsync(2);
 
-        main(serverMock, config, () => {
+        return main(serverMock, config).then(() => {
             Assert.equal(serverMock.register.callCount, pluginLength);
             expectedPlugins.forEach((plugin) => {
                 Assert.calledWith(serverMock.register, mocks[plugin], {
@@ -77,14 +77,13 @@ describe('Register Unit Test Case', () => {
                     }
                 });
             });
-            done();
         });
     });
 
-    it('registered resource plugins', (done) => {
+    it('registered resource plugins', () => {
         serverMock.register.callsArgAsync(2);
 
-        main(serverMock, config, () => {
+        return main(serverMock, config).then(() => {
             Assert.equal(serverMock.register.callCount, pluginLength);
 
             resourcePlugins.forEach((plugin) => {
@@ -97,19 +96,29 @@ describe('Register Unit Test Case', () => {
                     }
                 });
             });
-
-            done();
         });
     });
 
-    it('registers data for plugin when specified in the config object', (done) => {
+    it('bubbles failures up', () => {
+        serverMock.register.callsArgWithAsync(2, new Error('failure loading'));
+
+        return main(serverMock, config)
+            .then(() => {
+                throw new Error('should not be here');
+            })
+            .catch(err => {
+                Assert.equal(err.message, 'failure loading');
+            });
+    });
+
+    it('registers data for plugin when specified in the config object', () => {
         serverMock.register.callsArgAsync(2);
 
-        main(serverMock, {
+        return main(serverMock, {
             auth: {
                 foo: 'bar'
             }
-        }, () => {
+        }).then(() => {
             Assert.equal(serverMock.register.callCount, pluginLength);
 
             Assert.calledWith(serverMock.register, {
@@ -122,8 +131,6 @@ describe('Register Unit Test Case', () => {
                     prefix: '/v4'
                 }
             });
-
-            done();
         });
     });
 });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -117,7 +117,9 @@ describe('build plugin test', () => {
             {
                 register: plugin,
                 options: {
-                    logBaseUrl
+                    ecosystem: {
+                        store: logBaseUrl
+                    }
                 }
             }
         ], done);

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -150,7 +150,7 @@ describe('pipeline plugin test', () => {
             register: plugin,
             options: {
                 password,
-                scmPlugin: scmMock
+                scm: scmMock
             }
         }, {
             // eslint-disable-next-line global-require

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -36,7 +36,7 @@ describe('stats plugin test', () => {
             register: plugin,
             options: {
                 executor: mockStats,
-                scmPlugin: mockStats
+                scm: mockStats
             }
         }], (err) => {
             done(err);


### PR DESCRIPTION
Uses the new `setup` from Datastore, removes the `Plugin` in `scmPlugin`, refactors some internal callbacks as promises, and migrates away from the custom log url into ecosystem.

This requires:
 - https://github.com/screwdriver-cd/models/pull/118
 - https://github.com/screwdriver-cd/datastore-dynamodb/pull/29
 - https://github.com/screwdriver-cd/datastore-base/pull/17