### PR TITLE
Bugfix: job for PR workflow should be named PR-

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -56,7 +56,7 @@ module.exports = () => ({
                     .then(sha => eventFactory.create({
                         pipelineId: pipeline.id,
                         type: job.isPR() ? 'pr' : 'pipeline',
-                        workflow: job.isPR() ? ['main'] : pipeline.workflow,
+                        workflow: job.isPR() ? [job.name] : pipeline.workflow,
                         username,
                         sha
                     }))

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -609,7 +609,7 @@ describe('build plugin test', () => {
             type: 'pr',
             pipelineId,
             username,
-            workflow: ['main'],
+            workflow: ['PR-15'],
             sha: testBuild.sha
         };
 
@@ -655,6 +655,7 @@ describe('build plugin test', () => {
                 id: 'bbf22a3808c19dc50777258a253805b14fb3ad8b'
             };
 
+            jobMock.name = 'PR-15';
             jobMock.pipeline = sinon.stub().resolves(pipelineMock)();
             jobMock.isPR.returns(true);
             userMock.getPermissions.resolves({ push: true });


### PR DESCRIPTION
Caught a bug in event creation: the workflow job for a PR should be the `job.name` (eg: PR-15)