### PR TITLE
feat(472): alternative default docker registry

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -78,6 +78,7 @@ const userFactory = Models.UserFactory.getInstance({
 });
 const buildFactory = Models.BuildFactory.getInstance({
     datastore,
+    dockerRegistry: ecosystem.dockerRegistry,
     scm,
     executor,
     bookend,

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -151,3 +151,5 @@ ecosystem:
     store: ECOSYSTEM_STORE
     # Badge service (needs to add a status and color)
     badges: ECOSYSTEM_BADGES
+    # Default registry to pull build containers from
+    dockerRegistry: ECOSYSTEM_DOCKER_REGISTRY

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -163,3 +163,5 @@ ecosystem:
     store: https://store.screwdriver.cd
     # Badge service (needs to add a status and color)
     badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg
+    # Default registry to pull build containers from. Uses Docker Hub if nothing/empty string is provided
+    dockerRegistry: ""


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Screwdriver uses the default Docker implementation of `node:4 => registry.hub.docker.com/r/library/node:4`. For companies that run their own private registry, it may be more beneficial for them to override that default behavior.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This change allows for a global configuration where an image with a name like `node:4` translates into `private.registry.com/_/node:4`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

* Resolves #472 
* Dependent on screwdriver-cd/models#175