### PR TITLE
docs(api): Add swagger documentation to GET /auth/token

### DIFF
--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -19,6 +19,11 @@ module.exports = () => ({
             strategies: ['token', 'session', 'auth_token'],
             scope: ['user']
         },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             let profile = request.auth.credentials;
             const username = profile.username;

--- a/plugins/tokens/refresh.js
+++ b/plugins/tokens/refresh.js
@@ -34,13 +34,7 @@ module.exports = () => ({
 
                     return canAccess(credentials, token)
                         .then(() => token.refresh())
-                        .then(() => {
-                            const output = token.toJson();
-
-                            delete output.hash;
-
-                            return reply(output).code(200);
-                        });
+                        .then(() => reply(token.toJson()).code(200));
                 })
                 .catch(err => reply(boom.wrap(err)));
         },

--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -58,11 +58,7 @@ module.exports = () => ({
                             });
 
                             return token.update()
-                                .then(() => {
-                                    const output = token.toJson();
-
-                                    return reply(output).code(200);
-                                });
+                                .then(() => reply(token.toJson()).code(200));
                         });
                 })
                 .catch(err => reply(boom.wrap(err)));


### PR DESCRIPTION
* the `GET /auth/token` endpoint is very important for anybody wanting to use API tokens to interact with screwdriver, but is not listed in the api [swagger docs](api.screwdriver.cd/v4/documentation)
* removed an unnecessary statement in the tokens `refresh` and `update` endpoints

Related to https://github.com/screwdriver-cd/screwdriver/issues/532