### PR TITLE
feat: register artifact bookend to upload artifacts

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -43,10 +43,15 @@ const scm = new ScmPlugin(hoek.applyToDefaults({ ecosystem },
 
 authConfig.scm = scm;
 
+// Plugin to upload artifacts to store
+const ArtifactPlugin = require('screwdriver-artifact-bookend');
+const artifact = new ArtifactPlugin(ecosystem.store);
+
 // Plugins to run before/after a build
 const bookends = config.get('bookends');
-const bookend = new Bookend(
-    { scm },                    // default plugins defined by screwdriver
+const bookend = new Bookend({
+    scm,
+    'screwdriver-artifact-bookend': artifact },
     bookends.setup || [],      // plugins required for the setup- steps
     bookends.teardown || []    // plugins required for the teardown- steps
 );

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -140,6 +140,8 @@ bookends:
     # Plugins for build setup
     setup:
         - scm
+    teardown:
+        - screwdriver-artifact-bookend
 
 ecosystem:
     # Externally routable URL for the User Interface

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ndjson": "^1.4.3",
     "request": "^2.74.0",
     "requestretry": "^1.12.0",
+    "screwdriver-artifact-bookend": "1.0.0",
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-config-parser": "^3.1.0",
     "screwdriver-data-schema": "^16.0.1",


### PR DESCRIPTION
Registers artifact bookend, which uploads artifacts to S3
Blocked by: https://github.com/screwdriver-cd/artifact-bookend/pull/1
Related: https://github.com/screwdriver-cd/screwdriver/issues/458