### PR TITLE
fix(517): improve notification plugin register

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -79,10 +79,11 @@ module.exports = (server, config) => (
 
         return Object.keys(notificationConfig).forEach((plugin) => {
             const Plugin = require(`screwdriver-notifications-${plugin}`);
-            const notificationPlugin = new Plugin(
-                notificationConfig[plugin], server, 'build_status');
+            const notificationPlugin = new Plugin(notificationConfig[plugin]);
 
-            notificationPlugin.notify();
+            notificationPlugin.events.forEach((event) => {
+                server.on(event, buildData => notificationPlugin.notify(buildData));
+            });
         });
     })
   );

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "screwdriver-executor-docker": "^2.0.0",
     "screwdriver-executor-k8s": "^10.0.0",
     "screwdriver-models": "^21.5.0",
-    "screwdriver-notifications-email": "^1.0.3",
+    "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-bitbucket": "^2.6.0",
     "screwdriver-scm-github": "^4.6.0",
     "screwdriver-scm-gitlab": "^0.1.0",

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -42,7 +42,8 @@ describe('Register Unit Test Case', () => {
 
     beforeEach(() => {
         serverMock = {
-            register: sinon.stub()
+            register: sinon.stub(),
+            on: sinon.stub()
         };
 
         expectedPlugins.forEach((plugin) => {
@@ -124,15 +125,16 @@ describe('Register Unit Test Case', () => {
 
         notificationPlugins.forEach((plugin) => {
             mocks[plugin] = sinon.stub();
+            mocks[plugin].prototype.events = ['build_status'];
             mocks[plugin].prototype.notify = sinon.stub();
             mockery.registerMock(plugin, mocks[plugin]);
         });
 
-        return main(serverMock, newConfig).then(() =>
-            notificationPlugins.forEach(plugin =>
-                Assert.called(mocks[plugin].prototype.notify)
-            )
-        );
+        return main(serverMock, newConfig).then(() => {
+            notificationPlugins.forEach(() =>
+                Assert.calledTwice(serverMock.on)
+            );
+        });
     });
 
     it('bubbles failures up', () => {


### PR DESCRIPTION
### Context
Notification plugins are registered at [registerPlugins](https://github.com/screwdriver-cd/screwdriver/blob/master/lib/registerPlugins.js#L85) and called `notify`, then notification plugin returns a Promise but `registerPlugins` does not use the status of Promise. https://github.com/screwdriver-cd/notifications-base/pull/3 provides update about this.

And the registration logic can be also improved.

### Object
This PR provides to fix event registration logic. Notification plugins will have minimum parameters.

### Misc.
Related: https://github.com/screwdriver-cd/screwdriver/issues/517

#### TODO
- [x] https://github.com/screwdriver-cd/notifications-base/pull/3 is merged ~~and specify screwdirver-notification-base verson in package.json.~~ it should do in notifications-email
- [x] may need fix test
- [x] https://github.com/screwdriver-cd/notifications-email/pull/10 s merged and specify screwdirver-notification-base verson in package.json.