### PR TITLE
feat: Add endpoint to get versions for a template name

### DIFF
--- a/plugins/templates/index.js
+++ b/plugins/templates/index.js
@@ -3,6 +3,7 @@
 const createRoute = require('./create');
 const getRoute = require('./get');
 const listRoute = require('./list');
+const listVersionsRoute = require('./listVersions');
 
 /**
  * Template API Plugin
@@ -15,7 +16,8 @@ exports.register = (server, options, next) => {
     server.route([
         createRoute(),
         getRoute(),
-        listRoute()
+        listRoute(),
+        listVersionsRoute()
     ]);
 
     next();

--- a/plugins/templates/listVersions.js
+++ b/plugins/templates/listVersions.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const listSchema = joi.array().items(schema.models.template.get).label('List of templates');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/templates/{name}',
+    config: {
+        description: 'Get all template versions for a given template name with pagination',
+        notes: 'Returns all template records for a given template name',
+        tags: ['api', 'templates', 'versions'],
+        handler: (request, reply) => {
+            const factory = request.server.app.templateFactory;
+
+            return factory.list({
+                params: { name: request.params.name },
+                paginate: {
+                    page: request.query.page,
+                    count: request.query.count
+                },
+                sort: request.query.sort
+            }).then((templates) => {
+                if (templates.length === 0) {
+                    throw boom.notFound('Template does not exist');
+                }
+
+                reply(templates.map(p => p.toJson()));
+            })
+            .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: listSchema
+        },
+        validate: {
+            query: schema.api.pagination
+        }
+    }
+});

--- a/test/plugins/data/templateVersions.json
+++ b/test/plugins/data/templateVersions.json
@@ -1,0 +1,40 @@
+[{
+  "id": 7969,
+  "name": "screwdriver/build",
+  "labels": ["stable"],
+  "version": "0.0.1",
+  "description": "this is a template to test",
+  "maintainer": "foo@bar.com",
+  "scmUri": "github.com:12345678:master",
+  "config": {
+      "steps": [{
+          "echo": "echo hello"
+      }]
+  }
+},{
+  "id": 7970,
+  "name": "screwdriver/build",
+  "labels": ["stable"],
+  "version": "1.0.2",
+  "description": "this is a template to test",
+  "maintainer": "foo@bar.com",
+  "scmUri": "github.com:12345678:master",
+  "config": {
+      "steps": [{
+          "echo": "echo hello"
+      }]
+  }
+}, {
+  "id": 7971,
+  "name": "screwdriver/build",
+  "labels": ["stable"],
+  "version": "3.2.1",
+  "description": "this is a template to test",
+  "maintainer": "foo@bar.com",
+  "scmUri": "github.com:12345678:master",
+  "config": {
+      "steps": [{
+          "echo": "echo hello"
+      }]
+  }
+}]

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -8,6 +8,7 @@ const urlLib = require('url');
 const hoek = require('hoek');
 const testtemplate = require('./data/template.json');
 const testtemplates = require('./data/templates.json');
+const testtemplateversions = require('./data/templateVersions.json');
 const testpipeline = require('./data/pipeline.json');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -176,6 +177,42 @@ describe('template plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /templates/name', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: '/templates/screwdriver%2Fbuild'
+            };
+        });
+
+        it('returns 200 and all template versions for a template name', () => {
+            templateFactoryMock.list.resolves(getTemplateMocks(testtemplateversions));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testtemplateversions);
+                assert.calledWith(templateFactoryMock.list, {
+                    params: { name: 'screwdriver/build' },
+                    paginate: {
+                        page: 1,
+                        count: 50
+                    },
+                    sort: 'descending'
+                });
+            });
+        });
+
+        it('returns 404 when template does not exist', () => {
+            templateFactoryMock.list.resolves([]);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
             });
         });
     });


### PR DESCRIPTION
Add a `GET /templates/name` endpoint to the templates plugin in the API. This returns all the template versions for a given template name.

For example, for `{API_ROOT}/v4/templates/node%2Ftest`, it will return an array of all versions in the datastore:

```
[{
    "id": 9,
    "labels": ["stable"],
    "config": {
        "image": "node:6",
        "steps": [{
            "install": "npm install"
        }, {
            "test": "npm test"
        }]
    },
    "name": "node/test",
    "version": "1.0.6",
    "description": "this is a template for nodejs",
    "maintainer": "daolam112@gmail.com",
    "scmUri": "github.com:82863190:master"
}, {
    "id": 8,
    "labels": ["stable"],
    "config": {
        "steps": [{
            "install": "npm install"
        }, {
            "test": "npm test"
        }]
    },
    "name": "node/test",
    "version": "1.0.5",
    "description": "this is a template for nodejs",
    "maintainer": "daolam112@gmail.com",
    "scmUri": "github.com:82863190:master"
}]
```