### PR TITLE
Forgot required flag about HTTPS

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -92,6 +92,8 @@ exports.register = (server, options, next) => {
         .then(() => pluginOptions.scm.getBellConfiguration())
         .then((bellConfig) => {
             bellConfig.password = pluginOptions.cookiePassword;
+            bellConfig.isSecure = pluginOptions.https;
+            bellConfig.forceHttps = pluginOptions.https;
 
             server.auth.strategy('session', 'cookie', {
                 cookie: 'sid',

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -54,8 +54,6 @@ describe('auth plugin test', () => {
             getBellConfiguration: sinon.stub().resolves({
                 clientId: 'abcdefg',
                 clientSecret: 'hijklmno',
-                forceHttps: false,
-                isSecure: false,
                 provider: 'github',
                 scope: [
                     'admin:repo_hook',


### PR DESCRIPTION
Without this, OAuth flow fails due to trying to redirect to HTTP not HTTPS