### PR TITLE
fix(604): Pull in new executor-router version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.3",
     "screwdriver-executor-k8s-vm": "^0.0.2",
-    "screwdriver-executor-router": "^0.1.2",
+    "screwdriver-executor-router": "^1.0.0",
     "screwdriver-models": "^22.2.2",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-bitbucket": "^2.8.1",


### PR DESCRIPTION
Pulling in new executor-router version (https://github.com/screwdriver-cd/executor-router/pull/9)

Related to https://github.com/screwdriver-cd/screwdriver/pull/607
Original issue: #604 