### PR TITLE
Send conflicting pipeline ID on error

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -21,11 +21,17 @@ function prettyPrintErrors(request, reply) {
             request.log(['server', 'error'], stack);
         }
 
-        return reply({
+        const response = {
             statusCode,
             error: errName,
             message: errMessage
-        }).code(statusCode);
+        };
+
+        if (err.data) {
+            response.data = err.data;
+        }
+
+        return reply(response).code(statusCode);
     }
 
     return reply.continue();

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -49,7 +49,9 @@ module.exports = () => ({
                         .then((pipeline) => {
                             if (pipeline) {
                                 throw boom.conflict(
-                                    `Pipeline already exists with the ID: ${pipeline.id}`);
+                                    `Pipeline already exists with the ID: ${pipeline.id}`,
+                                    { existingId: pipeline.id }
+                                );
                             }
                         })
                         // set up pipeline admins, and create a new pipeline

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -136,6 +136,16 @@ describe('server case', () => {
                     }
                 });
 
+                server.route({
+                    method: 'GET',
+                    path: '/noWithResponse',
+                    handler: (request, reply) => {
+                        const response = boom.wrap(boom.conflict('conflict', { conflictOn: 1 }));
+
+                        return reply(response);
+                    }
+                });
+
                 return Promise.resolve();
             });
             /* eslint-disable global-require */
@@ -174,6 +184,21 @@ describe('server case', () => {
                 }).then((response) => {
                     Assert.equal(response.statusCode, 500);
                     Assert.equal(JSON.parse(response.payload).message, 'whatStackTrace');
+                })
+            ))
+        ));
+
+        it('responds with error response data', () => (
+            hapiEngine({ ecosystem }).then(server => (
+                server.inject({
+                    method: 'GET',
+                    url: '/noWithResponse'
+                }).then((response) => {
+                    const { message, data } = JSON.parse(response.payload);
+
+                    Assert.equal(response.statusCode, 409);
+                    Assert.equal(message, 'conflict');
+                    Assert.deepEqual(data, { conflictOn: 1 });
                 })
             ))
         ));


### PR DESCRIPTION
## Context

As of today error responses are simply text description of the error, making it difficult for clients like UI to parse it and do meaningful action on the error. For example, for on duplicate pipeline error, users are better served if we can take them to the pipeline which is already setup for the given repo.

## Objective

Send back existing pipeline id as part of JSON payload.
