### PR TITLE
Rolling back to v0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-api",
-  "version": "3.4.0",
+  "version": "0.4.0",
   "description": "API server for the Screwdriver CD service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Screwdriver is really still at version 0 (we don't have our 1.0 release yet).  I've already gone and corrected our git tags to be correct.  This will ensure our Docker and NPM packages will be shipped accordingly.