### PR TITLE
fix: POST/templates takes in yaml string instead of config

### DIFF
--- a/test/plugins/data/template-create.input.json
+++ b/test/plugins/data/template-create.input.json
@@ -1,0 +1,1 @@
+{"yaml":"{\"name\":\"template_namespace/nodejs_main\",\"version\":\"1.2\",\"description\":\"Template for building a NodeJS module\\nInstalls dependencies and runs tests\\n\",\"maintainer\":\"me@nowhere.com\",\"config\":{\"image\":\"node:6\",\"steps\":[{\"install\":\"npm install\"},{\"test\":\"npm test\"}],\"environment\":{\"KEYNAME\":\"value\"},\"secrets\":[\"NPM_TOKEN\"]}}"}

--- a/test/plugins/data/template.json
+++ b/test/plugins/data/template.json
@@ -1,8 +1,8 @@
 {
   "id": 7969,
-  "name": "screwdriver/build",
+  "name": "template_namespace/nodejs_main",
   "labels": ["stable"],
-  "version": "1.7.3",
+  "version": "1.0.0",
   "description": "this is a template",
   "maintainer": "foo@bar.com",
   "pipelineId": 123,


### PR DESCRIPTION
`POST /templates` is currently taking in the screwdriver config, and was validated based on `schema.models.template.create`: https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/templates/create.js#L69

This PR changes the payload to be the same as [`POST /validator/template`](https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/template-validator.js). It takes in yaml string instead of the config. 

So payload looks like:
```
{"yaml":"{\"name\":\"template_namespace/nodejs_main\",\"version\":\"1.2\",\"description\":\"Template for building a NodeJS module\\nInstalls dependencies and runs tests\\n\",\"maintainer\":\"me@nowhere.com\",\"config\":{\"image\":\"node:6\",\"steps\":[{\"install\":\"npm install\"},{\"test\":\"npm test\"}],\"environment\":{\"KEYNAME\":\"value\"},\"secrets\":[\"NPM_TOKEN\"]}}"}
```

It also calls validator before creating the template, and returns 400 if template is invalid. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/470