### PR TITLE
fix: Allow users to mount local.yaml files into /config/local.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ WORKDIR /usr/src/app
 RUN npm install screwdriver-api@$VERSION
 WORKDIR /usr/src/app/node_modules/screwdriver-api
 
+# Setup configuration folder
+RUN ln -s /usr/src/app/node_modules/screwdriver-api/config /config
+
 # Expose the web service port
 EXPOSE 8080
 


### PR DESCRIPTION
This makes it easy for people to insert their own local configuration.

We already do it in the store: https://github.com/screwdriver-cd/store/blob/master/Dockerfile#L14-L15