### PR TITLE
Pin scm-github version to not have habitat

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "screwdriver-models": "^22.2.2",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-bitbucket": "^2.8.1",
-    "screwdriver-scm-github": "^4.8.2",
+    "screwdriver-scm-github": "4.8.2",
     "screwdriver-scm-gitlab": "^0.1.0",
     "screwdriver-template-validator": "^3.0.0",
     "tinytim": "^0.1.1",


### PR DESCRIPTION
Habitat server is down. 

Roll scm-github version back  to not have habitat 
https://github.com/screwdriver-cd/scm-github/commit/625077368519cfe57769afe4f925d831f44ceab7

## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
