### PR TITLE
fix: fix failing unit tests

### DIFF
--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -21,7 +21,7 @@ module.exports = () => ({
             let stepIndex = -1;
 
             if (buildId !== buildIdCred) {
-                throw boom.forbidden(`Credential only valid for ${buildIdCred}`);
+                return reply(boom.forbidden(`Credential only valid for ${buildIdCred}`));
             }
 
             return factory.get(buildId)

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -26,7 +26,7 @@ module.exports = () => ({
             const isBuild = scope.includes('build');
 
             if (isBuild && username !== id) {
-                throw boom.forbidden(`Credential only valid for ${username}`);
+                return reply(boom.forbidden(`Credential only valid for ${username}`));
             }
 
             return buildFactory.get(id)


### PR DESCRIPTION
Due to some dependency changes (still investigating), `throw` boom error without return reply() will cause 500. This PR is to fix the current failing tests.