### PR TITLE
fix: do not throw err if func_config does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ npm-debug.log
 .*.swp
 database.*
 config/local.*
-.func_config.json
+.func_config
 .nyc_output
 data/*

--- a/README.md
+++ b/README.md
@@ -113,17 +113,16 @@ npm test
 
 Fork `functional-*` repositories to your organization from [screwdriver-cd-test](https://github.com/screwdriver-cd-test)
 
-#### With `.func_config.json`
+#### With `.func_config`
 
-Add `.func_config.json` to the root of the Screwdriver API folder with your username, github token, access key, host, and organization for test:
-```json
-{
-    "username": "YOUR-GITHUB-USERNAME",
-    "gitToken": "YOUR-ACCESS-TOKEN",
-    "accessKey": "YOUR-ACCESS-KEY",
-    "host": "YOUR-LOCAL-API-HOST",
-    "testOrg": "YOUR-TEST-ORGANIZATION"
-}
+Add `.func_config` to the root of the Screwdriver API folder with your username, github token, access key, host, and organization for test:
+```
+GIT_TOKEN=YOUR-GITHUB-TOKEN
+ACCESS_KEY=YOUR-ACCESS-KEY
+SD_API=YOUR-LOCAL-API-HOST
+TEST_ORG=OUR-TEST-ORGANIZATION
+TEST_USERNAME=YOUR-GITHUB-USERNAME
+
 ```
 
 #### With environment variables
@@ -132,7 +131,7 @@ Set the environment variables:
 
 ```bash
 $ export TEST_USERNAME=YOUR-GITHUB-USERNAME
-$ export GIT_TOKEN=YOUR-ACCESS-TOKEN
+$ export GIT_TOKEN=YOUR-GITHUB-TOKEN
 $ export ACCESS_KEY=YOUR-ACCESS-KEY
 $ export SD_API=YOUR-LOCAL-API-HOST
 $ export TEST_ORG=YOUR-TEST-ORGANIZATION

--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -1,8 +1,7 @@
 'use strict';
 
-/* eslint-disable import/no-unresolved */
-const config = require('../../.func_config');
-/* eslint-enable import/no-unresolved */
+const path = require('path');
+const env = require('node-env-file');
 const requestretry = require('requestretry');
 const request = require('../support/request');
 
@@ -37,13 +36,12 @@ function promiseToWait(timeToWait) {
 function beforeHooks() {
     // eslint-disable-next-line new-cap
     this.Before((scenario, cb) => {
-        const host = process.env.SD_API;
-
-        this.gitToken = process.env.GIT_TOKEN || config.gitToken;
-        this.accessKey = process.env.ACCESS_KEY || config.accessKey;
-        this.instance = host ? `https://${host}` : config.host;
-        this.testOrg = process.env.TEST_ORG || config.testOrg;
-        this.username = process.env.TEST_USERNAME || config.username;
+        env(path.join(__dirname, '../../.func_config'), { raise: false });
+        this.gitToken = process.env.GIT_TOKEN;
+        this.accessKey = process.env.ACCESS_KEY;
+        this.instance = `https://${process.env.SD_API}`;
+        this.testOrg = process.env.TEST_ORG;
+        this.username = process.env.TEST_USERNAME;
         this.namespace = 'v4';
         this.promiseToWait = time => promiseToWait(time);
         this.getJwt = accessKey =>

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "js-yaml": "^3.6.1",
     "jsonwebtoken": "^7.1.6",
     "ndjson": "^1.4.3",
+    "node-env-file": "^0.1.8",
     "request": "^2.74.0",
     "requestretry": "^1.12.0",
     "screwdriver-artifact-bookend": "^1.0.1",


### PR DESCRIPTION
It will throw an err during the `require('../../.func_config')` because we remove the `.func_config` file.
https://cd.screwdriver.cd/pipelines/1/builds/4770