### PR TITLE
fix(293): update current build before triggering next build

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -553,6 +553,7 @@ describe('build plugin test', () => {
                     return server.inject(options).then((reply) => {
                         assert.equal(reply.statusCode, 200);
                         assert.deepEqual(buildMock.meta, meta);
+                        assert.isTrue(buildMock.update.calledBefore(buildFactoryMock.create));
                         assert.calledWith(buildFactoryMock.create, {
                             jobId: publishJobId,
                             sha: testBuild.sha,


### PR DESCRIPTION
Move build.update() before triggering next build, otherwise the next build won't be able to get the `meta` from previous build when it starts.

Related to https://github.com/screwdriver-cd/screwdriver/issues/293
