### PR TITLE
fix(470): Add get endpoint for templates

### DIFF
--- a/plugins/templates/get.js
+++ b/plugins/templates/get.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const getSchema = schema.models.template.get;
+const baseSchema = schema.models.template.base;
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/templates/{name}/{version}',
+    config: {
+        description: 'Get a single template',
+        notes: 'Returns a template record',
+        tags: ['api', 'templates'],
+        handler: (request, reply) => {
+            const factory = request.server.app.templateFactory;
+
+            return factory.getTemplate({
+                name: request.params.name,
+                version: request.params.version
+            }).then((template) => {
+                if (!template) {
+                    throw boom.notFound('Template does not exist');
+                }
+
+                return reply(template);
+            })
+            .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: getSchema
+        },
+        validate: {
+            params: {
+                name: joi.reach(baseSchema, 'name'),
+                version: joi.reach(baseSchema, 'version')
+            }
+        }
+    }
+});

--- a/plugins/templates/index.js
+++ b/plugins/templates/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const createRoute = require('./create');
+const getRoute = require('./get');
 const listRoute = require('./list');
 
 /**
@@ -13,6 +14,7 @@ const listRoute = require('./list');
 exports.register = (server, options, next) => {
     server.route([
         createRoute(),
+        getRoute(),
         listRoute()
     ]);
 


### PR DESCRIPTION
Adding `GET templates/name/version` endpoint

`version` can be:
- exact version (`1.2.3`)
- OR major minor (`1.2`) or major (`1`): in these cases, it will get the latest. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/470