### PR TITLE
fix: update build link for notifications

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -76,7 +76,8 @@ module.exports = () => ({
                                 pipelineName: pipeline.scmRepo.name,
                                 jobName: job.name,
                                 buildId: build.id,
-                                buildLink: `${buildFactory.uiUri}/builds/${id}`
+                                buildLink:
+                                    `${buildFactory.uiUri}/pipelines/${pipeline.id}/builds/${id}`
                             });
 
                             // Guard against triggering non-successful builds

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -248,7 +248,7 @@ describe('build plugin test', () => {
             return server.inject(options).then((reply) => {
                 assert.calledWith(server.emit, 'build_status', {
                     buildId: 12345,
-                    buildLink: 'http://foo.bar/builds/12345',
+                    buildLink: 'http://foo.bar/pipelines/123/builds/12345',
                     jobName: 'main',
                     pipelineName: 'screwdriver-cd/screwdriver',
                     settings: {


### PR DESCRIPTION
It's faster to load from `/pipelines/{pipelineId}/builds/{buildId}`
We are trying to deprecate the other endpoint. 