### PR TITLE
feat: Add create and remove template tag routes

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -76,6 +76,9 @@ const Models = require('screwdriver-models');
 const templateFactory = Models.TemplateFactory.getInstance({
     datastore
 });
+const templateTagFactory = Models.TemplateTagFactory.getInstance({
+    datastore
+});
 const pipelineFactory = Models.PipelineFactory.getInstance({
     datastore,
     scm
@@ -120,6 +123,7 @@ datastore.setup()
         notifications: notificationConfig,
         ecosystem,
         templateFactory,
+        templateTagFactory,
         pipelineFactory,
         jobFactory,
         userFactory,

--- a/lib/server.js
+++ b/lib/server.js
@@ -88,6 +88,7 @@ module.exports = (config) => {
     // Instantiating the server with the factories will apply a shallow copy
     server.app = {
         templateFactory: config.templateFactory,
+        templateTagFactory: config.templateTagFactory,
         pipelineFactory: config.pipelineFactory,
         jobFactory: config.jobFactory,
         userFactory: config.userFactory,

--- a/plugins/templates/README.md
+++ b/plugins/templates/README.md
@@ -27,18 +27,18 @@ server.register({
 
 ### Routes
 
-#### Get all templates
-`page` and `count` optional
+#### Template
+##### Get all templates
 
-`GET /templates?page={pageNumber}&count={countNumber}`
+`GET /templates`
 
-#### Get a single template
+##### Get a single template
 
 You can get a single template by providing the template name and the specific version or the tag.
 
 `GET /templates/{name}/{tag}` or `GET /templates/{name}/{version}`
 
-**Arguments**
+###### Arguments
 
 'name', 'tag' or 'version'
 
@@ -46,18 +46,16 @@ You can get a single template by providing the template name and the specific ve
 * `tag` - Tag of the template (e.g. `stable`, `latest`, etc)
 * `version` - Version of the template
 
-#### Create a template
-Creating a template will store the template data (`config`, `name`, `version`, `description`, `maintainer`, `labels`) into the datastore.
+##### Create a template
+Creating a template will store the template data (`config`, `name`, `version`, `description`, `maintainer`) into the datastore.
 
-If the exact template and version already exist, the only thing that can be changed is `labels`.
-
-If the template already exists but not the version, the new version will be stored provided that the build has correct permissions.
+`version` will be auto-bumped. For example, if `mytemplate@1.0.0` already exists and the version passed in is `1.0.0`, the newly created template will be version `1.0.1`. 
 
 *Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that first creates the template.*
 
 `POST /templates`
 
-**Arguments**
+###### Arguments
 
 'name', 'version', 'description', 'maintainer', labels
 
@@ -84,25 +82,23 @@ Example payload:
 }
 ```
 
-#### Create/Update a tag for a template version
+#### Template Tag
+Template tag allows fetching on template version by tag. For example, tag `mytemplate@1.1.0` as `stable`. 
 
-Tagging a template version allows fetching on template version by tag. For example, tag `mytemplate@1.1.0` as `stable`. 
+##### Create/Update a tag
+
+If the template tag already exists, it will update the tag with the new version. If the template tag doesn't exist yet, this endpoint will create the tag.
 
 *Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the template.*
 
-`PUT /templates/tags` with the following payload
+`PUT /templates/{templateName}/tags/{tagName}` with the following payload
 
-* `name` - Name of the template (ex: `mytemplate`)
-* `version` - Version of the template (ex: `1.1.0`)
-* `tag` - Name of the tag (ex: `stable`)
+* `version` - Exact version of the template (ex: `1.1.0`)
 
-#### Delete a template tag
+##### Delete a tag
 
 Delete the template tag. This does not delete the template itself. 
 
 *Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the template.*
 
-`DELETE /templates/tags` with the following payload
-
-* `name` - Name of the template (ex: `mytemplate`)
-* `tag` - Name of the tag (ex: `stable`)
+`DELETE /templates/{templateName}/tags/{tagName}`

--- a/plugins/templates/README.md
+++ b/plugins/templates/README.md
@@ -32,7 +32,7 @@ server.register({
 
 `GET /templates?page={pageNumber}&count={countNumber}`
 
-#### Get single template
+#### Get a single template
 
 You can get a single template by providing the template name and the specific version or the tag.
 
@@ -47,13 +47,13 @@ You can get a single template by providing the template name and the specific ve
 * `version` - Version of the template
 
 #### Create a template
-Create a template will store the template data (`config`, `name`, `version`, `description`, `maintainer`, `labels`) into the datastore.
+Creating a template will store the template data (`config`, `name`, `version`, `description`, `maintainer`, `labels`) into the datastore.
 
 If the exact template and version already exist, the only thing that can be changed is `labels`.
 
 If the template already exists but not the version, the new version will be stored provided that the build has correct permissions.
 
-This endpoint is only accessible in `build` scope.
+*Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that first creates the template.*
 
 `POST /templates`
 
@@ -83,3 +83,26 @@ Example payload:
   }
 }
 ```
+
+#### Create/Update a tag for a template version
+
+Tagging a template version allows fetching on template version by tag. For example, tag `mytemplate@1.1.0` as `stable`. 
+
+*Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the template.*
+
+`PUT /templates/tags` with the following payload
+
+* `name` - Name of the template (ex: `mytemplate`)
+* `version` - Version of the template (ex: `1.1.0`)
+* `tag` - Name of the tag (ex: `stable`)
+
+#### Delete a template tag
+
+Delete the template tag. This does not delete the template itself. 
+
+*Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the template.*
+
+`DELETE /templates/tags` with the following payload
+
+* `name` - Name of the template (ex: `mytemplate`)
+* `tag` - Name of the tag (ex: `stable`)

--- a/plugins/templates/createTag.js
+++ b/plugins/templates/createTag.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const boom = require('boom');
+const schema = require('screwdriver-data-schema');
+const urlLib = require('url');
+
+/* Currently, only build scope is allowed to tag template due to security reasons.
+ * The same pipeline that publishes the template has the permission to tag it.
+ */
+module.exports = () => ({
+    method: 'PUT',
+    path: '/templates/tags',
+    config: {
+        description: 'Add or update a template tag',
+        notes: 'Add or update a specific template',
+        tags: ['api', 'templates'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const templateFactory = request.server.app.templateFactory;
+            const templateTagFactory = request.server.app.templateTagFactory;
+            const pipelineId = request.auth.credentials.pipelineId;
+            const config = request.payload;
+
+            return Promise.all([
+                pipelineFactory.get(pipelineId),
+                templateFactory.get({
+                    name: config.name,
+                    version: config.version
+                }),
+                templateTagFactory.get({
+                    name: config.name,
+                    tag: config.tag
+                })
+            ]).then(([pipeline, template, templateTag]) => {
+                // If template doesn't exist, throw error
+                if (!template) {
+                    throw boom.notFound(`Template ${config.name}@${config.version} not found`);
+                }
+
+                // If template exists, but this build's pipelineId is not the same as template's pipelineId
+                // Then this build does not have permission to tag the template
+                if (pipeline.id !== template.pipelineId) {
+                    throw boom.unauthorized('Not allowed to tag this template');
+                }
+
+                // If template tag exists, then the only thing it can update is the version
+                if (templateTag) {
+                    templateTag.version = config.version;
+
+                    return templateTag.update().then(tag => reply(tag.toJson()).code(200));
+                }
+
+                // If template exists, then create the tag
+                return templateTagFactory.create(config).then((tag) => {
+                    const location = urlLib.format({
+                        host: request.headers.host,
+                        port: request.headers.port,
+                        protocol: request.server.info.protocol,
+                        pathname: `${request.path}/${tag.id}`
+                    });
+
+                    return reply(tag.toJson()).header('Location', location).code(201);
+                });
+            }).catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            payload: schema.models.templateTag.create
+        }
+    }
+});

--- a/plugins/templates/createTag.js
+++ b/plugins/templates/createTag.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const boom = require('boom');
+const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const baseSchema = schema.models.templateTag.base;
 const urlLib = require('url');
 
 /* Currently, only build scope is allowed to tag template due to security reasons.
@@ -9,7 +11,7 @@ const urlLib = require('url');
  */
 module.exports = () => ({
     method: 'PUT',
-    path: '/templates/tags',
+    path: '/templates/{templateName}/tags/{tagName}',
     config: {
         description: 'Add or update a template tag',
         notes: 'Add or update a specific template',
@@ -28,22 +30,18 @@ module.exports = () => ({
             const templateFactory = request.server.app.templateFactory;
             const templateTagFactory = request.server.app.templateTagFactory;
             const pipelineId = request.auth.credentials.pipelineId;
-            const config = request.payload;
+            const name = request.params.templateName;
+            const tag = request.params.tagName;
+            const version = request.payload.version;
 
             return Promise.all([
                 pipelineFactory.get(pipelineId),
-                templateFactory.get({
-                    name: config.name,
-                    version: config.version
-                }),
-                templateTagFactory.get({
-                    name: config.name,
-                    tag: config.tag
-                })
+                templateFactory.get({ name, version }),
+                templateTagFactory.get({ name, tag })
             ]).then(([pipeline, template, templateTag]) => {
                 // If template doesn't exist, throw error
                 if (!template) {
-                    throw boom.notFound(`Template ${config.name}@${config.version} not found`);
+                    throw boom.notFound(`Template ${name}@${version} not found`);
                 }
 
                 // If template exists, but this build's pipelineId is not the same as template's pipelineId
@@ -54,26 +52,33 @@ module.exports = () => ({
 
                 // If template tag exists, then the only thing it can update is the version
                 if (templateTag) {
-                    templateTag.version = config.version;
+                    templateTag.version = version;
 
-                    return templateTag.update().then(tag => reply(tag.toJson()).code(200));
+                    return templateTag.update().then(newTag => reply(newTag.toJson()).code(200));
                 }
 
                 // If template exists, then create the tag
-                return templateTagFactory.create(config).then((tag) => {
+                return templateTagFactory.create({ name, tag, version })
+                .then((newTag) => {
                     const location = urlLib.format({
                         host: request.headers.host,
                         port: request.headers.port,
                         protocol: request.server.info.protocol,
-                        pathname: `${request.path}/${tag.id}`
+                        pathname: `${request.path}/${newTag.id}`
                     });
 
-                    return reply(tag.toJson()).header('Location', location).code(201);
+                    return reply(newTag.toJson()).header('Location', location).code(201);
                 });
             }).catch(err => reply(boom.wrap(err)));
         },
         validate: {
-            payload: schema.models.templateTag.create
+            params: {
+                templateName: joi.reach(baseSchema, 'name'),
+                tagName: joi.reach(baseSchema, 'tag')
+            },
+            payload: {
+                version: joi.reach(baseSchema, 'version')
+            }
         }
     }
 });

--- a/plugins/templates/index.js
+++ b/plugins/templates/index.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const createRoute = require('./create');
+const createTagRoute = require('./createTag');
 const getRoute = require('./get');
 const listRoute = require('./list');
 const listVersionsRoute = require('./listVersions');
+const removeTagRoute = require('./removeTag');
 
 /**
  * Template API Plugin
@@ -15,9 +17,11 @@ const listVersionsRoute = require('./listVersions');
 exports.register = (server, options, next) => {
     server.route([
         createRoute(),
+        createTagRoute(),
         getRoute(),
         listRoute(),
-        listVersionsRoute()
+        listVersionsRoute(),
+        removeTagRoute()
     ]);
 
     next();

--- a/plugins/templates/removeTag.js
+++ b/plugins/templates/removeTag.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const boom = require('boom');
+const schema = require('screwdriver-data-schema');
+
+/* Currently, only build scope is allowed to tag template due to security reasons.
+ * The same pipeline that publishes the template has the permission to tag it.
+ */
+module.exports = () => ({
+    method: 'DELETE',
+    path: '/templates/tags',
+    config: {
+        description: 'Delete a template tag',
+        notes: 'Delete a specific template',
+        tags: ['api', 'templates'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const templateFactory = request.server.app.templateFactory;
+            const templateTagFactory = request.server.app.templateTagFactory;
+            const pipelineId = request.auth.credentials.pipelineId;
+            const config = request.payload;
+
+            return templateTagFactory.get({
+                name: config.name,
+                tag: config.tag
+            })
+            .then((templateTag) => {
+                if (!templateTag) {
+                    throw boom.notFound('Template tag does not exist');
+                }
+
+                return Promise.all([
+                    pipelineFactory.get(pipelineId),
+                    templateFactory.get({
+                        name: config.name,
+                        version: templateTag.version
+                    })
+                ])
+                .then(([pipeline, template]) => {
+                    // Check for permission
+                    if (pipeline.id !== template.pipelineId) {
+                        throw boom.unauthorized('Not allowed to delete this template tag');
+                    }
+
+                    // Remove the template tag, not the template
+                    return templateTag.remove();
+                });
+            })
+            .then(() => reply().code(204))
+            .catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            payload: schema.models.templateTag.remove
+        }
+    }
+});

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -70,9 +70,6 @@ describe('template plugin test', () => {
             get: sinon.stub(),
             remove: sinon.stub()
         };
-        templateTagFactoryMock = {
-            get: sinon.stub()
-        };
         pipelineFactoryMock = {
             get: sinon.stub()
         };
@@ -404,20 +401,17 @@ describe('template plugin test', () => {
         let options;
         let templateMock;
         let pipelineMock;
-        const payload = {
-            name: 'testtemplate',
-            tag: 'stable'
-        };
-        const testTemplateTag = decorateObj(hoek.merge({
+        const testTemplateTag = decorateObj({
             id: 1,
+            name: 'testtemplate',
+            tag: 'stable',
             remove: sinon.stub().resolves(null)
-        }, payload));
+        });
 
         beforeEach(() => {
             options = {
                 method: 'DELETE',
-                url: '/templates/tags',
-                payload,
+                url: '/templates/testtemplate/tags/stable',
                 credentials: {
                     scope: ['build']
                 }
@@ -460,8 +454,6 @@ describe('template plugin test', () => {
         let templateMock;
         let pipelineMock;
         const payload = {
-            name: 'testtemplate',
-            tag: 'stable',
             version: '1.2.0'
         };
         const testTemplateTag = decorateObj(hoek.merge({ id: 1 }, payload));
@@ -469,7 +461,7 @@ describe('template plugin test', () => {
         beforeEach(() => {
             options = {
                 method: 'PUT',
-                url: '/templates/tags',
+                url: '/templates/testtemplate/tags/stable',
                 payload,
                 credentials: {
                     scope: ['build']
@@ -522,7 +514,11 @@ describe('template plugin test', () => {
                     name: 'testtemplate',
                     tag: 'stable'
                 });
-                assert.calledWith(templateTagFactoryMock.create, payload);
+                assert.calledWith(templateTagFactoryMock.create, {
+                    name: 'testtemplate',
+                    tag: 'stable',
+                    version: '1.2.0'
+                });
                 assert.equal(reply.statusCode, 201);
             });
         });


### PR DESCRIPTION
## Context
This PR allows tagging a template, similar to how docker tagging works.
- 1 tag can only map to 1 version
- 1 version can have multiple tags

Example:

| id | name | tag | version | 
|---|---|---|---|
| 1 | mytemplate | stable | 1.2.0 | 
| 2 | mytemplate | latest | 1.2.0 | 

## Objective
Add 2 routes for template tagging: CREATE and DELETE. 
UPDATE uses the same route as CREATE: send a `PUT templates/{templateTag}/tags/{tagName}` with the payload as: `{version}` instead of the usual `/id`, since it doesn't make sense that users need to look up the `id` to update.

DELETE: `DELETE templates/{templateTag}/tags/{tagName}`

**Notes:**  This only allows `build` scope to tag template due to security reasons. It will check if the build belongs to the pipeline that publishes this template. If not, then the build is not allowed to tag the template. 

## References
https://github.com/screwdriver-cd/screwdriver/issues/616