### PR TITLE
fix: update joi.boolean() validation for auth

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -32,7 +32,7 @@ const ALGORITHM = 'RS256';
  */
 exports.register = (server, options, next) => {
     const pluginOptions = joi.attempt(options, joi.object().keys({
-        https: joi.boolean().required(),
+        https: joi.boolean().truthy('true').falsy('false').required(),
         cookiePassword: joi.string().min(32).required(),
         encryptionPassword: joi.string().min(32).required(),
         temporaryAccessKey: joi.string().optional(),


### PR DESCRIPTION
- Allow https to be 'true' or 'false' as string
- Because when we set IS_HTTPS in k8s deployment, we set it as string "true"

Related to recent update on joi  https://github.com/screwdriver-cd/screwdriver/pull/382