### PR TITLE
feat(379) Add webhook during pipeline recreation

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -66,6 +66,12 @@ Example payload:
 
 `GET /pipelines/{id}/sync`
 
+#### Synchronize webhooks
+* Synchronize webhooks for the pipeline
+* Add or update webhooks if necessary
+
+`GET /pipelines/{id}/sync/webhooks`
+
 #### Get all pipeline events
 
 `GET /pipelines/{id}/events`

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -3,6 +3,7 @@
 const createRoute = require('./create');
 const removeRoute = require('./remove');
 const syncRoute = require('./sync');
+const syncWebhooksRoute = require('./syncWebhooks');
 const getRoute = require('./get');
 const listRoute = require('./list');
 const badgeRoute = require('./badge');
@@ -22,6 +23,7 @@ exports.register = (server, options, next) => {
         createRoute(),
         removeRoute(),
         syncRoute(),
+        syncWebhooksRoute(),
         getRoute(),
         listRoute(),
         badgeRoute(),

--- a/plugins/pipelines/syncWebhooks.js
+++ b/plugins/pipelines/syncWebhooks.js
@@ -7,10 +7,10 @@ const idSchema = joi.reach(schema.models.pipeline.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
-    path: '/pipelines/{id}/sync',
+    path: '/pipelines/{id}/sync/webhooks',
     config: {
-        description: 'Sync a pipeline',
-        notes: 'Sync a specific pipeline',
+        description: 'Add webhooks or update webhooks if already exists',
+        notes: 'Add or update Screwdriver API webhooks',
         tags: ['api', 'pipelines'],
         auth: {
             strategies: ['token', 'session'],
@@ -40,11 +40,11 @@ module.exports = () => ({
                     .then((permissions) => {
                         if (!permissions.push) {
                             throw boom.unauthorized(`User ${username} `
-                                + 'does not have write permission for this repo');
+                                + 'does not have push permission for this repo');
                         }
                     })
-                    // user has good permissions, sync the pipeline
-                    .then(() => pipeline.sync())
+                    // user has good permissions, add or update webhooks
+                    .then(() => pipeline.addWebhook(`${request.server.info.uri}/v4/webhooks`))
                     .then(() => reply().code(204));
             })
             .catch(err => reply(boom.wrap(err)));


### PR DESCRIPTION
- Since we [moved addWebhook out of sync](https://github.com/screwdriver-cd/models/pull/146), we should now call it inside the `POST /pipelines`. 
- Also added a new endpoint to sync webhooks if it's not correct. We can add a button for it in UI later.

Blocked by: https://github.com/screwdriver-cd/screwdriver/pull/401
Related: https://github.com/screwdriver-cd/screwdriver/issues/379