### PR TITLE
Fix functional tests to create pipelines dynamically

### DIFF
--- a/.func_config.json
+++ b/.func_config.json
@@ -2,5 +2,5 @@
     "username": "YOUR-GITHUB-USERNAME",
     "gitToken": "YOUR-ACCESS-TOKEN",
     "accessKey": "YOUR-ACCESS-KEY",
-    "jwt": "YOUR-JWT"
+    "host": "YOUR-LOCAL-HOST"
 }

--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ npm test
 
 ### Functional tests
 
-Update `.func_config.json` with your own username, github_token, and jwt:
+Update `.func_config.json` with your own username, github token, access key, and host:
 ```json
 {
     "username": "YOUR-GITHUB-USERNAME",
     "gitToken": "YOUR-ACCESS-TOKEN",
     "accessKey": "YOUR-ACCESS-KEY",
-    "jwt": "YOUR-JWT"
+    "host": "YOUR-LOCAL-HOST"
 }
 ```
 

--- a/features/secrets.feature
+++ b/features/secrets.feature
@@ -1,3 +1,4 @@
+@secrets
 Feature: Secrets
 
     One of the big blockers with continuous delivery in the existing tools out there is the

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -23,12 +23,7 @@ module.exports = function server() {
             throw new Error('insufficient set up, missing access key');
         }
 
