### PR TITLE
Adding .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+ci/
+.editorconfig
+eslint*
+CONTRIBUTING.md
+screwdriver.yaml
+test/
+features/


### PR DESCRIPTION
So we don't bundle extra files in our packages

Related to https://github.com/screwdriver-cd/screwdriver/issues/324
