### PR TITLE
feat: modify sd-step functional test for semver

### DIFF
--- a/features/sd-step.feature
+++ b/features/sd-step.feature
@@ -19,7 +19,7 @@ Feature: Shared Steps
     - Method to refer to installed packages via semver.
 
     Scenario Outline: Use package via sd-step
-        Given an existing pipeline with <image> image and <package> package:
+        Given an existing pipeline with <image> image and <package> package
         When the main job is started
         And sd-step command is executed to use <package> package
         Then <package> package is available via sd-step
@@ -30,7 +30,7 @@ Feature: Shared Steps
 
     @ignore
     Scenario Outline: Use package via sd-step with specified version
-        Given an existing pipeline with <image> image and <package> package:
+        Given an existing pipeline with <image> image and <package> package
         When the <job> job is started
         And sd-step command is executed to use <package> package with specified version <version>
         Then <package> package is available via sd-step with specified version <version>

--- a/features/sd-step.feature
+++ b/features/sd-step.feature
@@ -19,7 +19,7 @@ Feature: Shared Steps
     - Method to refer to installed packages via semver.
 
     Scenario Outline: Use package via sd-step
-        Given an existing pipeline with this image and package:
+        Given an existing pipeline with <image> image and <package> package:
             | image   | package   |
             | <image> | <package> |
         When the main job is started
@@ -32,7 +32,7 @@ Feature: Shared Steps
 
     @ignore
     Scenario Outline: Use package via sd-step with specified version
-        Given an existing pipeline with this image and package:
+        Given an existing pipeline with <image> image and <package> package:
             | job   | image   | package   | version   |
             | <job> | <image> | <package> | <version> |
         When the <job> job is started

--- a/features/sd-step.feature
+++ b/features/sd-step.feature
@@ -15,30 +15,32 @@ Feature: Shared Steps
     Rules:
     - Package manager is available in every build.
     - Global SDK state is restored into the package manager installation/download location.
-    - Package manager can use the global SDK state to reduce installation/download time.
     - Method to update global SDK state.
     - Method to refer to installed packages via semver.
 
-    Background:
-        Given an existing pipeline with these images and packages with version:
-            | image          | package        | version        |
-            | golang:latest  | node           | ^4.0.0         |
-        And <image> image is used in the pipeline
-
-    Scenario: Use package via sd-step
+    Scenario Outline: Use package via sd-step
+        Given an existing pipeline with this image and package:
+            | image   | package   |
+            | <image> | <package> |
         When the main job is started
         And sd-step command is executed to use <package> package
         Then <package> package is available via sd-step
 
+        Examples:
+            | image         | package   |
+            | golang:latest | core/node |
+
     @ignore
-    Scenario: Use package via sd-step with specified version
-        When the main job is started
+    Scenario Outline: Use package via sd-step with specified version
+        Given an existing pipeline with this image and package:
+            | job   | image   | package   | version   |
+            | <job> | <image> | <package> | <version> |
+        When the <job> job is started
         And sd-step command is executed to use <package> package with specified version <version>
         Then <package> package is available via sd-step with specified version <version>
 
-    @ignore
-    Scenario: Use shared package via sd-step
-        And <package> package is shared
-        When the main job is started
-        And sd-step command is executed to use <package> package
-        Then <package> package is available via sd-step without installation/download time
+        Examples:
+            | job     | image         | package   | version |
+            | tilde   | golang:latest | core/node |  ~6.9.0 |
+            | hat     | golang:latest | core/node |  ^6.0.0 |
+            | specify | golang:latest | core/node |   4.2.6 |

--- a/features/sd-step.feature
+++ b/features/sd-step.feature
@@ -20,8 +20,6 @@ Feature: Shared Steps
 
     Scenario Outline: Use package via sd-step
         Given an existing pipeline with <image> image and <package> package:
-            | image   | package   |
-            | <image> | <package> |
         When the main job is started
         And sd-step command is executed to use <package> package
         Then <package> package is available via sd-step
@@ -33,8 +31,6 @@ Feature: Shared Steps
     @ignore
     Scenario Outline: Use package via sd-step with specified version
         Given an existing pipeline with <image> image and <package> package:
-            | job   | image   | package   | version   |
-            | <job> | <image> | <package> | <version> |
         When the <job> job is started
         And sd-step command is executed to use <package> package with specified version <version>
         Then <package> package is available via sd-step with specified version <version>

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -23,7 +23,7 @@ module.exports = function server() {
         this.commands = null;
     });
 
