### PR TITLE
fix: can settings username and email for checkout

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -15,6 +15,9 @@ const authConfig = config.get('auth');
 // Setup HTTPd
 const httpdConfig = config.get('httpd');
 
+// Setup Webhooks
+const webhooksConfig = config.get('webhooks');
+
 // Special urls for things like the UI
 const ecosystem = config.get('ecosystem');
 
@@ -83,6 +86,7 @@ datastore.setup()
     .then(() => server({
         httpd: httpdConfig,
         auth: authConfig,
+        webhooks: webhooksConfig,
         ecosystem,
         pipelineFactory,
         jobFactory,

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -96,6 +96,9 @@ scm:
         oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
         # You can also configure for use with GitHub enterprise
         gheHost: SCM_GITHUB_GHE_HOST
+        # The username and email used for checkout with github
+        username: SCM_USERNAME
+        email: SCM_EMAIL
         # Secret to add to GitHub webhooks so that we can validate them
         secret: WEBHOOK_GITHUB_SECRET
         # Whether it supports private repo: boolean value.
@@ -108,6 +111,13 @@ scm:
         oauthClientId: SECRET_OAUTH_CLIENT_ID
         # The client secret used for OAuth with bitbucket
         oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
+        # The username and email used for checkout with bitbucket
+        username: SCM_USERNAME
+        email: SCM_EMAIL
+
+webhooks:
+    # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
+    username: SCM_USERNAME
 
 bookends:
     # List of module names, or objects { name, config } for instantiation to use in sd-setup

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -116,6 +116,9 @@ scm:
         oauthClientSecret: AGAIN-SOMETHING-HERE-IS-USEFUL
         # You can also configure for use with GitHub enterprise
         #gheHost: github.screwdriver.cd
+        # The username and email used for checkout with github
+        #username: sd-buildbot
+        #email: dev-null@screwdriver.cd
         # Secret to add to GitHub webhooks so that we can validate them
         secret: SUPER-SECRET-SIGNING-THING
         # Whether it supports private repo: boolean value.
@@ -125,6 +128,13 @@ scm:
     bitbucket:
         oauthClientId: YOUR-BITBUCKET-OAUTH-CLIENT-ID
         oauthClientSecret: YOUR-BITBUCKET-OAUTH-CLIENT-SECRET
+        # The username and email used for checkout with bitbucket
+        #username: sd-buildbot
+        #email: dev-null@screwdriver.cd
+
+webhooks:
+    # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
+    #username: sd-buildbot
 
 bookends:
     # Plugins for build setup

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -117,8 +117,8 @@ scm:
         # You can also configure for use with GitHub enterprise
         #gheHost: github.screwdriver.cd
         # The username and email used for checkout with github
-        #username: sd-buildbot
-        #email: dev-null@screwdriver.cd
+        username: sd-buildbot
+        email: dev-null@screwdriver.cd
         # Secret to add to GitHub webhooks so that we can validate them
         secret: SUPER-SECRET-SIGNING-THING
         # Whether it supports private repo: boolean value.
@@ -134,7 +134,7 @@ scm:
 
 webhooks:
     # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
-    #username: sd-buildbot
+    username: sd-buildbot
 
 bookends:
     # Plugins for build setup

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -2,7 +2,6 @@
 
 const boom = require('boom');
 const joi = require('joi');
-const GENERIC_SCM_USER = 'sd-buildbot';
 
 /**
  * Stop a job by stopping all the builds associated with it
@@ -377,7 +376,7 @@ function pushEvent(pluginOptions, request, reply, parsed) {
 exports.register = (server, options, next) => {
     const scm = server.root.app.pipelineFactory.scm;
     const pluginOptions = joi.attempt(options, joi.object().keys({
-        username: joi.string().optional().default(GENERIC_SCM_USER)
+        username: joi.string().required()
     }), 'Invalid config for plugin-webhooks');
 
     server.route({

--- a/test/plugins/webhooks/index.test.js
+++ b/test/plugins/webhooks/index.test.js
@@ -293,6 +293,38 @@ describe('github plugin test', () => {
                     assert.equal(response.statusCode, 201);
                 });
             });
+
+            it('handles checkouting when given a custom username', () => {
+                const testServer = new hapi.Server();
+
+                testServer.root.app = {
+                    jobFactory: jobFactoryMock,
+                    buildFactory: buildFactoryMock,
+                    pipelineFactory: pipelineFactoryMock,
+                    userFactory: userFactoryMock,
+                    eventFactory: eventFactoryMock
+                };
+                testServer.connection({
+                    host: 'localhost',
+                    port: 12345,
+                    uri: apiUri
+                });
+
+                testServer.register([{
+                    register: plugin,
+                    options: {
+                        username: 'abcd'
+                    }
+                }]);
+
+                userFactoryMock.get.resolves(null);
+                userFactoryMock.get.withArgs({ username: 'abcd' }).resolves(userMock);
+
+                return testServer.inject(options)
+                .then((response) => {
+                    assert.equal(response.statusCode, 201);
+                });
+            });
         });
 
         describe('pull-request event', () => {
@@ -437,6 +469,38 @@ describe('github plugin test', () => {
                     userFactoryMock.get.withArgs({ username: 'sd-buildbot' }).resolves(userMock);
 
                     return server.inject(options)
+                    .then((response) => {
+                        assert.equal(response.statusCode, 201);
+                    });
+                });
+
+                it('handles checkouting when given a custom username', () => {
+                    const testServer = new hapi.Server();
+
+                    testServer.root.app = {
+                        jobFactory: jobFactoryMock,
+                        buildFactory: buildFactoryMock,
+                        pipelineFactory: pipelineFactoryMock,
+                        userFactory: userFactoryMock,
+                        eventFactory: eventFactoryMock
+                    };
+                    testServer.connection({
+                        host: 'localhost',
+                        port: 12345,
+                        uri: apiUri
+                    });
+
+                    testServer.register([{
+                        register: plugin,
+                        options: {
+                            username: 'abcd'
+                        }
+                    }]);
+
+                    userFactoryMock.get.resolves(null);
+                    userFactoryMock.get.withArgs({ username: 'abcd' }).resolves(userMock);
+
+                    return testServer.inject(options)
                     .then((response) => {
                         assert.equal(response.statusCode, 201);
                     });


### PR DESCRIPTION
Add environment variables `SCM_USERNAME` and `SCM_EMAIL` with use custom user for checkout.
https://github.com/screwdriver-cd/scm-github/pull/52
https://github.com/screwdriver-cd/scm-bitbucket/pull/34

As a further modification, if a user does not have a valid SCM token registered with Screwdriver, `SCM_USERNAME` will use this user's token instead.