### PR TITLE
minor readme formatting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Two (2) options for executor:
  - Kubernetes (`k8s`)
  - Docker (`docker`)
 
- Two (2) options for SCM:
-  - Github (`github`)
-  - Bitbucket (`bitbucket`)
+Two (2) options for SCM:
+ - Github (`github`)
+ - Bitbucket (`bitbucket`)
 
 ## Testing
 


### PR DESCRIPTION
the description of the two SCM options had an extra space that indented it...

---------

old:

---------

Two (2) options for executor:
 - Kubernetes (`k8s`)
 - Docker (`docker`)

 Two (2) options for SCM:
  - Github (`github`)
  - Bitbucket (`bitbucket`)

## Testing

---------
vs. new

---------

Two (2) options for executor:
 - Kubernetes (`k8s`)
 - Docker (`docker`)

Two (2) options for SCM:
 - Github (`github`)
 - Bitbucket (`bitbucket`)

## Testing
