### PR TITLE
[DNM] feat(545): set timeout time when builds start running

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -4,6 +4,87 @@ const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.job.base, 'id');
+const defaultTimeout = 90 * 60 * 1000; // 90 minutes in ms
+
+/**
+ * Sends a build_status event to hapi plugin subscribers
+ * @method emitBuildStatus
+ * @param  {BuildModel}        build    An instance of the build model
+ * @param  {HapiRequest}       request  The initial request
+ * @return {BuildModel}                 Returns the original build model
+ */
+function emitBuildStatus({ build, request }) {
+    return build.job.then(job => job.pipeline.then((pipeline) => {
+        request.server.emit('build_status', {
+            settings: job.permutations[0].settings,
+            status: build.status,
+            pipelineName: pipeline.scmRepo.name,
+            jobName: job.name,
+            buildId: build.id,
+            buildLink: `${request.server.app.ecosystem.ui}/pipelines/` +
+                `${pipeline.id}/builds/${build.id}`
+        });
+
+        return build;
+    }));
+}
+
+/**
+ * [updateWorkflow description]
+ * @method updateWorkflow
+ * @param  {[type]}       desiredStatus [description]
+ * @param  {[type]}       username      [description]
+ * @param  {[type]}       build         [description]
+ * @param  {[type]}       jobFactory    [description]
+ * @param  {[type]}       buildFactory  [description]
+ * @return {[type]}                     [description]
+ */
+function updateWorkflow({ desiredStatus, username, build, jobFactory, buildFactory }) {
+    // Guard against triggering non-successful builds
+    if (desiredStatus !== 'SUCCESS') {
+        return Promise.resolve(null);
+    }
+
+    return build.job.then(job => job.pipeline.then((pipeline) => {
+        const workflow = pipeline.workflow;
+
+        // No workflow to follow
+        if (!workflow) {
+            return null;
+        }
+
+        const workflowIndex = workflow.indexOf(job.name);
+
+        // Current build is the last job in the workflow
+        if (workflowIndex === workflow.length - 1) {
+            return null;
+        }
+
+        // Skip if not in the workflow (like PRs)
+        if (workflowIndex === -1) {
+            return null;
+        }
+
+        const nextJobName = workflow[workflowIndex + 1];
+
+        return jobFactory.get({
+            name: nextJobName,
+            pipelineId: pipeline.id
+        }).then((nextJobToTrigger) => {
+            if (nextJobToTrigger.state === 'ENABLED') {
+                return buildFactory.create({
+                    jobId: nextJobToTrigger.id,
+                    sha: build.sha,
+                    parentBuildId: build.id,
+                    username,
+                    eventId: build.eventId
+                });
+            }
+
+            return null;
+        });
+    }));
+}
 
 module.exports = () => ({
     method: 'PUT',
@@ -49,15 +130,19 @@ module.exports = () => ({
                         // Check permission against the pipeline
                         // @TODO implement this
                     } else {
+                        const now = new Date();
+
                         switch (desiredStatus) {
                         case 'SUCCESS':
                         case 'FAILURE':
                         case 'ABORTED':
                             build.meta = request.payload.meta || {};
-                            build.endTime = (new Date()).toISOString();
+                            build.endTime = now.toISOString();
                             break;
                         case 'RUNNING':
-                            build.startTime = (new Date()).toISOString();
+                            build.startTime = now.toISOString();
+                            build.timeoutTime = (new Date(now.getTime() + defaultTimeout))
+                                .toISOString();
                             break;
                         default:
                             throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);
@@ -67,65 +152,16 @@ module.exports = () => ({
                     // Everyone is able to update the status
                     build.status = desiredStatus;
 
-                    // Only trigger next build on success
-                    return build.update()
-                        .then(() => build.job.then(job => job.pipeline.then((pipeline) => {
-                            request.server.emit('build_status', {
-                                settings: job.permutations[0].settings,
-                                status: build.status,
-                                pipelineName: pipeline.scmRepo.name,
-                                jobName: job.name,
-                                buildId: build.id,
-                                buildLink:
-                                    `${buildFactory.uiUri}/pipelines/${pipeline.id}/builds/${id}`
-                            });
-
-                            // Guard against triggering non-successful builds
-                            if (desiredStatus !== 'SUCCESS') {
-                                return null;
-                            }
-
-                            const workflow = pipeline.workflow;
-
-                            // No workflow to follow
-                            if (!workflow) {
-                                return null;
-                            }
-
-                            const workflowIndex = workflow.indexOf(job.name);
-
-                            // Current build is the last job in the workflow
-                            if (workflowIndex === workflow.length - 1) {
-                                return null;
-                            }
-
-                            // Skip if not in the workflow (like PRs)
-                            if (workflowIndex === -1) {
-                                return null;
-                            }
-
-                            const nextJobName = workflow[workflowIndex + 1];
-
-                            return jobFactory.get({
-                                name: nextJobName,
-                                pipelineId: pipeline.id
-                            }).then((nextJobToTrigger) => {
-                                if (nextJobToTrigger.state === 'ENABLED') {
-                                    return buildFactory.create({
-                                        jobId: nextJobToTrigger.id,
-                                        sha: build.sha,
-                                        parentBuildId: id,
-                                        username,
-                                        eventId: build.eventId
-                                    });
-                                }
-
-                                return null;
-                            });
-                        }))
-                        .then(() => reply(build.toJson()).code(200))
-                    );
+                    return build;
                 })
+                .then(build => build.update())
+                .then(build => emitBuildStatus({ build, request }))
+                .then(build =>
+                    updateWorkflow({
+                        desiredStatus, username, build, jobFactory, buildFactory
+                    })
+                    .then(() => reply(build.toJson()).code(200))
+                )
                 .catch(err => reply(boom.wrap(err)));
         },
         validate: {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -98,7 +98,8 @@ describe('build plugin test', () => {
             pipelineFactory: pipelineFactoryMock,
             jobFactory: jobFactoryMock,
             userFactory: userFactoryMock,
-            eventFactory: eventFactoryMock
+            eventFactory: eventFactoryMock,
+            ecosystem: { ui: 'http://foo.bar' }
         };
         server.connection({
             port: 12345,
@@ -211,7 +212,7 @@ describe('build plugin test', () => {
             };
         });
 
-        it('emits event buid_status', () => {
+        it('emits event build_status', () => {
             const jobMock = {
                 id: 1234,
                 name: 'main',
@@ -230,7 +231,7 @@ describe('build plugin test', () => {
             };
 
             buildFactoryMock.get.resolves(buildMock);
-            buildFactoryMock.uiUri = 'http://foo.bar';
+            // buildFactoryMock.uiUri = 'http://foo.bar';
 
             const options = {
                 method: 'PUT',


### PR DESCRIPTION
Context:
--------
Builds should have a time limit on execution

Objective:
----------
A `timeoutTime` is added to a build when its status is changed to "RUNNING". Ideally, this would be affected by some user configuration.

Misc:
-----
* Related to #545
* Refactored the actions that occur after status is updated to separate methods to make the handler a little cleaner

TODO:
-----
* [ ] Get a value from some build/job configuration (settings)
* [ ] Act on the build timeout value (`setTimeout()`, cron, ...)