### PR TITLE
fix: ignore metadata feature test

### DIFF
--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -1,8 +1,8 @@
-@metadata
+@ignore
 Feature: Metadata
 
     Users want to pass structured data between their builds.
-    The most common way is to use the value of the current Git tag. But that data 
+    The most common way is to use the value of the current Git tag. But that data
     cannot be guaranteed to be correct.
 
     Given this simple pipeline:
@@ -20,7 +20,7 @@ Feature: Metadata
     build container.
     - Metadata should be passed from one job to the next in succession (in the same
     event).
-    - When combining the results of matrix builds, they should be merge/replaced in 
+    - When combining the results of matrix builds, they should be merge/replaced in
     a random order (to ensure users don't depend on a side-effect).
     - When the event is done, a record of the metadata should be stored there as well.
     - Metadata can contain strings, numbers, boolean, objects, and arrays. The interface
@@ -61,7 +61,7 @@ Feature: Metadata
             | true         | false        |
             | ["arrg"]     | ["ARRG"]     |
             | { "x": "y" } | { "w": "z" } |
-    
+
     @ignore
     Scenario: Combining the results of matrix builds
         Given an existing pipeline with the workflow:


### PR DESCRIPTION
This is [blocking](https://cd.screwdriver.cd/pipelines/1/build/2505) the pipeline, It is failing with 
```
@metadata
Scenario: Adding some data to metadata
/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/cucumber/lib/cucumber/support_code/step_definition.js:63
var timeoutInMilliseconds = options.timeout || defaultTimeout;
TypeError: Cannot read property 'timeout' of undefined
```

I ran locally and found out when it matches the `an existing pipeline with the workflow:` on [this](https://github.com/screwdriver-cd/screwdriver/blob/master/features/step_definitions/events.js#L21-L22) line, the options `{timeout: TIMEOUT}` is not passed in. 

One possibility is that we are using `Scenario Outline` here, and event is using `Scenario`. However, I tried to simplify this test to a single case and use `Scenario`, but it's still not working. 

I don't know what is the problem here. Ignoring this test until we figure out. 