### PR TITLE
fix: Cleaning up Bookend Definition

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ CONTRIBUTING.md
 screwdriver.yaml
 test/
 features/
+config/local.*

--- a/bin/server
+++ b/bin/server
@@ -40,10 +40,12 @@ const scm = new ScmPlugin(hoek.applyToDefaults({ ecosystem },
 
 authConfig.scm = scm;
 
+// Plugins to run before/after a build
+const bookends = config.get('bookends');
 const bookend = new Bookend(
-    { 'sd-scm': scm },          // default plugins defined by screwdriver
-    ecosystem.setup || [],      // plugins required for the setup- steps
-    ecosystem.teardown || []    // plugins required for the teardown- steps
+    { scm },                    // default plugins defined by screwdriver
+    bookends.setup || [],      // plugins required for the setup- steps
+    bookends.teardown || []    // plugins required for the teardown- steps
 );
 
 // Setup Model Factories

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -105,13 +105,7 @@ scm:
         # The client secret used for OAuth with bitbucket
         oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
 
-ecosystem:
-    # URL for the User Interface
-    ui: ECOSYSTEM_UI
-    # Externally routable URL for the Artifact Store
-    store: ECOSYSTEM_STORE
-    # Badge service (needs to add a status and color)
-    badges: ECOSYSTEM_BADGES
+bookends:
     # List of module names, or objects { name, config } for instantiation to use in sd-setup
     setup:
         __name: BOOKENDS_SETUP
@@ -120,3 +114,11 @@ ecosystem:
     teardown:
         __name: BOOKENDS_TEARDOWN
         __format: json
+
+ecosystem:
+    # URL for the User Interface
+    ui: ECOSYSTEM_UI
+    # Externally routable URL for the Artifact Store
+    store: ECOSYSTEM_STORE
+    # Badge service (needs to add a status and color)
+    badges: ECOSYSTEM_BADGES

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -121,6 +121,11 @@ scm:
         oauthClientId: YOUR-BITBUCKET-OAUTH-CLIENT-ID
         oauthClientSecret: YOUR-BITBUCKET-OAUTH-CLIENT-SECRET
 
+bookends:
+    # Plugins for build setup
+    setup:
+        - scm
+
 ecosystem:
     # Externally routable URL for the User Interface
     ui: https://cd.screwdriver.cd
@@ -128,6 +133,3 @@ ecosystem:
     store: https://store.screwdriver.cd
     # Badge service (needs to add a status and color)
     badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg
-    # Plugins for build setup
-    setup:
-        - sd-scm


### PR DESCRIPTION
BREAKING CHANGE: Users who previously overrode bookend will need to fix `sd-scm` and config location in local.yaml

 - Moving `bookend` config to it's own top-level config instead of flooding `ecosystem`
 - Renamed `sd-scm` to `scm` as it already adds `sd-` in all bookeneds
 - Preventing local.* from going into NPM