### PR TITLE
fix: response assertions first

### DIFF
--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -85,9 +85,9 @@ module.exports = function server() {
             json: true
         })
         .then((response) => {
-            this.jobId = response.body[0].id;
-
             Assert.equal(response.statusCode, 200);
+
+            this.jobId = response.body[0].id;
         })
         .then(() =>
             request({
@@ -101,9 +101,9 @@ module.exports = function server() {
                 },
                 json: true
             }).then((resp) => {
-                this.buildId = resp.body.id;
-
                 Assert.equal(resp.statusCode, 201);
+
+                this.buildId = resp.body.id;
             })
         )
     );

--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -38,9 +38,9 @@ module.exports = function server() {
             method: 'GET',
             json: true
         }).then((response) => {
-            this.buildId = response.body[0].id;
-
             Assert.equal(response.statusCode, 200);
+
+            this.buildId = response.body[0].id;
         });
     });
 

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -71,11 +71,12 @@ module.exports = function server() {
             method: 'GET',
             json: true
         }).then((response) => {
+            Assert.equal(response.statusCode, 200);
+
             this.jobId = response.body[0].id;
             this.image = response.body[0].permutations[0].image;
             this.commands = response.body[0].permutations[0].commands;
 
-            Assert.equal(response.statusCode, 200);
             Assert.equal(this.image, this.expectedImage);
         })
         .then(() =>
@@ -90,11 +91,11 @@ module.exports = function server() {
                 },
                 json: true
             }).then((resp) => {
+                Assert.equal(resp.statusCode, 201);
+
                 this.buildId = resp.body.id;
                 this.eventId = resp.body.eventId;
                 this.meta = resp.body.meta;
-
-                Assert.equal(resp.statusCode, 201);
             })
         )
     );

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -66,8 +66,9 @@ module.exports = function server() {
             },
             json: true
         }).then((response) => {
-            this.secretId = response.body.id;
             Assert.equal(response.statusCode, 201);
+
+            this.secretId = response.body.id;
         })
     );
 
@@ -77,12 +78,12 @@ module.exports = function server() {
             method: 'GET',
             json: true
         }).then((response) => {
+            Assert.equal(response.statusCode, 200);
+
             this.jobId = response.body[0].id;
             this.secondJobId = response.body[1].id;
             this.thirdJobId = typeof response.body[2] === 'object' ? response.body[2].id : null;
             this.lastJobId = response.body.reverse().find(b => typeof b === 'object').id || null;
-
-            Assert.equal(response.statusCode, 200);
         })
         .then(() =>
             request({
@@ -96,10 +97,10 @@ module.exports = function server() {
                 },
                 json: true
             }).then((resp) => {
+                Assert.equal(resp.statusCode, 201);
+
                 this.buildId = resp.body.id;
                 this.eventId = resp.body.eventId;
-
-                Assert.equal(resp.statusCode, 201);
             })
         )
     );


### PR DESCRIPTION
## Context

Part of investigating the flaky functional tests. There are some assertions being made after the tests are searching for data in the payloads. 

## Objective

This update reverses the logic, so that we can assert the request is sane before we try to parse the payload for the data we're looking for.

## Miscellaneous 

* Assists with #533

EDIT: Included the related issue