### PR TITLE
fix: Increase git-flow func test timeout

### DIFF
--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -4,7 +4,7 @@ const Assert = require('chai').assert;
 const request = require('../support/request');
 const sdapi = require('../support/sdapi');
 const github = require('../support/github');
-const TIMEOUT = 120 * 1000;
+const TIMEOUT = 240 * 1000;
 
 module.exports = function server() {
     // eslint-disable-next-line new-cap


### PR DESCRIPTION
Trying to unblock the API pipeline. Seeing timeout failures in git-flow tests without seeing any other significant errors in the beta API logs. Increasing the timeout x2 just to see if the build will pass

<img width="768" alt="screen shot 2017-01-04 at 1 05 18 pm" src="https://cloud.githubusercontent.com/assets/3230529/21659199/8a8d7a16-d27e-11e6-9a30-c9556f678f73.png">


Related to https://github.com/screwdriver-cd/screwdriver/issues/399