### PR TITLE
Remove eslint-plugin-import package

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "cucumber": "^1.0.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^1.12.0",
     "github": "^6.0.1",
     "jenkins-mocha": "^3.0.0",
     "mockery": "^2.0.0",


### PR DESCRIPTION
Currently failing:
```
/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint-config-airbnb-base/rules/imports.js:
	Configuration for rule "import/no-unresolved" is invalid:
	Value "data["0"].caseSensitive" has additional properties.

Referenced from: airbnb-base
Referenced from: screwdriver
Referenced from: /sd/workspace/src/github.com/screwdriver-cd/screwdriver/.eslintrc.yaml
Error: /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint-config-airbnb-base/rules/imports.js:
	Configuration for rule "import/no-unresolved" is invalid:
	Value "data["0"].caseSensitive" has additional properties.

Referenced from: airbnb-base
Referenced from: screwdriver
Referenced from: /sd/workspace/src/github.com/screwdriver-cd/screwdriver/.eslintrc.yaml
    at validateRuleOptions (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-validator.js:115:15)
    at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-validator.js:162:13
    at Array.forEach (native)
    at Object.validate (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-validator.js:161:35)
    at load (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-file.js:522:19)
    at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-file.js:391:36
    at Array.reduceRight (native)
    at applyExtends (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-file.js:362:28)
    at load (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-file.js:529:22)
    at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/eslint/lib/config/config-file.js:391:36
```