### PR TITLE
feat(453): support Gitlab

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -114,7 +114,18 @@ scm:
         # The username and email used for checkout with bitbucket
         username: SCM_USERNAME
         email: SCM_EMAIL
-
+    gitlab:
+        # The client id used for OAuth with gitlab. Look up Gitlab OAuth for details
+        # https://docs.gitlab.com/ee/integration/oauth_provider.html
+        oauthClientId: SECRET_OAUTH_CLIENT_ID
+        # The client secret used for OAuth with bitbucket
+        oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
+        # The username and email used for checkout with gitlab
+        username: SCM_USERNAME
+        email: SCM_EMAIL
+        # if you have on-premise gitlab, you can specify that here
+        gitlabHost: SCM_GITLAB_HOST
+        gitlabProtocol: SCM_GITLAB_PROTOCOL
 webhooks:
     # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
     username: SCM_USERNAME

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -116,7 +116,7 @@ scm:
         # The client secret used for OAuth with github
         oauthClientSecret: AGAIN-SOMETHING-HERE-IS-USEFUL
         # You can also configure for use with GitHub enterprise
-        #gheHost: github.screwdriver.cd
+        # gheHost: github.screwdriver.cd
         # The username and email used for checkout with github
         username: sd-buildbot
         email: dev-null@screwdriver.cd
@@ -130,9 +130,17 @@ scm:
         oauthClientId: YOUR-BITBUCKET-OAUTH-CLIENT-ID
         oauthClientSecret: YOUR-BITBUCKET-OAUTH-CLIENT-SECRET
         # The username and email used for checkout with bitbucket
-        #username: sd-buildbot
-        #email: dev-null@screwdriver.cd
-
+        # username: sd-buildbot
+        # email: dev-null@screwdriver.cd
+    gitlab:
+        oauthClientId: YOUR-GITLAB-OAUTH-CLIENT-ID
+        oauthClientSecret: YOUR-GITLAB-OAUTH-CLIENT-SECRET
+        # If you have on-premise gitlab, you can specify that here
+        # gitlabHost: mygitlab.com
+        # gitlabProtocol: https
+        # The username and email used for checkout with gitlab
+        # username: sd-buildbot
+        # email: dev-null@screwdriver.cd
 webhooks:
     # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
     username: sd-buildbot

--- a/in-a-box.py
+++ b/in-a-box.py
@@ -142,9 +142,9 @@ def generate_jwt():
 
 # Ask to select a SCM provider
 def select_scm_provider():
-    scm_plugins = ['github', 'bitbucket']
+    scm_plugins = ['github', 'gitlab', 'bitbucket']
     while True:
-        prompt = get_input('📤   Which SCM provider would you like to use? (github/bitbucket) ')
+        prompt = get_input('📤   Which SCM provider would you like to use? (github/gitlab/bitbucket) ')
         scm_plugin = prompt.lower()
         if scm_plugin in scm_plugins:
             break
@@ -155,7 +155,7 @@ def select_scm_provider():
 
 def generate_oauth(scm_plugin, ip):
     """
-    Generate OAuth credentials from GitHub.com
+    Generate OAuth credentials from SCM
 
     Parameters
     ----------
@@ -167,7 +167,7 @@ def generate_oauth(scm_plugin, ip):
     if scm_plugin == 'github':
         service_name = 'GitHub.com'
         start_url = 'https://github.com/settings/applications/new'
-        homepage_url = 'Homepage URL'
+        homepage_url_msg = "For 'Homepage URL' put http://" + ip + ':9000'
         callback_url = 'Authorization callback URL'
         additional_process = ''
         client_id_name = 'Client ID'
@@ -175,16 +175,24 @@ def generate_oauth(scm_plugin, ip):
     elif scm_plugin == 'bitbucket':
         service_name = 'Bitbucket.org'
         start_url = 'https://bitbucket.org/account/user/<your username>/oauth-consumers/new'
-        homepage_url = 'URL'
+        homepage_url_msg =  "For 'URL' put http://" + ip + ':9000'
         callback_url = 'Callback URL'
         additional_process = "for 'Permissions' enable Read checkbox for Repositories, Account and Pull requests"
         client_id_name = 'Key'
+        client_secret_name = 'Secret'
+    elif scm_plugin == 'gitlab':
+        service_name = 'Gitlab.com'
+        start_url = 'https://gitlab.com/profile/applications'
+        homepage_url_msg = ''
+        callback_url = 'Redirect URL'
+        additional_process = ''
+        client_id_name = 'Application Id'
         client_secret_name = 'Secret'
 
     print('''
     Please create a new OAuth application on {service_name}
     Go to {start_url} to start the process
-    For '{homepage_url}' put http://{ip}:9000
+    {homepage_url_msg}
     For '{callback_url}' put http://{ip}:9001/v4/auth/login
     {additional_process}
     When done, please provide the following values:
@@ -192,7 +200,7 @@ def generate_oauth(scm_plugin, ip):
         ip = ip,
         start_url = start_url,
         service_name = service_name,
-        homepage_url = homepage_url,
+        homepage_url_msg = homepage_url_msg,
         callback_url = callback_url,
         additional_process = additional_process
     ))
@@ -264,7 +272,7 @@ def main():
     A few more things to note:
       - To stop/reset Screwdriver
         $ docker-compose -p screwdriver down
-      - If your internal IP changes, update the docker-compose.yml and your GitHub OAuth application
+      - If your internal IP changes, update the docker-compose.yml and your SCM OAuth application
       - In-a-box does not support Webhooks including PullRequests for triggering builds
       - For help with this and more, find us on Slack at https://slack.screwdriver.cd
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "screwdriver-notifications-email": "^1.0.3",
     "screwdriver-scm-bitbucket": "^2.6.0",
     "screwdriver-scm-github": "^4.6.0",
+    "screwdriver-scm-gitlab": "^0.1.0",
     "screwdriver-template-validator": "^3.0.0",
     "tinytim": "^0.1.1",
     "verror": "^1.6.1",


### PR DESCRIPTION
This PR allows users to use Gitlab as SCM. It also allows `in-a-box` script to take Gitlab as an option. 

This is blocked until @bdangit's  `scm-gitlab` is published: https://github.com/bdangit/scm-gitlab