### PR TITLE
chore: Created issue & PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
+
+
+_If this is a BUG REPORT, please:_
+
+  - _Fill in as much of the template below as you can.  If you leave out information, we can't help you as well._
+
+_If this is a FEATURE REQUEST, please:_
+
+  - _Describe **in detail** the feature/behavior/change you'd like to see._
+
+_In both cases, be ready for followup questions, and please respond in a timely manner.  If we can't reproduce a bug or think a feature already exists, we might close your issue.  If we're wrong, PLEASE feel free to reopen it and explain why._
+
+**Screwdriver.cd version**:
+
+**Environment**:
+- **Cloud provider or hardware configuration**:
+- **OS** (e.g. from /etc/os-release):
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it** (as minimally and precisely as possible):
+
+**Anything else we need to know**:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Context
+
+*Why do we need this PR? What was the reason that led you to make this change?*
+
+## Objective
+
+*What does this PR fix? What intentional changes will this PR make?*
+
+## References
+
+*Links or resources that help clarify and support your intentions (e.g., Github issue)*


### PR DESCRIPTION
## Context

Having templates for PRs helps maintain document the intentional changes that a PR introduces. This helps a lot with debugging features in the future, and for those who did not author the feature to determine a good remediation to related issues.

Issue templates help us by asking for the (usually missing) information that allows us to investigate issues more effeciently.

## Objective

Create an initial version of templates for both issues & pull requests.

## References

* https://github.com/blog/2111-issue-and-pull-request-templates