### PR TITLE
feat: allow configuration for Github private repo support

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -98,6 +98,10 @@ scm:
         gheHost: SCM_GITHUB_GHE_HOST
         # Secret to add to GitHub webhooks so that we can validate them
         secret: WEBHOOK_GITHUB_SECRET
+        # Whether it supports private repo: boolean value.
+        # If true, it will ask for read and write access to public and private repos
+        # https://developer.github.com/v3/oauth/#scopes
+        privateRepo: SCM_PRIVATE_REPO_SUPPORT
     bitbucket:
         # The client id used for OAuth with bitbucket. Look up Bitbucket OAuth for details
         # https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -118,6 +118,10 @@ scm:
         #gheHost: github.screwdriver.cd
         # Secret to add to GitHub webhooks so that we can validate them
         secret: SUPER-SECRET-SIGNING-THING
+        # Whether it supports private repo: boolean value.
+        # If true, it will ask for read and write access to public and private repos
+        # https://developer.github.com/v3/oauth/#scopes
+        privateRepo: false
     bitbucket:
         oauthClientId: YOUR-BITBUCKET-OAUTH-CLIENT-ID
         oauthClientSecret: YOUR-BITBUCKET-OAUTH-CLIENT-SECRET


### PR DESCRIPTION
Adds environment variables to specify if GitHub should ask for elevated privileges to read private repositories.

Related:
https://github.com/screwdriver-cd/scm-github/pull/51
https://github.com/screwdriver-cd/screwdriver/issues/436