### PR TITLE
Removing long-timeout and removing auth registration in Webhook test

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 3000",
+    "test": "jenkins-mocha --recursive",
     "start": "./bin/server",
     "functional": "cucumber-js --format=pretty ./features/server.feature ./features/secrets.feature ./features/git-flow.feature ./features/authorization.feature"
   },

--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -70,31 +70,6 @@ describe('github plugin test', () => {
         });
 
         server.register([{
-            // eslint-disable-next-line global-require
-            register: require('../../../plugins/auth'),
-            options: {
-                cookiePassword: 'this_is_a_password_that_needs_to_be_atleast_32_characters',
-                encryptionPassword: 'this_is_another_password_that_needs_to_be_atleast_32_chars',
-                jwtPrivateKey: 'supersecret',
-                jwtPublicKey: 'lesssecret',
-                https: true,
-                scm: {
-                    getBellConfiguration: sinon.stub().resolves({
-                        clientId: 'abcdefg',
-                        clientSecret: 'hijklmno',
-                        forceHttps: false,
-                        isSecure: false,
-                        provider: 'github',
-                        scope: [
-                            'admin:repo_hook',
-                            'read:org',
-                            'repo:status'
-                        ]
-                    })
-                }
-            }
-        },
-        {
             register: plugin,
             options: {
                 secret: 'secretssecretsarenofun'


### PR DESCRIPTION
Trying to reduce the load on this test.  This might fix #308