### PR TITLE
Add GET event/:id/builds endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
   * Create an event when creating a build
   * Add eventId to the build
+  * Add `GET /events/{id}` and `GET /events/{id}/builds` endpoints
 
 ## 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ All the possible environment variables are [defined here](config/custom-environm
 
 ## Plugins
 
-This API comes preloaded with 6 (six) resources:
+This API comes preloaded with 7 (seven) resources:
 
  - [auth](plugins/auth/README.md)
  - [builds](plugins/builds/README.md)
+ - [events](plugins/events/README.md)
  - [jobs](plugins/jobs/README.md)
  - [pipelines](plugins/pipelines/README.md)
  - [secrets](plugins/secrets/README.md)

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -39,6 +39,7 @@ function registerResourcePlugins(server, config, callback) {
     const plugins = [
         'auth',
         'builds',
+        'events',
         'jobs',
         'pipelines',
         'secrets',

--- a/plugins/events/README.md
+++ b/plugins/events/README.md
@@ -1,0 +1,45 @@
+# Events Plugin
+> Hapi events plugin for the Screwdriver API
+
+## Usage
+
+```javascript
+const Hapi = require('hapi');
+const server = new Hapi.Server();
+const eventsPlugin = require('./');
+
+server.connection({ port: 3000 });
+
+server.register({
+    register: eventsPlugin,
+    options: {}
+}, () => {
+    server.start((err) => {
+        if (err) {
+            throw err;
+        }
+        console.log('Server running at:', server.info.uri);
+    });
+});
+
+```
+
+### Routes
+
+#### Returns a single event
+`GET /events/{id}`
+
+#### Returns a list of builds associated with the event
+`GET /events/{id}/builds`
+
+### Access to Factory methods
+The server supplies factories to plugins in the form of server app values:
+
+```js
+// handler eventsPlugin.js
+handler: (request, reply) => {
+    const factory = request.server.app.eventFactory;
+
+    // ...
+}
+```

--- a/plugins/events/get.js
+++ b/plugins/events/get.js
@@ -3,23 +3,23 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const getSchema = schema.models.build.get;
-const idSchema = joi.reach(schema.models.build.base, 'id');
+const getSchema = schema.models.event.get;
+const idSchema = joi.reach(schema.models.event.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
-    path: '/builds/{id}',
+    path: '/events/{id}',
     config: {
-        description: 'Get a single build',
-        notes: 'Returns a build record',
-        tags: ['api', 'builds'],
+        description: 'Get a single event',
+        notes: 'Returns a event record',
+        tags: ['api', 'events'],
         handler: (request, reply) => {
-            const factory = request.server.app.buildFactory;
+            const factory = request.server.app.eventFactory;
 
             return factory.get(request.params.id)
                 .then((model) => {
                     if (!model) {
-                        throw boom.notFound('Build does not exist');
+                        throw boom.notFound('Event does not exist');
                     }
 
                     return reply(model.toJson());

--- a/plugins/events/index.js
+++ b/plugins/events/index.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const getRoute = require('./get');
+const listBuildsRoute = require('./listBuilds');
+
+/**
+ * Event API Plugin
+ * @method register
+ * @param  {Hapi}     server            Hapi Server
+ * @param  {Object}   options           Configuration
+ * @param  {Function} next              Function to call when done
+ */
+exports.register = (server, options, next) => {
+    server.route([
+        getRoute(),
+        listBuildsRoute()
+    ]);
+
+    next();
+};
+
+exports.register.attributes = {
+    name: 'events'
+};

--- a/plugins/events/listBuilds.js
+++ b/plugins/events/listBuilds.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const listSchema = joi.array().items(schema.models.build.get).label('List of builds');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/events/{id}/builds',
+    config: {
+        description: 'Get builds for a given event',
+        notes: 'Returns builds for a given event',
+        tags: ['api', 'events', 'builds'],
+        handler: (request, reply) => {
+            const factory = request.server.app.eventFactory;
+
+            return factory.get(request.params.id)
+              .then((event) => {
+                  if (!event) {
+                      throw boom.notFound('Event does not exist');
+                  }
+
+                  return event.getBuilds();
+              })
+              .then(builds => reply(builds.map(b => b.toJson())))
+              .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: listSchema
+        }
+    }
+});

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -18,6 +18,7 @@ describe('Register Unit Test Case', () => {
     const resourcePlugins = [
         '../plugins/auth',
         '../plugins/builds',
+        '../plugins/events',
         '../plugins/jobs',
         '../plugins/pipelines',
         '../plugins/secrets',

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const hapi = require('hapi');
+const mockery = require('mockery');
+const hoek = require('hoek');
+const testBuilds = require('./data/builds.json');
+const testEvent = require('./data/events.json')[0];
+
+sinon.assert.expose(assert, { prefix: '' });
+require('sinon-as-promised');
+
+const decorateBuildMock = (build) => {
+    const mock = hoek.clone(build);
+
+    mock.toJson = sinon.stub().returns(build);
+
+    return mock;
+};
+
+const getBuildMocks = (builds) => {
+    if (Array.isArray(builds)) {
+        return builds.map(decorateBuildMock);
+    }
+
+    return decorateBuildMock(builds);
+};
+
+const decorateEventMock = (event) => {
+    const decorated = hoek.clone(event);
+
+    decorated.getBuilds = sinon.stub();
+    decorated.toJson = sinon.stub().returns(event);
+
+    return decorated;
+};
+
+describe('event plugin test', () => {
+    let factoryMock;
+    let plugin;
+    let server;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach((done) => {
+        factoryMock = {
+            get: sinon.stub()
+        };
+
+        /* eslint-disable global-require */
+        plugin = require('../../plugins/events');
+        /* eslint-enable global-require */
+
+        server = new hapi.Server();
+        server.app = {
+            eventFactory: factoryMock
+        };
+        server.connection({
+            port: 1234
+        });
+
+        server.auth.scheme('custom', () => ({
+            authenticate: (request, reply) => reply.continue({})
+        }));
+        server.auth.strategy('token', 'custom');
+        server.auth.strategy('session', 'custom');
+
+        server.register([{
+            register: plugin
+        }], (err) => {
+            done(err);
+        });
+    });
+
+    afterEach(() => {
+        server = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('registers the plugin', () => {
+        assert.isOk(server.registrations.events);
+    });
+
+    describe('GET /events/{id}', () => {
+        const id = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+
+        it('exposes a route for getting a event', () => {
+            factoryMock.get.withArgs(id).resolves(decorateEventMock(testEvent));
+
+            return server.inject('/events/d398fb192747c9a0124e9e5b4e6e8e841cf8c71c')
+                .then((reply) => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.deepEqual(reply.result, testEvent);
+                });
+        });
+
+        it('returns 404 when event does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Event does not exist'
+            };
+
+            factoryMock.get.withArgs(id).resolves(null);
+
+            return server.inject('/events/d398fb192747c9a0124e9e5b4e6e8e841cf8c71c')
+                .then((reply) => {
+                    assert.equal(reply.statusCode, 404);
+                    assert.deepEqual(reply.result, error);
+                });
+        });
+
+        it('returns errors when datastore returns an error', () => {
+            factoryMock.get.withArgs(id).rejects(new Error('blah'));
+
+            return server.inject('/events/d398fb192747c9a0124e9e5b4e6e8e841cf8c71c')
+                .then((reply) => {
+                    assert.equal(reply.statusCode, 500);
+                });
+        });
+    });
+
+    describe('GET /events/{id}/builds', () => {
+        const id = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
+        let options;
+        let event;
+        let builds;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: `/events/${id}/builds`
+            };
+
+            event = decorateEventMock(testEvent);
+            builds = getBuildMocks(testBuilds);
+
+            factoryMock.get.withArgs(id).resolves(event);
+            event.getBuilds.resolves(builds);
+        });
+
+        it('returns 404 if event does not exist', () => {
+            factoryMock.get.withArgs(id).resolves(null);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 200 for getting builds', () =>
+            server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testBuilds);
+            })
+        );
+    });
+});

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -138,7 +138,7 @@ describe('job plugin test', () => {
         });
     });
 
-    describe('/jobs/{id}', () => {
+    describe('PUT /jobs/{id}', () => {
         const id = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
         const state = 'DISABLED';
         let jobMock;
@@ -213,7 +213,7 @@ describe('job plugin test', () => {
         });
     });
 
-    describe('/jobs/{id}/builds', () => {
+    describe('GET /jobs/{id}/builds', () => {
         const id = 'd398fb192747c9a0124e9e5b4e6e8e841cf8c71c';
         let options;
         let job;


### PR DESCRIPTION
- Add `GET event/:id/builds` and `GET event/:id` endpoints
- So that the UI can query all builds associated with a event 