### PR TITLE
fix: Whitelist jpae

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,6 +38,7 @@ auth:
         - dvdizon
         - jer
         - jerryzhang222
+        - jpae
         - minz1027
         - nicolaifsf
         - nkatzman


### PR DESCRIPTION
We would like jpae to get access to the screwdriver cluster so he can run through our demo (https://github.com/screwdriver-cd/fuji-demo)