### PR TITLE
Disabled jobs should not be triggered in workflow

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -98,11 +98,17 @@ module.exports = () => ({
                         return jobFactory.get({
                             name: nextJobName,
                             pipelineId: pipeline.id
-                        }).then(nextJobToTrigger => factory.create({
-                            jobId: nextJobToTrigger.id,
-                            sha: build.sha,
-                            username
-                        }));
+                        }).then((nextJobToTrigger) => {
+                            if (nextJobToTrigger.state === 'ENABLED') {
+                                return factory.create({
+                                    jobId: nextJobToTrigger.id,
+                                    sha: build.sha,
+                                    username
+                                });
+                            }
+
+                            return null;
+                        });
                     }))
                     .then(() => build.update());
                 })

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -457,7 +457,8 @@ describe('build plugin test', () => {
                     };
                     const publishJobMock = {
                         id: publishJobId,
-                        pipelineId
+                        pipelineId,
+                        state: 'ENABLED'
                     };
 
                     pipelineMock.workflow = ['main', 'publish', 'nerf_fight'];
@@ -539,6 +540,40 @@ describe('build plugin test', () => {
                     jobMock.name = 'PR-15';
 
                     pipelineMock.workflow = ['main', 'publish'];
+
+                    return server.inject(options).then((reply) => {
+                        assert.equal(reply.statusCode, 200);
+                        assert.notCalled(buildFactoryMock.create);
+                    });
+                });
+
+                it('skips triggering if next job is disabled', () => {
+                    const meta = {
+                        darren: 'thebest'
+                    };
+                    const username = id;
+                    const status = 'SUCCESS';
+                    const options = {
+                        method: 'PUT',
+                        url: `/builds/${id}`,
+                        credentials: {
+                            username,
+                            scope: ['build']
+                        },
+                        payload: {
+                            meta,
+                            status
+                        }
+                    };
+                    const publishJobMock = {
+                        id: publishJobId,
+                        pipelineId,
+                        state: 'DISABLED'
+                    };
+
+                    pipelineMock.workflow = ['main', 'publish', 'nerf_fight'];
+                    jobFactoryMock.get.withArgs({ pipelineId, name: 'publish' })
+                        .resolves(publishJobMock);
 
                     return server.inject(options).then((reply) => {
                         assert.equal(reply.statusCode, 200);


### PR DESCRIPTION
The UI already has the ability to disable jobs. This PR makes this actually have an effect on the workflow by stopping the line.