### PR TITLE
pr jobs can be started by non-screwdriver users

### DIFF
--- a/test/plugins/webhooks/github.test.js
+++ b/test/plugins/webhooks/github.test.js
@@ -253,6 +253,16 @@ describe('github plugin test', () => {
                     assert.equal(reply.statusCode, 500);
                 });
             });
+
+            it('handles checkouting when given a non-listed user', () => {
+                userFactoryMock.get.resolves(null);
+                userFactoryMock.get.withArgs({ username: 'sd-buildbot' }).resolves(userMock);
+
+                return server.inject(options)
+                .then((response) => {
+                    assert.equal(response.statusCode, 201);
+                });
+            });
         });
 
         describe('pull-request event', () => {
@@ -386,6 +396,16 @@ describe('github plugin test', () => {
                             sha,
                             username
                         });
+                    });
+                });
+
+                it('handles checkout when given a non-listed user', () => {
+                    userFactoryMock.get.resolves(null);
+                    userFactoryMock.get.withArgs({ username: 'sd-buildbot' }).resolves(userMock);
+
+                    return server.inject(options)
+                    .then((response) => {
+                        assert.equal(response.statusCode, 201);
                     });
                 });
             });


### PR DESCRIPTION
The Github API has request-threshold quotas in place. Requests are tracked by either IP or API token. During the PR job creation, Screwdriver uses the PR users's access token to communicate with the Github API. If a user is not registered in Screwdriver, this operation will fail and the job will not run.

This PR proposes a solution that fixes #335 . If a PR user does not have an API token registered in Screwdriver, then it will use a default, generic user's API token instead.