### PR TITLE
fix: Set parentBuildId for triggered builds

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -103,6 +103,7 @@ module.exports = () => ({
                                 return factory.create({
                                     jobId: nextJobToTrigger.id,
                                     sha: build.sha,
+                                    parentBuildId: id,
                                     username,
                                     eventId: build.eventId
                                 });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -472,10 +472,6 @@ describe('build plugin test', () => {
                     pipelineMock.workflow = ['main', 'publish', 'nerf_fight'];
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'publish' })
                         .resolves(publishJobMock);
-                    buildFactoryMock.create.withArgs({
-                        jobId: publishJobId,
-                        username
-                    }).resolves('doesNotMatter');
                     buildMock.eventId = 'bbf22a3808c19dc50777258a253805b14fb3ad8b';
 
                     return server.inject(options).then((reply) => {
@@ -484,6 +480,7 @@ describe('build plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId: publishJobId,
                             sha: testBuild.sha,
+                            parentBuildId: id,
                             username,
                             eventId: 'bbf22a3808c19dc50777258a253805b14fb3ad8b'
                         });


### PR DESCRIPTION
I found that triggered builds don't have `parentBuildId` parameter set.
I fixed that issue and remove the mock which seems to be unused around its test.
