### PR TITLE
feat(tokens): Add token refresh route

### DIFF
--- a/plugins/tokens/README.md
+++ b/plugins/tokens/README.md
@@ -65,6 +65,10 @@ Example payload:
 }
 ```
 
+#### Refresh a token value
+
+`PATCH /tokens/{id}/refresh`
+
 #### Remove a token
 
 `DELETE /tokens/{id}`

--- a/plugins/tokens/index.js
+++ b/plugins/tokens/index.js
@@ -4,6 +4,7 @@ const boom = require('boom');
 const createRoute = require('./create');
 const listRoute = require('./list');
 const updateRoute = require('./update');
+const refreshRoute = require('./refresh');
 const removeRoute = require('./remove');
 
 /**
@@ -44,6 +45,7 @@ exports.register = (server, options, next) => {
         createRoute(),
         listRoute(),
         updateRoute(),
+        refreshRoute(),
         removeRoute()
     ]);
 

--- a/plugins/tokens/refresh.js
+++ b/plugins/tokens/refresh.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const idSchema = joi.reach(schema.models.token.base, 'id');
+
+module.exports = () => ({
+    method: 'PATCH',
+    path: '/tokens/{id}/refresh',
+    config: {
+        description: 'Refresh a token',
+        notes: 'Update the value of a token while preserving its other metadata',
+        tags: ['api', 'secrets'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const tokenFactory = request.server.app.tokenFactory;
+            const credentials = request.auth.credentials;
+            const canAccess = request.server.plugins.tokens.canAccess;
+
+            return tokenFactory.get(request.params.id)
+                .then((token) => {
+                    if (!token) {
+                        throw boom.notFound('Token does not exist');
+                    }
+
+                    return canAccess(credentials, token)
+                        .then(token.refresh)
+                        .then(() => {
+                            const output = token.toJson();
+
+                            delete output.hash;
+
+                            return reply(output).code(200);
+                        });
+                })
+                .catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            params: {
+                id: idSchema
+            }
+        }
+    }
+});


### PR DESCRIPTION
* `PATCH` `/tokens/{id}/refresh` will refresh the token's value and return it while preserving the other fields of the token

Related to https://github.com/screwdriver-cd/screwdriver/issues/532
