### PR TITLE
Setting the default K8S_HOST to `service.namespace` instead of `service`

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -95,7 +95,7 @@ executor:
     plugin: k8s
     k8s:
         # The host or IP of the kubernetes cluster
-        host: kubernetes
+        host: kubernetes.default
         # The jwt token used for authenticating kubernetes requests
         # Loaded from /var/run/secrets/kubernetes.io/serviceaccount/token by default
         # token:


### PR DESCRIPTION
Same fix as this PR: https://github.com/screwdriver-cd/executor-k8s/pull/48