### PR TITLE
docs: make api documentation more clear and consistent

### DIFF
--- a/plugins/auth/crumb.js
+++ b/plugins/auth/crumb.js
@@ -11,7 +11,7 @@ module.exports = () => ({
     method: 'GET',
     path: '/auth/crumb',
     config: {
-        description: 'crumb generator',
+        description: 'Generate crumb',
         notes: 'Should return a crumb',
         tags: ['api', 'crumb', 'auth'],
         handler: (request, reply) => reply({

--- a/plugins/auth/key.js
+++ b/plugins/auth/key.js
@@ -13,7 +13,7 @@ module.exports = options => ({
     method: ['GET'],
     path: '/auth/key',
     config: {
-        description: 'jwt public key',
+        description: 'Get jwt public key',
         notes: 'Public Key for verifying JSON Web Tokens',
         tags: ['api', 'auth', 'key'],
         handler: (request, reply) => reply({

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -14,7 +14,7 @@ module.exports = config => ({
     method: ['GET', 'POST'],
     path: '/auth/login/{web?}',
     config: {
-        description: 'login using oauth',
+        description: 'Login using oauth',
         notes: 'Authenticate user with oauth provider',
         tags: ['api', 'login'],
         auth: {

--- a/plugins/auth/logout.js
+++ b/plugins/auth/logout.js
@@ -9,7 +9,7 @@ module.exports = () => ({
     method: 'POST',
     path: '/auth/logout',
     config: {
-        description: 'logout of screwdriver',
+        description: 'Logout of screwdriver',
         notes: 'Clears the cookie used for authentication',
         tags: ['api', 'logout'],
         auth: {

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -12,7 +12,7 @@ module.exports = () => ({
     method: ['GET'],
     path: '/auth/token/{buildId?}',
     config: {
-        description: 'generate jwt',
+        description: 'Generate jwt',
         notes: 'Generate a JWT for use throughout Screwdriver',
         tags: ['api', 'auth', 'token'],
         auth: {

--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -8,8 +8,8 @@ module.exports = () => ({
     method: 'POST',
     path: '/builds',
     config: {
-        description: 'Save a build',
-        notes: 'Save a specific build',
+        description: 'Create and start a build',
+        notes: 'Create and start a specific build',
         tags: ['api', 'builds'],
         auth: {
             strategies: ['token', 'session'],

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -9,8 +9,8 @@ module.exports = () => ({
     method: 'PUT',
     path: '/builds/{id}',
     config: {
-        description: 'Save a build',
-        notes: 'Save a specific build',
+        description: 'Update a build',
+        notes: 'Update a specific build',
         tags: ['api', 'builds'],
         auth: {
             strategies: ['token', 'session'],

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -36,7 +36,6 @@ server.register({
 
 `GET /pipelines/{id}`
 
-
 #### Create a pipeline
 Create a pipeline and create a job called 'main'
 
@@ -59,6 +58,26 @@ Example payload:
 #### Delete a pipeline
 
 `DELETE /pipelines/{id}`
+
+#### Synchronize a pipeline
+* Synchronize the pipeline by looking up latest screwdriver.yaml
+* Create, update, or disable jobs if necessary.
+* Store/update the pipeline workflow
+
+`GET /pipelines/{id}/sync`
+
+#### Get all pipeline events
+
+`GET /pipelines/{id}/events`
+
+#### Get all jobs (including pull requests jobs)
+`archived` is optional and has a default value of `false`, which makes the endpoint do not return archived jobs, e.g. closed pull requests.
+
+`GET /pipelines/{id}/jobs?archived={boolean}`
+
+#### Get all pipeline secrets
+
+`GET /pipelines/{id}/secrets`
 
 ### Access to Factory methods
 The server supplies factories to plugins in the form of server settings:


### PR DESCRIPTION
- Add documentation for pipeline endpoints
- Fix descriptions to make them consistent and clear when showing up in the swagger page