### PR TITLE
feat(365) Add functional test for multiple scms

### DIFF
--- a/features/authorization.feature
+++ b/features/authorization.feature
@@ -58,3 +58,10 @@ Feature: Authorization
         And they update the checkoutUrl
         Then the pipeline checkoutUrl is updated
         And the pipeline has the same id as before
+
+    @ignore
+    Scenario: SCM Context
+        And "github:calvin" is logged in
+        Then they can see the pipeline
+        And they can start the "main" job
+        And they can delete the pipeline

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -34,6 +34,10 @@ defineSupportCode(({ Before, Given, Then }) => {
             case 'calvin':
                 Assert.strictEqual(decodedToken.username, this.username);
                 break;
+            case 'github:calvin':
+                Assert.strictEqual(decodedToken.username, this.username);
+                Assert.strictEqual(decodedToken.scmContext, this.scmContext);
+                break;
             default:
                 return Promise.resolve('pending');
             }

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -100,6 +100,7 @@ function CustomWorld({ attach, parameters }) {
     this.instance = `${this.protocol}://${process.env.SD_API}`;
     this.testOrg = process.env.TEST_ORG;
     this.username = process.env.TEST_USERNAME;
+    this.scmContext = process.env.TEST_SCM_CONTEXT;
     this.namespace = 'v4';
     this.promiseToWait = time => promiseToWait(time);
     this.getJwt = accessKey =>


### PR DESCRIPTION
## Context

For the support multiple SCMs, Screwdriver has to determine the user by not only `username` but also `scmContext`.

## Objective

This PR add a functional test which check the user profile by `username` and `scmContext`.

## References

issue: https://github.com/screwdriver-cd/screwdriver/issues/365
data-schema change: https://github.com/screwdriver-cd/data-schema/pull/152