### PR TITLE
feat(562): Add update path to pipelines

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -55,6 +55,22 @@ Example payload:
 }
 ```
 
+#### Update a pipeline
+You can update the checkoutUrl of a pipeline.
+
+`PUT /pipelines/{id}`
+
+**Arguments**
+
+* `checkoutUrl` - Source code URL for the application. For a git-based repository, it is typically the SSH endpoint and the branch name, separated by a octothorpe. Must be unique.
+
+Example payload:
+```json
+{
+  "checkoutUrl": "git@github.com:screwdriver-cd/data-model.git#master"
+}
+```
+
 #### Delete a pipeline
 
 `DELETE /pipelines/{id}`

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -3,30 +3,7 @@
 const boom = require('boom');
 const schema = require('screwdriver-data-schema');
 const urlLib = require('url');
-
-const MATCH_COMPONENT_BRANCH_NAME = 4;
-/**
- * Format the scm url to include a branch and make case insensitive
- * @method formatCheckoutUrl
- * @param  {String}     checkoutUrl     Checkout url (ex: git@github.com:screwdriver-cd/screwdriver.git#branchName)
- *                                      or (ex: https://github.com/screwdriver-cd/screwdriver.git#branchName)
- * @return {String}                     Lowercase scm url with branch name
- */
-const formatCheckoutUrl = (checkoutUrl) => {
-    let result = checkoutUrl;
-    const matched = (schema.config.regex.CHECKOUT_URL).exec(result);
-    let branchName = matched[MATCH_COMPONENT_BRANCH_NAME];
-
-    // Check if branch name exists
-    if (!branchName) {
-        branchName = '#master';
-    }
-
-    // Do not convert branch name to lowercase
-    result = result.split('#')[0].toLowerCase().concat(branchName);
-
-    return result;
-};
+const helper = require('./helper');
 
 module.exports = () => ({
     method: 'POST',
@@ -45,7 +22,7 @@ module.exports = () => ({
             }
         },
         handler: (request, reply) => {
-            const checkoutUrl = formatCheckoutUrl(request.payload.checkoutUrl);
+            const checkoutUrl = helper.formatCheckoutUrl(request.payload.checkoutUrl);
             const pipelineFactory = request.server.app.pipelineFactory;
             const userFactory = request.server.app.userFactory;
             const username = request.auth.credentials.username;

--- a/plugins/pipelines/helper.js
+++ b/plugins/pipelines/helper.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const schema = require('screwdriver-data-schema');
+
+/**
+ * Format the scm url to include a branch and make case insensitive
+ * @method formatCheckoutUrl
+ * @param  {String}     checkoutUrl     Checkout url (ex: git@github.com:screwdriver-cd/screwdriver.git#branchName)
+ *                                      or (ex: https://github.com/screwdriver-cd/screwdriver.git#branchName)
+ * @return {String}                     Lowercase scm url with branch name
+ */
+const formatCheckoutUrl = (checkoutUrl) => {
+    let result = checkoutUrl;
+    const MATCH_COMPONENT_BRANCH_NAME = 4;
+    const matched = (schema.config.regex.CHECKOUT_URL).exec(result);
+    let branchName = matched[MATCH_COMPONENT_BRANCH_NAME];
+
+    // Check if branch name exists
+    if (!branchName) {
+        branchName = '#master';
+    }
+
+    // Do not convert branch name to lowercase
+    result = result.split('#')[0].toLowerCase().concat(branchName);
+
+    return result;
+};
+
+module.exports = {
+    formatCheckoutUrl
+};

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const createRoute = require('./create');
+const updateRoute = require('./update');
 const removeRoute = require('./remove');
 const syncRoute = require('./sync');
 const syncWebhooksRoute = require('./syncWebhooks');
@@ -23,6 +24,7 @@ exports.register = (server, options, next) => {
     server.route([
         createRoute(),
         removeRoute(),
+        updateRoute(),
         syncRoute(),
         syncWebhooksRoute(),
         syncPRsRoute(),

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const idSchema = joi.reach(schema.models.pipeline.base, 'id');
+const helper = require('./helper');
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/pipelines/{id}',
+    config: {
+        description: 'Update a pipeline',
+        notes: 'Update a specific pipeline',
+        tags: ['api', 'pipelines'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const checkoutUrl = helper.formatCheckoutUrl(request.payload.checkoutUrl);
+            const id = request.params.id;
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const userFactory = request.server.app.userFactory;
+            const username = request.auth.credentials.username;
+
+            return Promise.all([
+                pipelineFactory.get({ id }),
+                userFactory.get({ username })
+            ])
+            // get the pipeline given its ID and the user
+            .then(([oldPipeline, user]) => {
+                // if the pipeline ID is invalid, reject
+                if (!oldPipeline) {
+                    throw boom.notFound(
+                      `Pipeline ${id} does not exist`);
+                }
+
+                // get the user token
+                return user.unsealToken()
+                // get the scm URI
+                .then(token => pipelineFactory.scm.parseUrl({
+                    checkoutUrl,
+                    token
+                }))
+                // get the user permissions for the repo
+                .then(scmUri => user.getPermissions(scmUri)
+                    // if the user isn't an admin, reject
+                    .then((permissions) => {
+                        if (!permissions.admin) {
+                            throw boom.unauthorized(
+                              `User ${username} is not an admin of this repo`);
+                        }
+                    })
+                    // check if there is already a pipeline with the new checkoutUrl
+                    .then(() => pipelineFactory.get({ scmUri }))
+                    .then((newPipeline) => {
+                        // reject if pipeline already exists with new checkoutUrl
+                        if (newPipeline) {
+                            throw boom.conflict(
+                                `Pipeline already exists with the ID: ${newPipeline.id}`);
+                        }
+
+                        // update keys
+                        oldPipeline.scmUri = scmUri;
+                        oldPipeline.admins = {
+                            [username]: true
+                        };
+
+                        // update pipeline with new scmRepo and branch
+                        return oldPipeline.update()
+                        .then(updatedPipeline => updatedPipeline.sync())
+                        .then(syncedPipeline => reply(syncedPipeline.toJson()).code(200));
+                    })
+                );
+            })
+            // something broke, respond with error
+            .catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            params: {
+                id: idSchema
+            },
+            payload: schema.models.pipeline.update
+        }
+    }
+});

--- a/test/plugins/data/updatedPipeline.json
+++ b/test/plugins/data/updatedPipeline.json
@@ -1,0 +1,8 @@
+{
+  "id": 123,
+  "scmUri": "github.com:12345:master",
+  "createTime": "2038-01-19T03:14:08.131Z",
+  "admins": {
+    "d2lam": true
+  }
+}


### PR DESCRIPTION
## Context

Users would like the ability to update their checkout repo and branch without having to create a new pipeline.

## Objective

This PR is a continuation of work done previously to allow users to update their checkoutUrls. This PR adds a `PUT` route for updating `checkoutUrl` and also has a minor refactor of the `formatCheckoutUrl` method into a separate helper file.

## References

Original issue: https://github.com/screwdriver-cd/screwdriver/issues/562
Other relevant PRs: [models](https://github.com/screwdriver-cd/models/pull/176), [data-schema](https://github.com/screwdriver-cd/data-schema/pull/148)