### PR TITLE
fix: datastore scan requires params key

### DIFF
--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -1,4 +1,4 @@
-@metadata
+@ignore
 Feature: Metadata
 
     Users want to pass structured data between their builds.

--- a/plugins/templates/create.js
+++ b/plugins/templates/create.js
@@ -30,7 +30,7 @@ module.exports = () => ({
 
             return Promise.all([
                 pipelineFactory.get(pipelineId),
-                templateFactory.list({ name })
+                templateFactory.list({ params: { name } })
             ]).then(([pipeline, templates]) => {
                 const templateConfig = hoek.applyToDefaults(request.payload, {
                     scmUri: pipeline.scmUri,

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -236,6 +236,11 @@ describe('template plugin test', () => {
                 };
                 assert.deepEqual(reply.result, testtemplate);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledWith(templateFactoryMock.list, {
+                    params: {
+                        name: 'mytemplate'
+                    }
+                });
                 assert.calledWith(templateFactoryMock.create, {
                     name: 'mytemplate',
                     version: '1',
@@ -265,6 +270,11 @@ describe('template plugin test', () => {
                 };
                 assert.deepEqual(reply.result, testtemplate);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledWith(templateFactoryMock.list, {
+                    params: {
+                        name: 'mytemplate'
+                    }
+                });
                 assert.calledWith(templateFactoryMock.create, {
                     name: 'mytemplate',
                     version: '1.8',


### PR DESCRIPTION
It looks through `config.params` in datastore scan:
https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L319-L320