### PR TITLE
chore: github issue template comments

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,17 @@
 **Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
 
+<!--
+If this is a BUG REPORT, please:
 
-_If this is a BUG REPORT, please:_
+  - Fill in as much of the template below as you can.  If you leave out information, we can't help you as well.
 
-  - _Fill in as much of the template below as you can.  If you leave out information, we can't help you as well._
+If this is a FEATURE REQUEST, please:
 
-_If this is a FEATURE REQUEST, please:_
+  - Describe **in detail** the feature/behavior/change you'd like to see.
 
-  - _Describe **in detail** the feature/behavior/change you'd like to see._
+In both cases, be ready for followup questions, and please respond in a timely manner.  If we can't reproduce a bug or think a feature already exists, we might close your issue.  If we're wrong, PLEASE feel free to reopen it and explain why.
+-->
 
-_In both cases, be ready for followup questions, and please respond in a timely manner.  If we can't reproduce a bug or think a feature already exists, we might close your issue.  If we're wrong, PLEASE feel free to reopen it and explain why._
 
 **Screwdriver.cd version**:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 ## Context
 
-*Why do we need this PR? What was the reason that led you to make this change?*
+<!-- Why do we need this PR? What was the reason that led you to make this change? -->
 
 ## Objective
 
-*What does this PR fix? What intentional changes will this PR make?*
+<!-- What does this PR fix? What intentional changes will this PR make? -->
 
 ## References
 
-*Links or resources that help clarify and support your intentions (e.g., Github issue)*
+<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->


### PR DESCRIPTION
<!--  This is a comment. It does not render, but it still exists in the body of the issue. -->

<!--
Two roads diverged in a yellow wood,
And sorry I could not travel both
And be one traveler, long I stood
And looked down one as far as I could
To where it bent in the undergrowth;

Then took the other, as just as fair,
And having perhaps the better claim,
Because it was grassy and wanted wear;
Though as for that the passing there
Had worn them really about the same,

And both that morning equally lay
In leaves no step had trodden black.
Oh, I kept the first for another day!
Yet knowing how way leads on to way,
I doubted if I should ever come back.

I shall be telling this with a sigh
Somewhere ages and ages hence:
Two roads diverged in a wood, and I—
I took the one less traveled by,
And that has made all the difference.
-->

## Context

*Why do we need this PR? What was the reason that led you to make this change?*

The original templates were inherited from the Kubernetes repository. They contained comments so that the reporter would better understand what each section was about. When the team implemented the Github issue templates, these comments were changed to always render. 

## Objective

*What does this PR fix? What intentional changes will this PR make?*

Re-implement the template comments as comments so that the markdown does not render it.

## References

*Links or resources that help clarify and support your intentions (e.g., Github issue)*

* https://github.com/kubernetes/kubernetes/blob/master/.github/ISSUE_TEMPLATE.md
* https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
* #612