### PR TITLE
Change secret GIT_TOKEN to GITHUB_TOKEN to be consistent other repos

### DIFF
--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -37,7 +37,7 @@ function beforeHooks() {
     this.Before((scenario, cb) => {
         const host = process.env.SD_API;
 
-        this.gitToken = process.env.GIT_TOKEN || config.gitToken;
+        this.gitToken = process.env.GITHUB_TOKEN || config.gitToken;
         this.accessKey = process.env.ACCESS_KEY || config.accessKey;
         this.instance = host ? `https://${host}` : config.host;
         this.namespace = 'v4';

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -55,7 +55,7 @@ jobs:
             # Access key for functional tests
             - ACCESS_KEY
             # Git access token
-            - GIT_TOKEN
+            - GITHUB_TOKEN
             # Talking to Kubernetes
             - K8S_TOKEN
 
@@ -81,6 +81,6 @@ jobs:
             # Access key for functional tests
             - ACCESS_KEY
             # Git access token
-            - GIT_TOKEN
+            - GITHUB_TOKEN
             # Talking to Kubernetes
             - K8S_TOKEN


### PR DESCRIPTION
Trying to make the secret key match the UI's (https://github.com/screwdriver-cd/ui/blob/master/screwdriver.yaml#L34) so the mass-create script will be easier to write

Related to https://github.com/screwdriver-cd/screwdriver/issues/400