### PR TITLE
feat(321): Support restarting in-a-box service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ database.*
 config/local.*
 .func_config.json
 .nyc_output
+data/*

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ info: Server running at http://localhost:8080
 ### In-A-Box
 
 This handy feature will bring up an entire Screwdriver instance (ui, api, and log store) locally for you to play with.
+All data written to a database will be stored in `data` directory.
 
 Requires:
  - Mac OSX 10.10+

--- a/in-a-box.py
+++ b/in-a-box.py
@@ -26,6 +26,7 @@ services:
             - 9001:80
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock:rw
+            - ./data/:/tmp/sd-data/:rw
         environment:
             PORT: 80
             URI: http://${ip}:9001
@@ -34,6 +35,7 @@ services:
             SCM_PLUGIN: ${scm_plugin}
             DATASTORE_PLUGIN: sequelize
             DATASTORE_SEQUELIZE_DIALECT: sqlite
+            DATASTORE_SEQUELIZE_STORAGE: /tmp/sd-data/storage.db
             EXECUTOR_PLUGIN: docker
             SECRET_WHITELIST: "[]"
             EXECUTOR_DOCKER_DOCKER: |


### PR DESCRIPTION
I added a feature to support restarting in-a-box described in #321.
I confirmed that the database file is created when the first run and data still remains after restart.