### PR TITLE
Switching to pluggable auth

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -40,16 +40,21 @@ const ScmPlugin = require(`screwdriver-scm-${scmConfig.plugin}`);
 const scm = new ScmPlugin(hoek.applyToDefaults({ ecosystem },
     (scmConfig[scmConfig.plugin] || {})));
 
+authConfig.scm = scm;
+
 // Setup Model Factories
 const Models = require('screwdriver-models');
 const pipelineFactory = Models.PipelineFactory.getInstance({
-    datastore, scm
+    datastore,
+    scm
 });
 const jobFactory = Models.JobFactory.getInstance({
     datastore
 });
 const userFactory = Models.UserFactory.getInstance({
-    datastore, scm, password: authConfig.password
+    datastore,
+    scm,
+    password: authConfig.encryptionPassword
 });
 const buildFactory = Models.BuildFactory.getInstance({
     datastore,
@@ -58,7 +63,8 @@ const buildFactory = Models.BuildFactory.getInstance({
     uiUri: ecosystem.ui
 });
 const secretFactory = Models.SecretFactory.getInstance({
-    datastore, password: authConfig.password
+    datastore,
+    password: authConfig.encryptionPassword
 });
 
 // @TODO run setup for SCM and Executor

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -10,20 +10,18 @@ auth:
     # Generate one by running
     # $ openssl rsa -in jwt.pem -pubout -out jwt.pub
     jwtPublicKey: SECRET_JWT_PUBLIC_KEY
-    # The client id used for OAuth with github. Look up GitHub OAuth for details
-    # https://developer.github.com/v3/oauth/
-    oauthClientId: SECRET_OAUTH_CLIENT_ID
-    # The client secret used for OAuth with github
-    oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
     # The access token to use on behalf of a user to access the API. Used as
     # an alternative to the OAuth flow
     temporaryAccessKey: SECRET_ACCESS_KEY
     # The user name associated with the temproary access token. Used as a
     # means of functionally testing the API
     temporaryAccessUser: SECRET_ACCESS_USER
-    # A password used for encrypting session, and OAuth data.
+    # A password used for encrypting session data.
     # **Needs to be minimum 32 characters**
-    password: SECRET_PASSWORD
+    cookiePassword: SECRET_COOKIE_PASSWORD
+    # A password used for encrypting stored secrets.
+    # **Needs to be minimum 32 characters**
+    encryptionPassword: SECRET_PASSWORD
     # A flag to set if the server is running over https.
     # Used as a flag for the OAuth flow
     https: IS_HTTPS
@@ -82,6 +80,16 @@ executor:
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
 
+scm:
+    plugin: SCM_PLUGIN
+    github:
+        # The client id used for OAuth with github. Look up GitHub OAuth for details
+        # https://developer.github.com/v3/oauth/
+        oauthClientId: SECRET_OAUTH_CLIENT_ID
+        # The client secret used for OAuth with github
+        oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
+        # You can also configure for use with GitHub enterprise
+        gheHost: SCM_GITHUB_GHE_HOST
 
 webhooks:
     github:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -14,14 +14,12 @@ auth:
         -----BEGIN PUBLIC KEY-----
         YOUR-KEY-HERE
         -----END PUBLIC KEY-----
-    # The client id used for OAuth with github. Look up GitHub OAuth for details
-    # https://developer.github.com/v3/oauth/
-    oauthClientId: YOU-PROBABLY-WANT-SOMETHING-HERE
-    # The client secret used for OAuth with github
-    oauthClientSecret: AGAIN-SOMETHING-HERE-IS-USEFUL
-    # A password used for encrypting session, and OAuth data.
+    # A password used for encrypting session data.
     # **Needs to be minimum 32 characters**
-    password: WOW-ANOTHER-INSECURE-PASSWORD!!!
+    cookiePassword: WOW-ANOTHER-INSECURE-PASSWORD!!!
+    # A password used for encrypting stored secrets.
+    # **Needs to be minimum 32 characters**
+    encryptionPassword: WOW-ANOTHER-MORE-INSECURE-PASSWORD!!!
     # A single access token used as an alternative to the Oauth login flow
     temporaryAccessKey: someAccessTokenThatIsTemporaryForUsingInTheMeantime
     # User name that is associated with the temporary access key
@@ -113,6 +111,14 @@ executor:
 
 scm:
     plugin: github
+    github:
+        # The client id used for OAuth with github. Look up GitHub OAuth for details
+        # https://developer.github.com/v3/oauth/
+        oauthClientId: YOU-PROBABLY-WANT-SOMETHING-HERE
+        # The client secret used for OAuth with github
+        oauthClientSecret: AGAIN-SOMETHING-HERE-IS-USEFUL
+        # You can also configure for use with GitHub enterprise
+        #gheHost: github.screwdriver.cd
 
 webhooks:
     github:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "jenkins-mocha --recursive --timeout 3000",
     "start": "./bin/server",
     "functional": "cucumber-js --format=pretty ./features/server.feature ./features/secrets.feature ./features/git-flow.feature ./features/authorization.feature"
   },
@@ -83,7 +83,7 @@
     "screwdriver-executor-k8s": "^9.0.0",
     "screwdriver-executor-docker": "^1.1.2",
     "screwdriver-models": "^16.0.0",
-    "screwdriver-scm-github": "^2.0.0",
+    "screwdriver-scm-github": "^3.0.0",
     "tinytim": "^0.1.1",
     "verror": "^1.6.1",
     "vision": "^4.1.0",

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -7,15 +7,15 @@ const boom = require('boom');
  * Login to Screwdriver API
  * @method login
  * @param  {Object}      config           Configuration from the user
- * @param  {String}      config.password  Password to encrypt/decrypt data in Iron
+ * @param  {Array}       config.whitelist List of allowed users to the API
  * @return {Object}                       Hapi Plugin Route
  */
 module.exports = config => ({
     method: ['GET', 'POST'],
     path: '/auth/login/{web?}',
     config: {
-        description: 'login using github',
-        notes: 'Authenticate user with github oauth provider',
+        description: 'login using oauth',
+        notes: 'Authenticate user with oauth provider',
         tags: ['api', 'login'],
         auth: {
             strategy: 'oauth',
@@ -29,7 +29,7 @@ module.exports = config => ({
             }
 
             const factory = request.server.app.userFactory;
-            const githubToken = request.auth.credentials.token;
+            const accessToken = request.auth.credentials.token;
             const username = request.auth.credentials.profile.username;
             const profile = request.server.plugins.auth.generateProfile(username, ['user'], {});
 
@@ -48,14 +48,11 @@ module.exports = config => ({
                     if (!model) {
                         return factory.create({
                             username,
-                            token: githubToken,
-                            password: config.password
+                            token: accessToken
                         });
                     }
-                    // seal and save updated token
-                    model.password = config.password;
 
-                    return model.sealToken(githubToken)
+                    return model.sealToken(accessToken)
                         .then((token) => {
                             model.token = token;
 

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -73,12 +73,25 @@ describe('github plugin test', () => {
             // eslint-disable-next-line global-require
             register: require('../../../plugins/auth'),
             options: {
-                password: 'this_is_a_password_that_needs_to_be_atleast_32_characters',
-                oauthClientId: '1234id5678',
-                oauthClientSecret: '1234secretoauthything5678',
+                cookiePassword: 'this_is_a_password_that_needs_to_be_atleast_32_characters',
+                encryptionPassword: 'this_is_another_password_that_needs_to_be_atleast_32_chars',
                 jwtPrivateKey: 'supersecret',
                 jwtPublicKey: 'lesssecret',
-                https: true
+                https: true,
+                scm: {
+                    getBellConfiguration: sinon.stub().resolves({
+                        clientId: 'abcdefg',
+                        clientSecret: 'hijklmno',
+                        forceHttps: false,
+                        isSecure: false,
+                        provider: 'github',
+                        scope: [
+                            'admin:repo_hook',
+                            'read:org',
+                            'repo:status'
+                        ]
+                    })
+                }
             }
         },
         {


### PR DESCRIPTION
Blocked on https://github.com/screwdriver-cd/scm-github/pull/25

- Can configure to use GitHub Enterprise
- Can configure to use another SCM other than GitHub
- Split password up into its two forms (encryption and cookie signing)

_note I tried to keep the environment variables backwards compatible, but `local.yaml` is no longer the same_