### PR TITLE
fix(470): autobump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "screwdriver-datastore-sequelize": "^2.0.0",
     "screwdriver-executor-docker": "^2.0.0",
     "screwdriver-executor-k8s": "^10.0.0",
-    "screwdriver-models": "^21.3.0",
+    "screwdriver-models": "^21.5.0",
     "screwdriver-notifications-email": "^1.0.3",
     "screwdriver-scm-bitbucket": "^2.6.0",
     "screwdriver-scm-github": "^4.6.0",

--- a/test/plugins/data/templates.json
+++ b/test/plugins/data/templates.json
@@ -15,7 +15,7 @@
   "id": 7970,
   "name": "screwdriver/publish",
   "labels": ["test"],
-  "version": "1.0",
+  "version": "1.0.1",
   "description": "this is a template to publish",
   "maintainer": "foo@bar.com",
   "scmUri": "github.com:12345678:master",

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -61,7 +61,6 @@ describe('template plugin test', () => {
     beforeEach((done) => {
         templateFactoryMock = {
             create: sinon.stub(),
-            getTemplate: sinon.stub(),
             list: sinon.stub()
         };
         pipelineFactoryMock = {
@@ -151,13 +150,13 @@ describe('template plugin test', () => {
                 method: 'POST',
                 url: '/templates',
                 payload: {
-                    name: 'template',
-                    version: '1.7',
+                    name: 'mytemplate',
+                    version: '1',
                     maintainer: 'foo@bar.com',
                     description: 'test template',
                     config: {
                         steps: [{
-                            echo: 'echo bye'
+                            echo: 'echo hello'
                         }]
                     }
                 },
@@ -167,7 +166,6 @@ describe('template plugin test', () => {
             };
 
             templateMock = getTemplateMocks(testtemplate);
-            templateFactoryMock.getTemplate.resolves(null);
             templateFactoryMock.create.resolves(templateMock);
             templateFactoryMock.list.resolves([templateMock]);
 
@@ -177,7 +175,6 @@ describe('template plugin test', () => {
 
         it('returns 401 when scmUri does not match', () => {
             templateMock.scmUri = 'github.com:67890:branchName';
-            templateFactoryMock.getTemplate.resolves(templateMock);
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 401);
@@ -199,13 +196,13 @@ describe('template plugin test', () => {
                 assert.deepEqual(reply.result, testtemplate);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(templateFactoryMock.create, {
-                    name: 'template',
-                    version: '1.7.0',
+                    name: 'mytemplate',
+                    version: '1',
                     maintainer: 'foo@bar.com',
                     description: 'test template',
                     scmUri: 'github.com:12345:branchName',
                     labels: [],
-                    config: { steps: [{ echo: 'echo bye' }] }
+                    config: { steps: [{ echo: 'echo hello' }] }
                 });
                 assert.equal(reply.statusCode, 201);
             });
@@ -215,7 +212,6 @@ describe('template plugin test', () => {
             let expectedLocation;
 
             templateFactoryMock.list.resolves([templateMock]);
-            templateFactoryMock.getTemplate.resolves(null);
 
             options.payload.version = '1.8';
 
@@ -229,50 +225,13 @@ describe('template plugin test', () => {
                 assert.deepEqual(reply.result, testtemplate);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(templateFactoryMock.create, {
-                    name: 'template',
-                    version: '1.8.0',
+                    name: 'mytemplate',
+                    version: '1.8',
                     maintainer: 'foo@bar.com',
                     description: 'test template',
                     scmUri: 'github.com:12345:branchName',
                     labels: [],
-                    config: { steps: [{ echo: 'echo bye' }] }
-                });
-                assert.equal(reply.statusCode, 201);
-            });
-        });
-
-        it('auto-bump patch version', () => {
-            templateFactoryMock.list.resolves([templateMock]);
-            templateFactoryMock.getTemplate.resolves(templateMock);
-
-            return server.inject(options).then((reply) => {
-                assert.calledWith(templateFactoryMock.create, {
-                    name: 'template',
-                    version: '1.7.4',
-                    maintainer: 'foo@bar.com',
-                    description: 'test template',
-                    scmUri: 'github.com:12345:branchName',
-                    labels: [],
-                    config: { steps: [{ echo: 'echo bye' }] }
-                });
-                assert.equal(reply.statusCode, 201);
-            });
-        });
-
-        it('auto-bump patch version when only major version is passed in', () => {
-            options.payload.version = '1';
-            templateFactoryMock.list.resolves([templateMock]);
-            templateFactoryMock.getTemplate.resolves(templateMock);
-
-            return server.inject(options).then((reply) => {
-                assert.calledWith(templateFactoryMock.create, {
-                    name: 'template',
-                    version: '1.7.4',
-                    maintainer: 'foo@bar.com',
-                    description: 'test template',
-                    scmUri: 'github.com:12345:branchName',
-                    labels: [],
-                    config: { steps: [{ echo: 'echo bye' }] }
+                    config: { steps: [{ echo: 'echo hello' }] }
                 });
                 assert.equal(reply.statusCode, 201);
             });

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -140,7 +140,7 @@ describe('template plugin test', () => {
         });
     });
 
-    describe('PUT /templates', () => {
+    describe('POST /templates', () => {
         let options;
         let templateMock;
         let pipelineMock;
@@ -148,10 +148,10 @@ describe('template plugin test', () => {
 
         beforeEach(() => {
             options = {
-                method: 'PUT',
-                url: '/templates/mytemplate/1.7',
+                method: 'POST',
+                url: '/templates',
                 payload: {
-                    name: 'mytemplate',
+                    name: 'template',
                     version: '1.7',
                     maintainer: 'foo@bar.com',
                     description: 'test template',
@@ -199,7 +199,7 @@ describe('template plugin test', () => {
                 assert.deepEqual(reply.result, testtemplate);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(templateFactoryMock.create, {
-                    name: 'mytemplate',
+                    name: 'template',
                     version: '1.7',
                     maintainer: 'foo@bar.com',
                     description: 'test template',
@@ -216,11 +216,10 @@ describe('template plugin test', () => {
 
             templateFactoryMock.list.resolves([templateMock]);
             templateFactoryMock.get.withArgs({
-                name: 'mytemplate',
+                name: 'template',
                 version: '1.8'
             }).resolves(null);
 
-            options.url = '/templates/mytemplate/1.8';
             options.payload.version = '1.8';
 
             return server.inject(options).then((reply) => {
@@ -233,7 +232,7 @@ describe('template plugin test', () => {
                 assert.deepEqual(reply.result, testtemplate);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(templateFactoryMock.create, {
-                    name: 'mytemplate',
+                    name: 'template',
                     version: '1.8',
                     maintainer: 'foo@bar.com',
                     description: 'test template',


### PR DESCRIPTION
Auto bump version:
For example, if latest version is 1.7.3

If template.yaml says 1, it will create 1.7.4
If template.yaml says 1.7, it will create 1.7.4
If template.yaml says 1.7.3, it will create 1.7.4 (does not matter what the patch is)
If template.yaml says 1.8, it will create 1.8.0
If template.yaml says 2, it will create 2.0.0

Blocked by https://github.com/screwdriver-cd/models/pull/151
https://github.com/screwdriver-cd/models/pull/152
Related: https://github.com/screwdriver-cd/screwdriver/issues/470
