### PR TITLE
fix: pull in newer version of k8s-vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "screwdriver-datastore-sequelize": "^2.0.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.3",
-    "screwdriver-executor-k8s-vm": "^0.0.2",
+    "screwdriver-executor-k8s-vm": "^1.0.0",
     "screwdriver-executor-router": "^1.0.0",
     "screwdriver-models": "^22.2.2",
     "screwdriver-notifications-email": "^1.1.2",


### PR DESCRIPTION
## Context
New version of k8s-vm contains the fix for prestop hook