### PR TITLE
fix: template ties to pipelineId instead of scmUri

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "screwdriver-artifact-bookend": "^1.0.1",
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-config-parser": "^3.3.0",
-    "screwdriver-data-schema": "^16.3.0",
+    "screwdriver-data-schema": "^16.5.2",
     "screwdriver-datastore-sequelize": "^2.0.0",
     "screwdriver-executor-docker": "^2.0.0",
     "screwdriver-executor-k8s": "^10.0.0",

--- a/plugins/templates/create.js
+++ b/plugins/templates/create.js
@@ -33,7 +33,7 @@ module.exports = () => ({
                 templateFactory.list({ params: { name } })
             ]).then(([pipeline, templates]) => {
                 const templateConfig = hoek.applyToDefaults(request.payload, {
-                    scmUri: pipeline.scmUri,
+                    pipelineId: pipeline.id,
                     labels
                 });
 
@@ -42,9 +42,9 @@ module.exports = () => ({
                     return templateFactory.create(templateConfig);
                 }
 
-                // If template name exists, but this build's scmUri is not the same as template's scmUri
+                // If template name exists, but this build's pipelineId is not the same as template's pipelineId
                 // Then this build does not have permission to publish
-                if (pipeline.scmUri !== templates[0].scmUri) {
+                if (pipeline.id !== templates[0].pipelineId) {
                     throw boom.unauthorized('Not allowed to publish this template');
                 }
 

--- a/test/plugins/data/template.json
+++ b/test/plugins/data/template.json
@@ -5,7 +5,7 @@
   "version": "1.7.3",
   "description": "this is a template",
   "maintainer": "foo@bar.com",
-  "scmUri": "github.com:12345:branchName",
+  "pipelineId": 123,
   "config": {
       "steps": [{
           "echo": "echo hello"

--- a/test/plugins/data/templateVersions.json
+++ b/test/plugins/data/templateVersions.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "description": "this is a template to test",
   "maintainer": "foo@bar.com",
-  "scmUri": "github.com:12345678:master",
+  "pipelineId": 8765,
   "config": {
       "steps": [{
           "echo": "echo hello"
@@ -18,7 +18,7 @@
   "version": "1.0.2",
   "description": "this is a template to test",
   "maintainer": "foo@bar.com",
-  "scmUri": "github.com:12345678:master",
+  "pipelineId": 8765,
   "config": {
       "steps": [{
           "echo": "echo hello"
@@ -31,7 +31,7 @@
   "version": "3.2.1",
   "description": "this is a template to test",
   "maintainer": "foo@bar.com",
-  "scmUri": "github.com:12345678:master",
+  "pipelineId": 8765,
   "config": {
       "steps": [{
           "echo": "echo hello"

--- a/test/plugins/data/templates.json
+++ b/test/plugins/data/templates.json
@@ -5,7 +5,7 @@
   "version": "1.7.3",
   "description": "this is a template to test",
   "maintainer": "foo@bar.com",
-  "scmUri": "github.com:12345678:master",
+  "pipelineId": 123,
   "config": {
       "steps": [{
           "echo": "echo hello"
@@ -18,7 +18,7 @@
   "version": "1.0.1",
   "description": "this is a template to publish",
   "maintainer": "foo@bar.com",
-  "scmUri": "github.com:12345678:master",
+  "pipelineId": 124,
   "config": {
       "steps": [{
           "echo": "echo goodbye"

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -251,8 +251,8 @@ describe('template plugin test', () => {
             pipelineFactoryMock.get.resolves(pipelineMock);
         });
 
-        it('returns 401 when scmUri does not match', () => {
-            templateMock.scmUri = 'github.com:67890:branchName';
+        it('returns 401 when pipelineId does not match', () => {
+            templateMock.pipelineId = 8888;
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 401);
@@ -283,7 +283,7 @@ describe('template plugin test', () => {
                     version: '1',
                     maintainer: 'foo@bar.com',
                     description: 'test template',
-                    scmUri: 'github.com:12345:branchName',
+                    pipelineId: 123,
                     labels: [],
                     config: { steps: [{ echo: 'echo hello' }] }
                 });
@@ -317,7 +317,7 @@ describe('template plugin test', () => {
                     version: '1.8',
                     maintainer: 'foo@bar.com',
                     description: 'test template',
-                    scmUri: 'github.com:12345:branchName',
+                    pipelineId: 123,
                     labels: [],
                     config: { steps: [{ echo: 'echo hello' }] }
                 });


### PR DESCRIPTION
We should tie template to `pipelineId` instead of pipeline's `scmUri` since `pipelineId` is the identifier. 

Related: https://github.com/screwdriver-cd/data-schema/pull/116