### PR TITLE
feat: Modify functional test for running locally

### DIFF
--- a/.func_config.json
+++ b/.func_config.json
@@ -2,5 +2,6 @@
     "username": "YOUR-GITHUB-USERNAME",
     "gitToken": "YOUR-ACCESS-TOKEN",
     "accessKey": "YOUR-ACCESS-KEY",
-    "host": "YOUR-LOCAL-API-HOST"
+    "host": "YOUR-LOCAL-API-HOST",
+    "testOrg": "YOUR-TEST-ORGANIZATION"
 }

--- a/README.md
+++ b/README.md
@@ -107,13 +107,16 @@ npm test
 
 ### Functional tests
 
-Update `.func_config.json` with your own username, github token, access key, and host:
+Fork `functional-*` repositories to your organization from [screwdriver-cd-test](https://github.com/screwdriver-cd-test)
+
+Update `.func_config.json` with your own username, github token, access key, host, and organization for test:
 ```json
 {
     "username": "YOUR-GITHUB-USERNAME",
     "gitToken": "YOUR-ACCESS-TOKEN",
     "accessKey": "YOUR-ACCESS-KEY",
-    "host": "YOUR-LOCAL-API-HOST"
+    "host": "YOUR-LOCAL-API-HOST",
+    "testOrg": "YOUR-TEST-ORGANIZATION"
 }
 ```
 

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -10,7 +10,7 @@ module.exports = function server() {
     this.Before({
         tags: ['@auth']
     }, () => {
-        this.repoOrg = 'screwdriver-cd-test';
+        this.repoOrg = this.testOrg;
         this.repoName = 'functional-auth';
         this.pipelineId = null;
     });
@@ -34,7 +34,7 @@ module.exports = function server() {
 
             switch (user) {
             case 'calvin':
-                Assert.strictEqual(decodedToken.username, 'sd-buildbot');
+                Assert.strictEqual(decodedToken.username, this.username);
                 break;
             default:
                 return Promise.resolve('pending');
@@ -44,7 +44,7 @@ module.exports = function server() {
         });
     });
 
-    this.Then(/^they can see the project$/, () =>
+    this.Then(/^they can see the project$/, { timeout: TIMEOUT }, () =>
         request({                           // make sure pipeline exists (TODO: move to Given an existing pipeline with that repository scenario)
             uri: `${this.instance}/${this.namespace}/pipelines`,
             method: 'POST',

--- a/features/step_definitions/events.js
+++ b/features/step_definitions/events.js
@@ -9,7 +9,7 @@ module.exports = function server() {
     this.Before({
         tags: ['@events']
     }, () => {
-        this.repoOrg = 'screwdriver-cd-test';
+        this.repoOrg = this.testOrg;
         this.repoName = 'functional-events';
 
         // Reset shared information

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -13,7 +13,7 @@ module.exports = function server() {
         timeout: TIMEOUT
     }, () => {
         this.branch = 'darrenBranch';
-        this.repoOrg = 'screwdriver-cd-test';
+        this.repoOrg = this.testOrg;
         this.repoName = 'functional-git';
 
         // Reset shared information

--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -9,7 +9,7 @@ module.exports = function server() {
     this.Before({
         tags: ['@metadata']
     }, () => {
-        this.repoOrg = 'screwdriver-cd-test';
+        this.repoOrg = this.testOrg;
         this.repoName = 'functional-metadata';
         this.pipelineId = null;
         this.eventId = null;

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -9,7 +9,7 @@ module.exports = function server() {
     this.Before({
         tags: ['@secrets']
     }, () => {
-        this.repoOrg = 'screwdriver-cd-test';
+        this.repoOrg = this.testOrg;
         this.repoName = 'functional-secrets';
         this.pipelineId = null;
         this.secretId = null;

--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -40,6 +40,8 @@ function beforeHooks() {
         this.gitToken = process.env.GIT_TOKEN || config.gitToken;
         this.accessKey = process.env.ACCESS_KEY || config.accessKey;
         this.instance = host ? `https://${host}` : config.host;
+        this.testOrg = process.env.TEST_ORG || config.testOrg;
+        this.username = process.env.TEST_USERNAME || config.username;
         this.namespace = 'v4';
         this.promiseToWait = time => promiseToWait(time);
         this.getJwt = accessKey =>

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -51,6 +51,8 @@ jobs:
             SD_API: beta.api.screwdriver.cd
             K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
             K8S_ENV_VALUE: beta_rc2_
+            TEST_USERNAME: sd-buildbot
+            TEST_ORG: screwdriver-cd-test
         secrets:
             # Access key for functional tests
             - ACCESS_KEY
@@ -77,6 +79,8 @@ jobs:
             SD_API: api.screwdriver.cd
             K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
             K8S_ENV_VALUE: rc2_
+            TEST_USERNAME: sd-buildbot
+            TEST_ORG: screwdriver-cd-test
         secrets:
             # Access key for functional tests
             - ACCESS_KEY


### PR DESCRIPTION
In order to running locally functional test, I needed to fix some.

1. First of all we have to login local SD with `sd-buildbot` account to run functional test. But I can't login local SD with `sd-buildbot` account because I'm not owner of `sd-buildbot`. So, I need to use my own account to run functional test.
2. My own account can't access [screwdriver-cd-test Org](https://github.com/screwdriver-cd-test) with administrator privileges. So, I needed to fork `functional-*` repositories from [screwdriver-cd-test Org](https://github.com/screwdriver-cd-test) and use it.