### PR TITLE
Use new git-latest command to get the current git tag

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -38,8 +38,9 @@ jobs:
     beta:
         steps:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
-            - wait-docker: DOCKER_TAG=`git describe --abbrev=0 --tags` ./ci/docker-wait.sh
-            - deploy-k8s: K8S_TAG=`git describe --abbrev=0 --tags` ./ci/k8s-deploy.sh
+            - get-tag: ./ci/git-latest.sh
+            - wait-docker: DOCKER_TAG=$(<VERSION) ./ci/docker-wait.sh
+            - deploy-k8s: K8S_TAG=$(<VERSION) ./ci/k8s-deploy.sh
             - test: npm install && npm run functional
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
@@ -63,8 +64,9 @@ jobs:
     prod:
         steps:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
-            - wait-docker: DOCKER_TAG=`git describe --abbrev=0 --tags` ./ci/docker-wait.sh
-            - deploy-k8s: K8S_TAG=`git describe --abbrev=0 --tags` ./ci/k8s-deploy.sh
+            - get-tag: ./ci/git-latest.sh
+            - wait-docker: DOCKER_TAG=$(<VERSION) ./ci/docker-wait.sh
+            - deploy-k8s: K8S_TAG=$(<VERSION) ./ci/k8s-deploy.sh
             - test: npm install && npm run functional
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver


### PR DESCRIPTION
The previous command only worked if there was 1 tag per commit. This is not always the case.