### PR TITLE
feat(tokens): Token PUT acceptance test

### DIFF
--- a/features/api-token.feature
+++ b/features/api-token.feature
@@ -29,11 +29,11 @@ Feature: User API Token
         Then their "tiger" token is in the list
         And their token is safely described
 
-    @ignore
     Scenario: Edit API Token Labels
-        And owns an existing API token
-        When "calvin" changes the label associated with the token
+        Given "calvin" owns an existing API token named "tiger"
+        When they change the label associated with the token
         Then their token will have that new label
+        And the token's 'last used' property will not be updated
 
     @ignore
     Scenario: Revoke API Token

--- a/plugins/tokens/README.md
+++ b/plugins/tokens/README.md
@@ -50,7 +50,7 @@ Example payload:
 
 #### Update a token
 
-`PATCH /tokens/{id}`
+`PUT /tokens/{id}`
 
 **Arguments**
 
@@ -67,7 +67,7 @@ Example payload:
 
 #### Refresh a token value
 
-`PATCH /tokens/{id}/refresh`
+`PUT /tokens/{id}/refresh`
 
 #### Remove a token
 

--- a/plugins/tokens/refresh.js
+++ b/plugins/tokens/refresh.js
@@ -6,7 +6,7 @@ const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.token.base, 'id');
 
 module.exports = () => ({
-    method: 'PATCH',
+    method: 'PUT',
     path: '/tokens/{id}/refresh',
     config: {
         description: 'Refresh a token',

--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -6,7 +6,7 @@ const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.token.base, 'id');
 
 module.exports = () => ({
-    method: 'PATCH',
+    method: 'PUT',
     path: '/tokens/{id}',
     config: {
         description: 'Update a token',
@@ -60,8 +60,6 @@ module.exports = () => ({
                             return token.update()
                             .then(() => {
                                 const output = token.toJson();
-
-                                delete output.hash;
 
                                 return reply(output).code(200);
                             });

--- a/test/plugins/tokens.test.js
+++ b/test/plugins/tokens.test.js
@@ -235,12 +235,12 @@ describe('token plugin test', () => {
         });
     });
 
-    describe('PATCH /tokens/{id}', () => {
+    describe('PUT /tokens/{id}', () => {
         let options;
 
         beforeEach(() => {
             options = {
-                method: 'PATCH',
+                method: 'PUT',
                 url: `/tokens/${tokenId}`,
                 credentials: {
                     username,
@@ -316,12 +316,12 @@ describe('token plugin test', () => {
         });
     });
 
-    describe('PATCH /tokens/{id}/refresh', () => {
+    describe('PUT /tokens/{id}/refresh', () => {
         let options;
 
         beforeEach(() => {
             options = {
-                method: 'PATCH',
+                method: 'PUT',
                 url: `/tokens/${tokenId}/refresh`,
                 credentials: {
                     username,


### PR DESCRIPTION
* Added a criterion to make sure `PUT`ting the token doesn't count as "using" it.
* Switch token update/refresh routes to use `PUT` instead of `PATCH`

Related to https://github.com/screwdriver-cd/screwdriver/issues/532