### PR TITLE
enhancement: remove .func_config.json

### DIFF
--- a/.func_config.json
+++ b/.func_config.json
@@ -1,7 +1,0 @@
-{
-    "username": "YOUR-GITHUB-USERNAME",
-    "gitToken": "YOUR-ACCESS-TOKEN",
-    "accessKey": "YOUR-ACCESS-KEY",
-    "host": "YOUR-LOCAL-API-HOST",
-    "testOrg": "YOUR-TEST-ORGANIZATION"
-}

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ npm test
 
 Fork `functional-*` repositories to your organization from [screwdriver-cd-test](https://github.com/screwdriver-cd-test)
 
-Update `.func_config.json` with your own username, github token, access key, host, and organization for test:
+#### With `.func_config.json`
+
+Add `.func_config.json` to the root of the Screwdriver API folder with your username, github token, access key, host, and organization for test:
 ```json
 {
     "username": "YOUR-GITHUB-USERNAME",
@@ -122,6 +124,18 @@ Update `.func_config.json` with your own username, github token, access key, hos
     "host": "YOUR-LOCAL-API-HOST",
     "testOrg": "YOUR-TEST-ORGANIZATION"
 }
+```
+
+#### With environment variables
+
+Set the environment variables:
+
+```bash
+$ export TEST_USERNAME=YOUR-GITHUB-USERNAME
+$ export GIT_TOKEN=YOUR-ACCESS-TOKEN
+$ export ACCESS_KEY=YOUR-ACCESS-KEY
+$ export SD_API=YOUR-LOCAL-API-HOST
+$ export TEST_ORG=YOUR-TEST-ORGANIZATION
 ```
 
 Then run the cucumber tests:

--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -1,6 +1,8 @@
 'use strict';
 
+/* eslint-disable import/no-unresolved */
 const config = require('../../.func_config');
+/* eslint-enable import/no-unresolved */
 const requestretry = require('requestretry');
 const request = require('../support/request');
 


### PR DESCRIPTION
Since `.func_config.json` was already in the index, it being in the .gitignore did nothing. This made it easy to accidentally publish tokens on github.

* removed `.func_config.json` from git index
* updated `readme.md` to have instructions on creating `.func_config.json` rather than modifying it, as well as adding that you can set these with environment variables as well