### PR TITLE
fix(tests): Fix a pipelines test that was failing

### DIFF
--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -856,7 +856,7 @@ describe('pipeline plugin test', () => {
     describe('POST /pipelines', () => {
         let options;
         const unformattedCheckoutUrl = 'git@github.com:screwdriver-cd/data-MODEL.git';
-        const checkoutUrl = 'git@github.com:screwdriver-cd/data-model.git';
+        const formattedCheckoutUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
         const scmUri = 'github.com:12345:master';
         const scmRepo = {
             id: 'github.com:123456:master'
@@ -919,15 +919,14 @@ describe('pipeline plugin test', () => {
         });
 
         it('formats the checkout url correctly', () => {
-            const goodCheckoutUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
 
-            options.payload.checkoutUrl = goodCheckoutUrl;
-
-            userMock.getPermissions.withArgs(goodCheckoutUrl).resolves({ admin: false });
-
-            return server.inject(options, () => {
-                assert.calledWith(pipelineFactoryMock.scm.parseUrl, checkoutUrl);
-                assert.calledWith(userMock.getPermissions, goodCheckoutUrl);
+            return server.inject(options).then(() => {
+                assert.calledWith(pipelineFactoryMock.scm.parseUrl, {
+                    checkoutUrl: formattedCheckoutUrl,
+                    token
+                });
+                assert.calledWith(userMock.getPermissions, scmUri);
             });
         });
 


### PR DESCRIPTION
One of the tests in pipeline.test.js was failing, but it wasn't showing up in the summary at the end because the test was using a callback instead of a `then` block.

I *think* this is what the test should be testing for, by looking at the code for pipelines and talking to @d2lam, but @d2lam please confirm this!