### PR TITLE
fix: fix the unit tests to have scmContext in pipelines

### DIFF
--- a/test/plugins/data/pipeline.json
+++ b/test/plugins/data/pipeline.json
@@ -4,5 +4,6 @@
   "createTime": "2038-01-19T03:14:08.131Z",
   "admins": {
     "stjohn": true
-  }
+  },
+  "scmContext": "github.com"
 }

--- a/test/plugins/data/pipelines.json
+++ b/test/plugins/data/pipelines.json
@@ -5,7 +5,8 @@
         "createTime": "2038-01-19T03:14:08.131Z",
         "admins": {
             "stjohn": true
-        }
+        },
+        "scmContext": "github.com"
     },
     {
         "id": 124,
@@ -13,7 +14,8 @@
         "createTime": "2038-01-19T03:14:08.131Z",
         "admins": {
             "tkyi": true
-        }
+        },
+        "scmContext": "github.com"
     },
     {
         "id": 125,
@@ -21,6 +23,7 @@
         "createTime": "2038-01-19T03:14:08.131Z",
         "admins": {
             "d2lam": true
-        }
+        },
+        "scmContext": "github.com"
     }
 ]


### PR DESCRIPTION
## Context

We merge https://github.com/screwdriver-cd/data-schema/pull/152 to make `scmContext` a required field. We have added the `scmContext` column in the database. But it failed the unit tests since `scmContext` is not in the pipeline mock data.

## Objective

Fix the broken unit tests.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
