### PR TITLE
fix(562): Add feature test scenario for updating a pipeline

### DIFF
--- a/features/authorization.feature
+++ b/features/authorization.feature
@@ -28,26 +28,33 @@ Feature: Authorization
     @ignore
     Scenario: No Access
         And "miss wormwood" is logged in
-        Then they can not see the project
+        Then they can not see the pipeline
         And they can not start the "main" job
         And they can not delete the pipeline
 
     @ignore
     Scenario: Read Only
         And "susie" is logged in
-        Then they can see the project
+        Then they can see the pipeline
         And they can not start the "main" job
         And they can not delete the pipeline
 
     @ignore
     Scenario: Committer
         And "hobbes" is logged in
-        Then they can see the project
+        Then they can see the pipeline
         And they can start the "main" job
         And they can not delete the pipeline
 
     Scenario: Admin
         And "calvin" is logged in
-        Then they can see the project
+        Then they can see the pipeline
         And they can start the "main" job
         And they can delete the pipeline
+
+    @ignore
+    Scenario: Admin2
+        And "calvin" is logged in
+        And they update the checkoutUrl
+        Then the pipeline checkoutUrl is updated
+        And the pipeline has the same id as before

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -42,7 +42,7 @@ defineSupportCode(({ Before, Given, Then }) => {
         });
     });
 
-    Then(/^they can see the project$/, { timeout: TIMEOUT }, function step() {
+    Then(/^they can see the pipeline$/, { timeout: TIMEOUT }, function step() {
         return request({                           // make sure pipeline exists (TODO: move to Given an existing pipeline with that repository scenario)
             uri: `${this.instance}/${this.namespace}/pipelines`,
             method: 'POST',

--- a/features/templates.feature
+++ b/features/templates.feature
@@ -70,7 +70,7 @@ Feature: Templates
     Scenario Outline: Publish template stores the template
         Given a template with a(n) <format> format
         And the template does not exist
-        When a project with the <permission> permissions publishes the template
+        When a pipeline with the <permission> permissions publishes the template
         Then the template <stored> stored
 
         Examples:


### PR DESCRIPTION
## Context

Users would like to be able to update the repo and branch on their pipeline without having to create a new pipeline (and lose their pipeline ID).

## Objective

A previous PR has already added an update route. This PR will add a feature test scenario for updating a pipeline checkoutUrl. Also, it will rename "project" to "pipeline" in feature test files.

We will add a passing feature test in the future.

## References

- Issue: https://github.com/screwdriver-cd/screwdriver/issues/562
- Related PR: https://github.com/screwdriver-cd/screwdriver/pull/627