-    this.Given(/^an existing pipeline with (.*) image and (.*) package:$/,
+    this.Given(/^an existing pipeline with (.*) image and (.*) package$/,
         { timeout: TIMEOUT }, (image, pkg) =>
         this.getJwt(this.accessKey)
         .then((response) => {

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -20,17 +20,15 @@ module.exports = function server() {
         this.jwt = null;
         this.image = null;
         this.expectedImage = null;
-        this.expectedPackage = null;
         this.commands = null;
     });
 
-    this.Given(/^an existing pipeline with these images and packages with version:$/,
+    this.Given(/^an existing pipeline with this image and package:$/,
         { timeout: TIMEOUT }, table =>
         this.getJwt(this.accessKey)
         .then((response) => {
             this.jwt = response.body.token;
-            this.expectedImage = table.rows()[0][0];
-            this.expectedPackage = table.rows()[0][1];
+            this.expectedImage = table.hashes()[0].image;
 
             return request({
                 uri: `${this.instance}/${this.namespace}/pipelines`,
@@ -60,12 +58,7 @@ module.exports = function server() {
         })
     );
 
-    // for second pass
-    this.Given(/^(.*) package is shared/, { timeout: TIMEOUT }, pkg => null);
-
-    this.Given(/^(.*) image is used in the pipeline$/, { timeout: TIMEOUT }, image => null);
-
-    this.When(/^the main job is started$/, { timeout: TIMEOUT }, () =>
+    this.When(/^the (.*) job is started$/, { timeout: TIMEOUT }, jobName =>
         request({
             uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/jobs`,
             method: 'GET',
@@ -73,10 +66,14 @@ module.exports = function server() {
         }).then((response) => {
             Assert.equal(response.statusCode, 200);
 
-            this.jobId = response.body[0].id;
-            this.image = response.body[0].permutations[0].image;
-            this.commands = response.body[0].permutations[0].commands;
-
+            for (let i = 0; i < response.body.length; i += 1) {
+                if (response.body[i].name === jobName) {
+                    this.jobId = response.body[i].id;
+                    this.image = response.body[i].permutations[0].image;
+                    this.commands = response.body[i].permutations[0].commands;
+                    break;
+                }
+            }
             Assert.equal(this.image, this.expectedImage);
         })
         .then(() =>
@@ -103,7 +100,19 @@ module.exports = function server() {
     this.When(/^sd-step command is executed to use (.*) package$/, { timeout: TIMEOUT }, (pkg) => {
         this.commands.forEach((c) => {
             if (c.name === 'sd_step') {
-                Assert.include(c.command, this.expectedPackage);
+                Assert.include(c.command, pkg);
+            } else if (c.name.match(/^sd_step_/)) {
+                Assert.include(c.command, '--pkg-version');
+            }
+        });
+    });
+
+    this.When(/^sd-step command is executed to use (.*) package with specified version (.*)$/, {
+        timeout: TIMEOUT
+    }, (pkg, version) => {
+        this.commands.forEach((c) => {
+            if (c.name === 'sd_step') {
+                Assert.include(c.command, `--pkg-version "${version}" ${pkg}`);
             }
         });
     });
@@ -115,10 +124,12 @@ module.exports = function server() {
         });
     });
 
-    // for second pass
-    this.Then(/^(.*) package is available via sd-step with specified version (.*)$/,
-        { timeout: TIMEOUT }, (pkg, version) => null);
-    // for second pass
-    this.Then(/^(.*) package is available via sd-step without installation\/download time$/,
-        { timeout: TIMEOUT }, pkg => null);
+    this.Then(/^(.*) package is available via sd-step with specified version (.*)$/, {
+        timeout: TIMEOUT
+    }, (pkg, version) => {
+        this.waitForBuild(this.buildId).then((response) => {
+            Assert.equal(response.statusCode, 200);
+            Assert.equal(response.body.status, 'SUCCESS');
+        });
+    });
 };

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -15,8 +15,6 @@ module.exports = function server() {
         this.repoOrg = this.testOrg;
         this.repoName = 'functional-shared-steps';
         this.pipelineId = null;
-        this.eventId = null;
-        this.meta = null;
         this.jwt = null;
         this.image = null;
         this.expectedImage = null;
@@ -89,8 +87,6 @@ module.exports = function server() {
                 Assert.equal(resp.statusCode, 201);
 
                 this.buildId = resp.body.id;
-                this.eventId = resp.body.eventId;
-                this.meta = resp.body.meta;
             })
         )
     );

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -23,12 +23,12 @@ module.exports = function server() {
         this.commands = null;
     });
 
-    this.Given(/^an existing pipeline with this image and package:$/,
-        { timeout: TIMEOUT }, table =>
+    this.Given(/^an existing pipeline with (.*) image and (.*) package:$/,
+        { timeout: TIMEOUT }, (image, pkg) =>
         this.getJwt(this.accessKey)
         .then((response) => {
             this.jwt = response.body.token;
-            this.expectedImage = table.hashes()[0].image;
+            this.expectedImage = image;
 
             return request({
                 uri: `${this.instance}/${this.namespace}/pipelines`,
@@ -53,8 +53,6 @@ module.exports = function server() {
 
                 this.pipelineId = id;
             }
-
-            return table;
         })
     );
 


### PR DESCRIPTION
This PR is a modified functional test for the semver feature of sd-step.

I originally thought about running Scenario for each version (e.g. ~6.9.0, ^6.0.0),
but now it seems that all jobs are triggered by workflow, so I’ll add step in the main job　(screwdriver-cd-test/functional-shared-steps/pull/3)

Related to screwdriver-cd/sd-step#3, screwdriver-cd-test/functional-shared-steps/pull/3