### PR TITLE
Fix: make the badge show status of the latest event

### DIFF
--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -46,21 +46,15 @@ module.exports = () => ({
                         return reply.redirect(getUrl(request.server.app.ecosystem.badges));
                     }
 
-                    return pipeline.jobs.then((jobs) => {
-                        const main = jobs.filter(job => job.name === 'main').pop();
+                    return pipeline.getEvents({ sort: 'ascending' }).then((events) => {
+                        const lastEvent = events.pop();
 
-                        if (!main) {
+                        if (!lastEvent) {
                             return reply.redirect(getUrl(badgeService));
                         }
 
-                        return main.getBuilds({
-                            paginate: {
-                                page: 1,
-                                count: 1
-                            },
-                            sort: 'descending'
-                        }).then((builds) => {
-                            const build = builds.pop();
+                        return lastEvent.getBuilds().then((builds) => {
+                            const build = builds.reverse().pop();
 
                             return reply.redirect(getUrl(badgeService, build && build.status));
                         });

--- a/test/plugins/data/events.json
+++ b/test/plugins/data/events.json
@@ -14,7 +14,7 @@
             "username": "imbatman"
         }
     },
-    "workflow": ["main", "publish"],
+    "workflow": ["main", "publish", "beta"],
     "causeMessage": "Merge pull request #26 from screwdriver-cd/models",
     "creator": {
         "avatar": "https://avatars.githubusercontent.com/u/2042?v=3",

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -459,7 +459,7 @@ describe('pipeline plugin test', () => {
         it('returns 302 to for a valid build', () =>
             server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'failure/red');
+                assert.deepEqual(reply.headers.location, '1 unknown, 2 failure/red');
             })
         );
 
@@ -468,7 +468,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'unknown/lightgrey');
+                assert.deepEqual(reply.headers.location, '/lightgrey');
             });
         });
 
@@ -477,7 +477,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'unknown/lightgrey');
+                assert.deepEqual(reply.headers.location, '/lightgrey');
             });
         });
 
@@ -486,7 +486,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'unknown/lightgrey');
+                assert.deepEqual(reply.headers.location, '/lightgrey');
             });
         });
 
@@ -495,7 +495,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'unknown/lightgrey');
+                assert.deepEqual(reply.headers.location, '/lightgrey');
             });
         });
     });


### PR DESCRIPTION
- Previously the badge only reflect the build status for main job
- Change it to get the last build status of the latest event

<img width="170" alt="screen shot 2017-02-16 at 3 32 24 pm" src="https://cloud.githubusercontent.com/assets/20427140/23046283/8b7e9b52-f45d-11e6-9e86-14ba7f8bb437.png">
<img width="174" alt="screen shot 2017-02-16 at 3 35 00 pm" src="https://cloud.githubusercontent.com/assets/20427140/23046286/8d89defc-f45d-11e6-8b49-58b7f5d9f164.png">

related to https://github.com/screwdriver-cd/screwdriver/issues/460