### PR TITLE
fix(470): Pass templateFactory to parser

### DIFF
--- a/plugins/validator.js
+++ b/plugins/validator.js
@@ -20,8 +20,9 @@ exports.register = (server, options, next) => {
             description: 'Validate a given screwdriver.yaml',
             notes: 'Returns the parsed config or validation errors',
             tags: ['api', 'validation', 'yaml'],
-            handler: (request, reply) => parser(request.payload.yaml)
-                    .then(pipeline => reply(pipeline)),
+            handler: (request, reply) =>
+                parser(request.payload.yaml, request.server.app.templateFactory)
+                .then(pipeline => reply(pipeline)),
             validate: {
                 payload: validatorSchema.input
             },


### PR DESCRIPTION
TemplateFactory should be passed to `config-parser`

https://github.com/screwdriver-cd/config-parser/blob/master/index.js#L26