### PR TITLE
fix: Add SCM selector to in-a-box

### DIFF
--- a/in-a-box.py
+++ b/in-a-box.py
@@ -31,6 +31,7 @@ services:
             URI: http://${ip}:9001
             ECOSYSTEM_UI: http://${ip}:9000
             ECOSYSTEM_STORE: http://${ip}:9002
+            SCM_PLUGIN: ${scm_plugin}
             DATASTORE_PLUGIN: sequelize
             DATASTORE_SEQUELIZE_DIALECT: sqlite
             EXECUTOR_PLUGIN: docker
@@ -140,26 +141,65 @@ def generate_jwt():
         'private_key': pad_lines(jwt_private, 16)
     }
 
+# Ask to select a SCM provider
+def select_scm_provider():
+    scm_plugins = ['github', 'bitbucket']
+    while True:
+        prompt = get_input('📤   Which SCM provider would you like to use? (github/bitbucket) ')
+        scm_plugin = prompt.lower()
+        if scm_plugin in scm_plugins:
+            break
 
-def generate_oauth(ip):
+    return {
+        'scm_plugin': scm_plugin
+    }
+
+def generate_oauth(scm_plugin, ip):
     """
     Generate OAuth credentials from GitHub.com
 
     Parameters
     ----------
+    scm_plugin: str
+        The SCM provider
     ip: str
         The IP address
     """
-    print('''
-    Please create a new OAuth application on GitHub.com
-    Go to https://github.com/settings/applications/new to start the process
-    For 'Homepage URL' put http://{ip}:9000
-    For 'Authorization callback URL' put http://{ip}:9001/v4/auth/login
-    When done, please provide the following values:
-    '''.format(ip=ip))
+    if scm_plugin == 'github':
+        service_name = 'GitHub.com'
+        start_url = 'https://github.com/settings/applications/new'
+        homepage_url = 'Homepage URL'
+        callback_url = 'Authorization callback URL'
+        additional_process = ''
+        client_id_name = 'Client ID'
+        client_secret_name = 'Client Secret'
+    elif scm_plugin == 'bitbucket':
+        service_name = 'Bitbucket.org'
+        start_url = 'https://bitbucket.org/account/user/<your username>/oauth-consumers/new'
+        homepage_url = 'URL'
+        callback_url = 'Callback URL'
+        additional_process = "for 'Permissions' enable Read checkbox for Repositories, Account and Pull requests"
+        client_id_name = 'Key'
+        client_secret_name = 'Secret'
 
-    client_id = get_input('    Client ID: ')
-    secret = getpass.getpass('    Client Secret: ')
+    print('''
+    Please create a new OAuth application on {service_name}
+    Go to {start_url} to start the process
+    For '{homepage_url}' put http://{ip}:9000
+    For '{callback_url}' put http://{ip}:9001/v4/auth/login
+    {additional_process}
+    When done, please provide the following values:
+    '''.format(
+        ip = ip,
+        start_url = start_url,
+        service_name = service_name,
+        homepage_url = homepage_url,
+        callback_url = callback_url,
+        additional_process = additional_process
+    ))
+
+    client_id = get_input('    %s: ' % client_id_name)
+    secret = getpass.getpass('    %s: ' % client_secret_name)
 
     print('')
     return dict(oauth_id=client_id, oauth_secret=secret)
@@ -194,8 +234,10 @@ def main():
     print('🔐   Generating signing secrets')
     fields.update(generate_jwt())
 
+    fields = dict(fields, **select_scm_provider())
+
     print('📦   Generating OAuth credentials')
-    fields.update(generate_oauth(fields['ip']))
+    fields.update(generate_oauth(fields['scm_plugin'], fields['ip']))
 
     print('💾   Writing Docker Compose file')
     compose = Template(DOCKER_TEMPLATE).substitute(fields)


### PR DESCRIPTION
I added a feature for supporting bitbucket addressed in #321.


##### Output
```
🎁   Boxing up Screwdriver
👀   Checking prerequisites
🔐   Generating signing secrets
📤   Which SCM provider would you like to use? (github/bitbucket) a
📤   Which SCM provider would you like to use? (github/bitbucket) bitbucket
📦   Generating OAuth credentials

    Please create a new OAuth application on Bitbucket.com
    Go to https://bitbucket.org/account/user/<your username>/oauth-consumers/new to start the process
    For 'URL' put http://192.168.1.16:9000
    For 'Callback URL' put http://192.168.1.16:9001/v4/auth/login
    for 'Permissions' enable Read checkbox for Repositories, Account and Pull requests
    When done, please provide the following values:

    Key: thisiskey
    Secret:

💾   Writing Docker Compose file
🚀   Screwdriver is ready to launch!
(snip)
```
docker-compose.yml (excerpt)
```
        environment:
            PORT: 80
            URI: http://192.168.1.16:9001
            ECOSYSTEM_UI: http://192.168.1.16:9000
            ECOSYSTEM_STORE: http://192.168.1.16:9002
            SCM_PLUGIN: bitbucket
            DATASTORE_PLUGIN: sequelize
            DATASTORE_SEQUELIZE_DIALECT: sqlite
            EXECUTOR_PLUGIN: docker
            SECRET_WHITELIST: "[]"
            EXECUTOR_DOCKER_DOCKER: |
                {
                    "socketPath": "/var/run/docker.sock"
                }
            SECRET_OAUTH_CLIENT_ID: thisiskey
            SECRET_OAUTH_CLIENT_SECRET: thisissecret