### PR TITLE
Revert "Update github to version 5.2.1 🚀"

### DIFF
--- a/features/support/github.js
+++ b/features/support/github.js
@@ -34,7 +34,7 @@ function randomString(stringLength) {
  */
 function cleanUpRepository(token, branch, repoOwner, repoName) {
     const branchParams = {
-        owner: repoOwner,
+        user: repoOwner,
         repo: repoName,
         ref: `heads/${branch}`
     };
@@ -65,7 +65,7 @@ function closePullRequest(token, repoOwner, repoName, prNumber) {
     });
 
     return github.pullRequests.update({
-        owner: repoOwner,
+        user: repoOwner,
         repo: repoName,
         number: prNumber,
         state: 'closed'
@@ -155,7 +155,7 @@ function createPullRequest(token, branch, repoOwner, repoName) {
     });
 
     return github.pullRequests.create({
-        owner: repoOwner,
+        user: repoOwner,
         repo: repoName,
         title: '[DNM] testing',
         head: branch,
@@ -180,7 +180,7 @@ function getStatus(token, repoOwner, repoName, sha) {
     });
 
     return github.repos.getCombinedStatus({
-        owner: repoOwner,
+        user: repoOwner,
         repo: repoName,
         sha
     });

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
     "eslint-plugin-import": "^1.12.0",
-    "github": "^5.2.1",
+    "github": "^3.0.0",
     "jenkins-mocha": "^3.0.0",
     "mockery": "^1.7.0",
     "nock": "^8.0.0",


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#271

This is breaking functional tests. Will reopen after fixing functional tests and after `scm-github` is also updated.
The change was also incomplete: https://github.com/screwdriver-cd/screwdriver/pull/290/files?diff=split#diff-7f1dbea8150406f3ab171515f38879b7L133