-        return request({
-            followAllRedirects: true,
-            json: true,
-            method: 'GET',
-            url: `https://api.screwdriver.cd/v4/auth/token?access_key=${this.accessKey}`
-        }).then((response) => {
+        return this.getJwt(this.accessKey).then((response) => {
             const accessToken = response.body.token;
             const decodedToken = jwt.decode(accessToken);
 

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -5,18 +5,6 @@ const request = require('../support/request');
 const sdapi = require('../support/sdapi');
 const github = require('../support/github');
 
-/**
- * Promise to wait a certain number of seconds
- * @method promiseToWait
- * @param  {Number}      timeToWait  Number of seconds to wait before continuing the chain
- * @return {Promise}
- */
-function promiseToWait(timeToWait) {
-    return new Promise((resolve) => {
-        setTimeout(() => resolve(), timeToWait * 1000);
-    });
-}
-
 module.exports = function server() {
     // eslint-disable-next-line new-cap
     this.Before({
@@ -26,10 +14,10 @@ module.exports = function server() {
         this.branch = 'darrenBranch';
         this.repoOrg = 'screwdriver-cd-test';
         this.repoName = 'functional-git';
-        this.pipelineId = '2e0138dfa7c4ff83720dc0cd510d2252a3398fc3';  // TODO: determine dynamically
 
         // Reset shared information
         this.pullRequestNumber = null;
+        this.pipelineId = null;
 
         return request({  // TODO : perform this in the before-hook for all func tests
             method: 'GET',
@@ -44,8 +32,11 @@ module.exports = function server() {
         );
     });
 
-    this.Given(/^an existing pipeline$/, () =>
-        request({
+    this.Given(/^an existing pipeline$/, {
+        timeout: 60 * 1000
+    }, () =>
+        this.promiseToWait(5)
+        .then(() => request({
             uri: `${this.instance}/${this.namespace}/pipelines`,
             method: 'POST',
             auth: {
@@ -55,12 +46,10 @@ module.exports = function server() {
                 scmUrl: `git@github.com:${this.repoOrg}/${this.repoName}.git#master`
             },
             json: true
-        }).then((response) => {
-            if (!this.pipelineId) {
-                this.pipelineId = response.body.id;
-            }
+        })).then((response) => {
+            this.pipelineId = response.body.id;
 
-            Assert.oneOf(response.statusCode, [409, 201]);
+            Assert.strictEqual(response.statusCode, 201);
         })
     );
 
@@ -105,7 +94,7 @@ module.exports = function server() {
     this.When(/^the pull request is closed$/, {
         timeout: 60 * 1000
     }, () =>
-        promiseToWait(3)  // Wait for the build to be enabled before moving forward
+        this.promiseToWait(3)  // Wait for the build to be enabled before moving forward
         .then(() =>
             sdapi.searchForBuild({
                 instance: this.instance,
@@ -124,7 +113,7 @@ module.exports = function server() {
     this.When(/^new changes are pushed to that pull request$/, {
         timeout: 60 * 1000
     }, () =>
-        promiseToWait(3)  // Find & save the previous build
+        this.promiseToWait(3)  // Find & save the previous build
         .then(() =>
             sdapi.searchForBuild({
                 instance: this.instance,
@@ -151,7 +140,7 @@ module.exports = function server() {
     this.Then(/^a new build from `main` should be created to test that change$/, {
         timeout: 60 * 1000
     }, () =>
-        promiseToWait(8)
+        this.promiseToWait(8)
         .then(() => sdapi.searchForBuild({
             instance: this.instance,
             pipelineId: this.pipelineId,
@@ -159,8 +148,6 @@ module.exports = function server() {
         }))
         .then((data) => {
             const build = data;
-
-            console.log('status: ', build.status);
 
             Assert.oneOf(build.status, ['QUEUED', 'RUNNING', 'SUCCESS']);
             this.jobId = build.jobId;
@@ -200,4 +187,22 @@ module.exports = function server() {
             Assert.oneOf(data.state, ['success', 'pending']);
         })
     );
+
+    // eslint-disable-next-line new-cap
+    this.After({
+        tags: ['@gitflow']
+    }, () => {
+        request({
+            method: 'DELETE',
+            auth: {
+                bearer: this.jwt
+            },
+            url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}`,
+            followAllRedirects: true,
+            json: true
+        })
+        .then((resp) => {
+            Assert.strictEqual(resp.statusCode, 204);
+        });
+    });
 };

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -4,15 +4,46 @@ const Assert = require('chai').assert;
 const request = require('../support/request');
 
 module.exports = function server() {
-    this.Given(/^an existing repository for secret with these users and permissions:$/, (table) => {
-        this.pipelineId = '4de9888518fd74beb336eb6e36f68b25697c219f';
-
-        return table;
+    // eslint-disable-next-line new-cap
+    this.Before({
+        tags: ['@secrets']
+    }, () => {
+        this.repoOrg = 'screwdriver-cd-test';
+        this.repoName = 'functional-secrets';
+        this.pipelineId = null;
     });
+
+    this.Given(/^an existing repository for secret with these users and permissions:$/,
+        { timeout: 60 * 1000 }, table =>
+        this.promiseToWait(5)
+        .then(() => this.getJwt(this.accessKey))
+        .then((response) => {
+            this.jwt = response.body.token;
+
+            return request({
+                uri: `${this.instance}/${this.namespace}/pipelines`,
+                method: 'POST',
+                auth: {
+                    bearer: this.jwt
+                },
+                body: {
+                    scmUrl: `git@github.com:${this.repoOrg}/${this.repoName}.git#master`
+                },
+                json: true
+            })
+            .then((res) => {
+                this.pipelineId = res.body.id;
+
+                Assert.strictEqual(res.statusCode, 201);
+
+                return table;
+            });
+        })
+    );
 
     this.Given(/^an existing pipeline with that repository with the workflow:$/, table => table);
 
-    this.When(/^a secret "foo" is added globally$/, () => {
+    this.When(/^a secret "foo" is added globally$/, () =>
         request({
             uri: `${this.instance}/${this.namespace}/secrets`,
             method: 'POST',
@@ -29,8 +60,8 @@ module.exports = function server() {
         }).then((response) => {
             this.secretId = response.body.id;
             Assert.equal(response.statusCode, 201);
-        });
-    });
+        })
+    );
 
     this.When(/^the "main" job is started$/, { timeout: 60 * 1000 }, () =>
         request({
@@ -124,4 +155,22 @@ module.exports = function server() {
             Assert.equal(response.statusCode, 200);
         })
     );
+
+    // eslint-disable-next-line new-cap
+    this.After({
+        tags: ['@secrets']
+    }, () => {
+        request({
+            method: 'DELETE',
+            auth: {
+                bearer: this.jwt
+            },
+            url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}`,
+            followAllRedirects: true,
+            json: true
+        })
+        .then((resp) => {
+            Assert.strictEqual(resp.statusCode, 204);
+        });
+    });
 };

--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -2,6 +2,7 @@
 
 const config = require('../../.func_config');
 const requestretry = require('requestretry');
+const request = require('../support/request');
 
 /**
  * Retry until the build has finished
@@ -16,16 +17,38 @@ function buildRetryStrategy(err, response, body) {
 }
 
 /**
+ * Promise to wait a certain number of seconds
+ * @method promiseToWait
+ * @param  {Number}      timeToWait  Number of seconds to wait before continuing the chain
+ * @return {Promise}
+ */
+function promiseToWait(timeToWait) {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(), timeToWait * 1000);
+    });
+}
+
+/**
  * Before hooks
  * @return
  */
 function beforeHooks() {
     // eslint-disable-next-line new-cap
     this.Before((scenario, cb) => {
+        const host = process.env.SD_API;
+
         this.gitToken = process.env.GIT_TOKEN || config.gitToken;
         this.accessKey = process.env.ACCESS_KEY || config.accessKey;
-        this.instance = 'https://api.screwdriver.cd';
+        this.instance = host ? `https://${host}` : config.host;
         this.namespace = 'v4';
+        this.promiseToWait = time => promiseToWait(time);
+        this.getJwt = accessKey =>
+            request({
+                followAllRedirects: true,
+                json: true,
+                method: 'GET',
+                url: `${this.instance}/${this.namespace}/auth/token?access_key=${accessKey}`
+            });
         this.waitForBuild = buildID =>
             requestretry({
                 uri: `${this.instance}/${this.namespace}/builds/${buildID}`,


### PR DESCRIPTION
Currently, `pipelineId` is hardcoded. This PR will create pipelines dynamically instead.

Some caveats:
- deletes and creates a new pipeline with each scenario; not sure if there's a better way to handle this issue???

Blocks https://github.com/screwdriver-cd/screwdriver/pull/280