### PR TITLE
User Tokens: Add test for GET route

### DIFF
--- a/features/api-token.feature
+++ b/features/api-token.feature
@@ -23,11 +23,10 @@ Feature: User API Token
         Then a valid JWT is received that represents "calvin"
         And the "tiger" token's 'last used' property is updated
 
-    @ignore
     Scenario: List API Tokens
-        And owns an existing API token
-        When "calvin" lists all their tokens
-        Then their API token is in the list
+        Given "calvin" owns an existing API token named "tiger"
+        When they list all their tokens
+        Then their "tiger" token is in the list
         And their token is safely described
 
     @ignore

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -6,7 +6,6 @@ const jwt = require('jsonwebtoken');
 const TIMEOUT = 240 * 1000;
 
 module.exports = function server() {
-    // eslint-disable-next-line new-cap
     this.Before({
         tags: ['@auth']
     }, () => {

--- a/features/step_definitions/events.js
+++ b/features/step_definitions/events.js
@@ -5,7 +5,6 @@ const request = require('../support/request');
 const TIMEOUT = 240 * 1000;
 
 module.exports = function server() {
-    // eslint-disable-next-line new-cap
     this.Before({
         tags: ['@events']
     }, () => {

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -7,7 +7,6 @@ const github = require('../support/github');
 const TIMEOUT = 240 * 1000;
 
 module.exports = function server() {
-    // eslint-disable-next-line new-cap
     this.Before({
         tags: ['@gitflow'],
         timeout: TIMEOUT

--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -5,7 +5,6 @@ const request = require('../support/request');
 const TIMEOUT = 240 * 1000;
 
 module.exports = function server() {
-    // eslint-disable-next-line new-cap
     this.Before({
         tags: ['@metadata']
     }, () => {

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -8,7 +8,6 @@ const sdapi = require('../support/sdapi');
 const TIMEOUT = 240 * 1000;
 
 module.exports = function server() {
-    // eslint-disable-next-line new-cap
     this.Before({
         tags: ['@sd-step']
     }, () => {

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -5,7 +5,6 @@ const request = require('../support/request');
 const TIMEOUT = 240 * 1000;
 
 module.exports = function server() {
-    // eslint-disable-next-line new-cap
     this.Before({
         tags: ['@secrets']
     }, () => {
@@ -168,7 +167,6 @@ module.exports = function server() {
         })
     );
 
-    // eslint-disable-next-line new-cap
     this.After({
         tags: ['@secrets']
     }, () =>

--- a/features/support/before-hook.js
+++ b/features/support/before-hook.js
@@ -34,7 +34,6 @@ function promiseToWait(timeToWait) {
  * @return
  */
 function beforeHooks() {
-    // eslint-disable-next-line new-cap
     this.Before((scenario, cb) => {
         env(path.join(__dirname, '../../.func_config'), { raise: false });
         this.gitToken = process.env.GIT_TOKEN;


### PR DESCRIPTION
* Add the acceptance test for the token `GET` route
* Remove the `eslint-ignore`s because that rule got amended to ignore `Before` and `After` in https://github.com/screwdriver-cd/eslint-config-screwdriver/pull/23

Related to https://github.com/screwdriver-cd/screwdriver/issues/532