### PR TITLE
feat(616): Can get a template using template name and tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "screwdriver-artifact-bookend": "^1.0.1",
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-config-parser": "^3.3.0",
-    "screwdriver-data-schema": "^16.12.1",
+    "screwdriver-data-schema": "^16.14.1",
     "screwdriver-datastore-sequelize": "^2.0.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.3",

--- a/plugins/templates/README.md
+++ b/plugins/templates/README.md
@@ -34,7 +34,17 @@ server.register({
 
 #### Get single template
 
-`GET /templates/{id}`
+You can get a single template by providing the template name and the specific version or the tag.
+
+`GET /templates/{name}/{tag}` or `GET /templates/{name}/{version}`
+
+**Arguments**
+
+'name', 'tag' or 'version'
+
+* `name` - Name of the template
+* `tag` - Tag of the template (e.g. `stable`, `latest`, etc)
+* `version` - Version of the template
 
 #### Create a template
 Create a template will store the template data (`config`, `name`, `version`, `description`, `maintainer`, `labels`) into the datastore.


### PR DESCRIPTION
## Context

Users should be able to get a template by using the endpoint `/templates/{name}/{version}` or `/templates/{name}/{tag}`.

## Objective

This PR will modify the original `/templates/{name}/{version}` endpoint to also accept `{tag}` instead of `{version}`.

_Not sure if there's a better name for `versionOrTag`.._

## References

- Original issue: https://github.com/screwdriver-cd/screwdriver/issues/616
- Blocked by: https://github.com/screwdriver-cd/models/pull/179
- Related to: https://github.com/screwdriver-cd/screwdriver/pull/647