### PR TITLE
feat: Fix not to capture unused string

### DIFF
--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -33,13 +33,12 @@ module.exports = function server() {
             throw new Error('jobName is neither BAR or BAZ');
         }
 
-        request({
+        return request({
             uri: `${this.instance}/${this.namespace}/jobs/${jobId}/builds`,
             method: 'GET',
             json: true
         }).then((response) => {
             this.buildId = response.body[0].id;
-            this.meta = response.body.meta;
 
             Assert.equal(response.statusCode, 200);
         });
@@ -49,15 +48,9 @@ module.exports = function server() {
 
     this.Then(/^add the { "bar": (?:.*) } to metadata in the "BAR" build container$/, () => null);
 
-    this.Then(/^in the build, the { "foo": "(.*)" } is available from metadata$/, (value) => {
-        Assert.ok('foo', this.meta);
-        Assert.equal(value, this.meta.foo);
-    });
+    this.Then(/^in the build, the { "foo": "(?:.*)" } is available from metadata$/, () => null);
 
-    this.Then(/^in the build, the { "bar": "(.*)" } is available from metadata$/, (value) => {
-        Assert.ok('bar', this.meta);
-        Assert.equal(value, this.meta.bar);
-    });
+    this.Then(/^in the build, the { "bar": "(?:.*)" } is available from metadata$/, () => null);
 
     this.Then(/^the build succeeded$/, { timeout: TIMEOUT }, () =>
         this.waitForBuild(this.buildId).then((resp) => {
@@ -73,6 +66,7 @@ module.exports = function server() {
             json: true
         }).then((response) => {
             this.buildId = response.body[0].id;
+            this.meta = response.body[0].meta;
 
             return this.waitForBuild(this.buildId).then((resp) => {
                 Assert.equal(resp.statusCode, 200);

--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -44,13 +44,12 @@ module.exports = function server() {
         });
     });
 
-    this.Then(/^add the { "foo": (?:.*) } to metadata in the "main" build container$/, () => null);
+    this.Then(/^add the { "(.*)": "(.*)" } to metadata/, (key, value) => {
+        this.expectedMeta = this.expectedMeta || {};
+        this.expectedMeta[key] = value;
+    });
 
-    this.Then(/^add the { "bar": (?:.*) } to metadata in the "BAR" build container$/, () => null);
-
-    this.Then(/^in the build, the { "foo": "(?:.*)" } is available from metadata$/, () => null);
-
-    this.Then(/^in the build, the { "bar": "(?:.*)" } is available from metadata$/, () => null);
+    this.Then(/^in the build, the { "(?:.*)": "(?:.*)" } is available from metadata$/, () => null);
 
     this.Then(/^the build succeeded$/, { timeout: TIMEOUT }, () =>
         this.waitForBuild(this.buildId).then((resp) => {
@@ -75,9 +74,9 @@ module.exports = function server() {
     );
 
     this.Then(/^a record of the metadata is stored$/, { timeout: TIMEOUT }, () => {
-        Assert.ok('foo', this.meta);
-        Assert.ok('bar', this.meta);
-        Assert.equal('foobar', this.meta.foo);
-        Assert.equal('barbaz', this.meta.bar);
+        Object.keys(this.expectedMeta).forEach((key) => {
+            Assert.ok(key, this.meta);
+            Assert.equal(this.meta[key], this.expectedMeta[key]);
+        });
     });
 };

--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -75,7 +75,6 @@ module.exports = function server() {
 
     this.Then(/^a record of the metadata is stored$/, { timeout: TIMEOUT }, () => {
         Object.keys(this.expectedMeta).forEach((key) => {
-            Assert.ok(key, this.meta);
             Assert.equal(this.meta[key], this.expectedMeta[key]);
         });
     });

--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -45,9 +45,9 @@ module.exports = function server() {
         });
     });
 
-    this.Then(/^add the { "foo": (.*) } to metadata in the "main" build container$/, () => null);
+    this.Then(/^add the { "foo": (?:.*) } to metadata in the "main" build container$/, () => null);
 
-    this.Then(/^add the { "bar": (.*) } to metadata in the "BAR" build container$/, () => null);
+    this.Then(/^add the { "bar": (?:.*) } to metadata in the "BAR" build container$/, () => null);
 
     this.Then(/^in the build, the { "foo": "(.*)" } is available from metadata$/, (value) => {
         Assert.ok('foo', this.meta);

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -98,7 +98,6 @@ module.exports = function server() {
             }).then((resp) => {
                 this.buildId = resp.body.id;
                 this.eventId = resp.body.eventId;
-                this.meta = resp.body.meta;
 
                 Assert.equal(resp.statusCode, 201);
             })


### PR DESCRIPTION
I found that it need to give arguments when capturing with regular expressions.
https://cd.screwdriver.cd/pipelines/1/build/2781
![2017-03-23 11 44 14](https://cloud.githubusercontent.com/assets/24538326/24229660/1865c43e-0fbe-11e7-891e-56470772fc58.png)

So, I modified to not capture. By modifying this way, it seems that there is no problem without specifying arguments.
