### PR TITLE
Add pipelineId to 409 error message

### DIFF
--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -56,7 +56,14 @@ module.exports = function server() {
             json: true
         }).then((response) => {
             if (!this.pipelineId) {
-                this.pipelineId = response.body.id;
+                if (response.statusCode === 201) {
+                    this.pipelineId = response.body.id;
+                } else if (response.statusCode === 409) {
+                    const str = response.body.message;
+                    const id = str.split(': ')[1];
+
+                    this.pipelineId = id;
+                }
             }
 
             Assert.oneOf(response.statusCode, [409, 201]);

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -71,7 +71,7 @@ module.exports = () => ({
                         // if there is already a pipeline for the checkoutUrl, reject
                         .then((pipeline) => {
                             if (pipeline) {
-                                throw boom.conflict('pipeline already exists');
+                                throw boom.conflict(`Pipeline already exists: ${pipeline.id}`);
                             }
                         })
                         // set up pipeline admins, and create a new pipeline

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -725,6 +725,8 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 409);
+                assert.strictEqual(reply.result.message,
+                    `Pipeline already exists: ${pipelineMock.id}`);
             });
         });
 


### PR DESCRIPTION
- Add `pipelineId` to 409 error message
- Use error message to get `pipelineId` in functional test

Fixes https://github.com/screwdriver-cd/screwdriver/issues/289