### PR TITLE
fix(545): Pin screwdriver-datastore-sequelize version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-config-parser": "^3.3.0",
     "screwdriver-data-schema": "^16.8.5",
-    "screwdriver-datastore-sequelize": "^2.0.0",
+    "screwdriver-datastore-sequelize": "2.0.2",
     "screwdriver-executor-docker": "^2.0.0",
     "screwdriver-executor-k8s": "^10.0.0",
     "screwdriver-models": "^22.2.0",


### PR DESCRIPTION
The previous rollback PR didn't work because 2.1.0 has the Breaking Change already but we failed to bump the version. Pin the last working version now till we figure out the sequelize problem. 

Last rollback PR: https://github.com/screwdriver-cd/screwdriver/pull/590
Releases for `screwdriver-datastore-sequelize`: https://github.com/screwdriver-cd/datastore-sequelize/releases