### PR TITLE
Allow users to customize TLS settings via a JSON stringified environment variable `HTTPD_TLS`

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -39,6 +39,11 @@ httpd:
     host: HOST
     # Externally routable URI (usually your load balancer or CNAME)
     uri: URI
+    # TLS configuration (key, cert, etc.)
+    # https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener
+    tls:
+        __name: HTTPD_TLS
+        __format: json
 
 datastore:
     plugin: DATASTORE_PLUGIN


### PR DESCRIPTION
So you can do something like:
```
HTTPD_TLS='{"key":"`cat ./cert.key`","cert":"`cat ./cert.cert`"}'
```

More options are here: https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener