### PR TITLE
Pass in executor config correctly

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -29,8 +29,7 @@ const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem },
 const executorConfig = config.get('executor');
 const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
 const executor = new ExecutorPlugin(hoek.applyToDefaults({ ecosystem },
-    (executorConfig[executorConfig.plugin] || {})));
-
+    ({ executor: executorConfig[executorConfig.plugin] } || {})));
 // Source Code Plugin
 const scmConfig = config.get('scm');
 const ScmPlugin = require(`screwdriver-scm-${scmConfig.plugin}`);


### PR DESCRIPTION
`executor-k8s` expects options to be: ``` { kubernetes: { host, token... } } ``` 
`executor-docker` expects options to be: ``` { docker: { host, port, ... } }```

But we've been passing them in without `kubernetes` or `docker` so it's been taking default values. This also explains why k8s never worked locally. This pass the options in as ``` { executor: { ... } } ```

Relates to https://github.com/screwdriver-cd/screwdriver/issues/347

