### PR TITLE
[WIP] feat: Add read protection for pipelines

### DIFF
--- a/test/plugins/data/pipelines.json
+++ b/test/plugins/data/pipelines.json
@@ -1,7 +1,7 @@
 [
     {
         "id": 123,
-        "scmUri": "github.com:12345:branchName",
+        "scmUri": "github.com:123:branchName",
         "createTime": "2038-01-19T03:14:08.131Z",
         "admins": {
             "stjohn": true
@@ -9,7 +9,7 @@
     },
     {
         "id": 124,
-        "scmUri": "github.com:12345:branchName",
+        "scmUri": "github.com:124:branchName",
         "createTime": "2038-01-19T03:14:08.131Z",
         "admins": {
             "tkyi": true
@@ -17,7 +17,7 @@
     },
     {
         "id": 125,
-        "scmUri": "github.com:12345:branchName",
+        "scmUri": "github.com:125:branchName",
         "createTime": "2038-01-19T03:14:08.131Z",
         "admins": {
             "d2lam": true


### PR DESCRIPTION
Some work for https://github.com/screwdriver-cd/screwdriver/issues/436
- When get a pipeline, if no access return `404`
- When list pipelines, only returns the ones that user has access to. 

Please give some feedback :) 