### PR TITLE
Add README for authentication routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ All the possible environment variables are [defined here](config/custom-environm
 
 ## Plugins
 
-This API comes preloaded with 5 (five) resources:
+This API comes preloaded with 6 (six) resources:
+
+ - [auth](plugins/auth/README.md)
  - [builds](plugins/builds/README.md)
  - [jobs](plugins/jobs/README.md)
  - [pipelines](plugins/pipelines/README.md)

--- a/plugins/auth/README.md
+++ b/plugins/auth/README.md
@@ -1,0 +1,44 @@
+# Authentication Plugin
+> Hapi auth plugin for the Screwdriver API
+
+## Usage
+
+### Register plugin
+
+```javascript
+const Hapi = require('hapi');
+const server = new Hapi.Server();
+const authPlugin = require('./');
+
+server.connection({ port: 3000 });
+
+server.register({
+    register: authPlugin,
+    options: {}
+}, () => {
+    server.start((err) => {
+        if (err) {
+            throw err;
+        }
+        console.log('Server running at:', server.info.uri);
+    });
+});
+```
+
+### Routes
+
+#### Login
+
+`GET /auth/login` or `POST /auth/login`
+
+#### Get a token
+
+`GET /auth/token`
+
+#### Get a public key for verifying JSON Web Tokens (JWTs)
+
+`GET /auth/key`
+
+#### Logout
+
+`POST /auth/logout`


### PR DESCRIPTION
Documenting the different authentication routes:
- `GET /auth/login` or `POST /auth/login`
- `GET /auth/token`
- `GET /auth/key`
- `POST /auth/logout`