### PR TITLE
fix(tokens): don't show tokens in server logs

### DIFF
--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const good = require('good');
+const suppressAPITokens = require('./tokens/filter');
 
 module.exports = {
     register: good,
@@ -15,7 +16,7 @@ module.exports = {
                 args: [{ error: '*', log: '*', response: '*', request: '*' }]
             }, {
                 module: 'good-console'
-            }, 'stdout']
+            }, suppressAPITokens, 'stdout']
         }
     }
 };

--- a/plugins/tokens/filter.js
+++ b/plugins/tokens/filter.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { Transform } = require('stream');
+const tokenRegex = /(^|[^a-zA-Z0-9_-])[a-zA-Z0-9_-]{43}([^a-zA-Z0-9_-]|$)/g;
+
+module.exports = new Transform({
+    transform(chunk, encoding, callback) {
+        callback(null, chunk.toString().replace(tokenRegex, '$1(API Token Suppressed)$2'));
+    }
+});


### PR DESCRIPTION
## Context

Currently if a user makes a GET request to `/v4/auth/token?api_token=(api token here)` while they have a session, the server logs will display the arguments that the path got called with, exposing the token.

## Objective

This PR adds a transform stream to the `hapi/good` list of streams that filters out anything that looks like one of our API tokens from the logs.

## References

https://github.com/hapijs/good/blob/master/API.md#options

I did a quick search, I don't think we had an issue for this.
