### PR TITLE
fix: allow alternative pod template with in-a-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Requires:
 $ python <(curl https://raw.githubusercontent.com/screwdriver-cd/screwdriver/master/in-a-box.py)
 ```
 
+#### Alternative pod template for K8S executor:
+You can create your own pod template at `./alternative_pod_template.yaml.tim` and it will override the default pod template define in the [screwdriver-executor-k8s](https://github.com/screwdriver-cd/executor-k8s/blob/master/config/pod.yaml.tim) plugin.
+
 ## Configuration
 
 Screwdriver already [defaults most configuration](config/default.yaml), but you can override defaults using a `local.yaml` or environment variables.

--- a/in-a-box.py
+++ b/in-a-box.py
@@ -27,6 +27,7 @@ services:
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock:rw
             - ./data/:/tmp/sd-data/:rw
+            ${alternative_pod_template}
         environment:
             PORT: 80
             URI: http://${ip}:9001
@@ -213,6 +214,15 @@ def generate_oauth(scm_plugin, ip):
     print('')
     return dict(oauth_id=client_id, oauth_secret=secret)
 
+def generate_alternative_pod_template():
+    if os.path.isfile('./alternative_pod_template.yaml.tim'):
+            return {
+                'alternative_pod_template': '- ./alternative_pod_template.yaml.tim:/usr/src/app/node_modules/screwdriver-executor-k8s/config/pod.yaml.tim'
+            }
+
+    return {
+        'alternative_pod_template': ''
+    }
 
 def check_component(component):
     """
@@ -247,6 +257,9 @@ def main():
 
     print('📦   Generating OAuth credentials')
     fields.update(generate_oauth(fields['scm_plugin'], fields['ip']))
+
+    print('🗒   Generating alternative pod tempalte if it exists')
+    fields.update(generate_alternative_pod_template())
 
     print('💾   Writing Docker Compose file')
     compose = Template(DOCKER_TEMPLATE).substitute(fields)


### PR DESCRIPTION
allow alternative pod template with in-a-box.

If you provide a alternative pod template and put it at `./alternative_pod_template.yaml.tim`, it will override the default one when you run  in-a-box.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/597