### PR TITLE
docs(tokens): Document ability to call GET /auth/token with access key

### DIFF
--- a/plugins/auth/README.md
+++ b/plugins/auth/README.md
@@ -33,7 +33,7 @@ server.register({
 
 #### Get a token
 
-`GET /auth/token`
+`GET /auth/token` (with OAuth) or `GET /auth/token?access_key=YOUR_ACCESS_KEY` (with API token)
 
 #### Get a public key for verifying JSON Web Tokens (JWTs)
 


### PR DESCRIPTION
Related to https://github.com/screwdriver-cd/screwdriver/issues/532

Realized that this wasn't in the docs while talking to Bharwal about how to call the API.