### PR TITLE
docs: refer to the correct docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ info: Server running at http://localhost:8080
 
 ```bash
 $ vim ./local.yaml # See below for configuration
-$ docker run --rm -it --volume=`pwd`/local.yaml:/config/local.yaml -p 8080 screwdrivercd/api:latest
+$ docker run --rm -it --volume=`pwd`/local.yaml:/config/local.yaml -p 8080 screwdrivercd/screwdriver:stable
 info: Server running at http://localhost:8080
 ```
 


### PR DESCRIPTION
The `README.md` refers to the wrong docker image. It's referring to `screwdrivercd/api` when it should be `screwdrivercd/screwdriver`.

Reference: https://news.ycombinator.com/item?id=13424592
Docker Image: https://hub.docker.com/r/screwdrivercd/screwdriver/