### PR TITLE
feat(523): Add GET and LIST routes to collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "screwdriver-artifact-bookend": "^1.0.1",
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-config-parser": "^3.3.0",
-    "screwdriver-data-schema": "^16.14.1",
+    "screwdriver-data-schema": "^16.14.5",
     "screwdriver-datastore-sequelize": "^2.0.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.3",

--- a/plugins/collections/README.md
+++ b/plugins/collections/README.md
@@ -27,6 +27,14 @@ server.register({
 
 ### Routes
 
+#### Get a list of collections belonging to the requesting user
+
+`GET /collections`
+
+#### Get a single collection
+
+`GET /collections/{id}`
+
 #### Create a collection
 
 `POST /collections`

--- a/plugins/collections/get.js
+++ b/plugins/collections/get.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const getSchema = schema.models.collection.get;
+const idSchema = joi.reach(schema.models.collection.base, 'id');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/collections/{id}',
+    config: {
+        description: 'Get a single collection',
+        notes: 'Returns a collection record',
+        tags: ['api', 'collections'],
+        handler: (request, reply) => {
+            const { collectionFactory, pipelineFactory } = request.server.app;
+
+            return collectionFactory.get(request.params.id)
+                .then((collection) => {
+                    if (!collection) {
+                        throw boom.notFound('Collection does not exist');
+                    }
+
+                    // Store promises from pipelineFactory fetch operations
+                    const collectionPipelines = [];
+
+                    collection.pipelineIds.forEach((id) => {
+                        collectionPipelines.push(pipelineFactory.get(id));
+                    });
+
+                    return Promise.all(collectionPipelines)
+                        .then((pipelines) => {
+                            const result = collection.toJson();
+
+                            // Iterate over all the fetched pipelines, skip if null
+                            // else add it to the result object
+                            result.pipelines = pipelines.reduce((accumulator, current) => {
+                                if (current) {
+                                    accumulator.push(current.toJson());
+                                }
+
+                                return accumulator;
+                            }, []);
+                            delete result.pipelineIds;
+                            delete result.userId;
+
+                            return reply(result);
+                        });
+                })
+                .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: getSchema
+        },
+        validate: {
+            params: {
+                id: idSchema
+            }
+        }
+    }
+});

--- a/plugins/collections/index.js
+++ b/plugins/collections/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const createRoute = require('./create');
+const getRoute = require('./get');
+const listRoute = require('./list');
 
 /**
  * Collections API Plugin
@@ -11,7 +13,9 @@ const createRoute = require('./create');
  */
 exports.register = (server, options, next) => {
     server.route([
-        createRoute()
+        createRoute(),
+        getRoute(),
+        listRoute()
     ]);
 
     next();

--- a/plugins/collections/list.js
+++ b/plugins/collections/list.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const boom = require('boom');
+const schema = require('screwdriver-data-schema');
+const listSchema = schema.models.collection.list;
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/collections',
+    config: {
+        description: 'Get collections for requesting user',
+        notes: 'Returns all collection records belonging to the requesting user',
+        tags: ['api', 'collections'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const { userFactory, collectionFactory } = request.server.app;
+            const { username } = request.auth.credentials;
+
+            return userFactory.get({ username })
+                .then((user) => {
+                    if (!user) {
+                        throw boom.notFound(`User ${username} does not exist`);
+                    }
+
+                    const config = {
+                        params: {
+                            userId: user.id
+                        }
+                    };
+
+                    return collectionFactory.list(config)
+                        .then(collections => reply(collections.map(c => c.toJson())));
+                })
+                .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: listSchema
+        }
+    }
+});

--- a/test/plugins/collections.test.js
+++ b/test/plugins/collections.test.js
@@ -7,6 +7,9 @@ const mockery = require('mockery');
 const urlLib = require('url');
 const hoek = require('hoek');
 const testCollection = require('./data/collection.json');
+const testCollectionResponse = require('./data/collection.response.json');
+const testCollections = require('./data/collections.json');
+const testPipelines = require('./data/pipelines.json');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -20,6 +23,31 @@ const getCollectionMock = (collection) => {
     return mock;
 };
 
+const getCollectionsMock = (collections) => {
+    if (Array.isArray(collections)) {
+        return collections.map(getCollectionMock);
+    }
+
+    return getCollectionMock(collections);
+};
+
+// Get the mock pipeline in testPipelines using the input id
+const getPipelineMockFromId = (id) => {
+    let result = null;
+
+    testPipelines.forEach((pipeline) => {
+        if (pipeline.id === id) {
+            result = hoek.clone(pipeline);
+
+            result.update = sinon.stub();
+            result.toJson = sinon.stub().returns(pipeline);
+            result.remove = sinon.stub();
+        }
+    });
+
+    return Promise.resolve(result);
+};
+
 const getUserMock = (user) => {
     const mock = hoek.clone(user);
 
@@ -31,6 +59,7 @@ describe('collection plugin test', () => {
     const userId = testCollection.userId;
     let collectionFactoryMock;
     let userFactoryMock;
+    let pipelineFactoryMock;
     let collectionMock;
     let userMock;
     let plugin;
@@ -46,9 +75,13 @@ describe('collection plugin test', () => {
     beforeEach((done) => {
         collectionFactoryMock = {
             create: sinon.stub(),
-            get: sinon.stub()
+            get: sinon.stub(),
+            list: sinon.stub()
         };
         userFactoryMock = {
+            get: sinon.stub()
+        };
+        pipelineFactoryMock = {
             get: sinon.stub()
         };
 
@@ -62,6 +95,7 @@ describe('collection plugin test', () => {
             id: userId
         });
         userFactoryMock.get.withArgs({ username }).resolves(userMock);
+        pipelineFactoryMock.get.callsFake(getPipelineMockFromId);
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/collections');
@@ -69,7 +103,8 @@ describe('collection plugin test', () => {
         server = new hapi.Server();
         server.app = {
             collectionFactory: collectionFactoryMock,
-            userFactory: userFactoryMock
+            userFactory: userFactoryMock,
+            pipelineFactory: pipelineFactoryMock
         };
         server.connection({
             port: 1234
@@ -159,6 +194,95 @@ describe('collection plugin test', () => {
             const testError = new Error('collectionModelError');
 
             collectionFactoryMock.create.rejects(testError);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /collections', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: '/collections',
+                credentials: {
+                    username,
+                    scope: ['user']
+                }
+            };
+        });
+
+        it('returns 200 and all collections', () => {
+            collectionFactoryMock.list.resolves(getCollectionsMock(testCollections));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testCollections);
+                assert.calledWith(collectionFactoryMock.list, {
+                    params: {
+                        userId: testCollection.userId
+                    }
+                });
+            });
+        });
+
+        it('returns 404 when the user does not exist', () => {
+            userFactoryMock.get.withArgs({ username }).resolves(null);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 500 when datastore fails', () => {
+            collectionFactoryMock.list.rejects(new Error('fail'));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /collections/{id}', () => {
+        const id = testCollectionResponse.id;
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: `/collections/${id}`
+            };
+        });
+
+        it('exposes a route for getting a collection', () => {
+            collectionFactoryMock.get.withArgs(id).resolves(collectionMock);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testCollectionResponse);
+            });
+        });
+
+        it('throws error not found when collection does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Collection does not exist'
+            };
+
+            collectionFactoryMock.get.withArgs(id).resolves(null);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('throws error when call returns error', () => {
+            collectionFactoryMock.get.withArgs(id).rejects(new Error('Failed'));
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 500);

--- a/test/plugins/data/collection.json
+++ b/test/plugins/data/collection.json
@@ -3,5 +3,5 @@
     "name": "screwdriver",
     "description": "pipelines for screwdriver",
     "userId": 34,
-    "pipelineIds": [12, 34, 56, 78]
+    "pipelineIds": [123, 124, 125, 126]
 }

--- a/test/plugins/data/collection.response.json
+++ b/test/plugins/data/collection.response.json
@@ -1,0 +1,31 @@
+{
+    "id": 12,
+    "name": "screwdriver",
+    "description": "pipelines for screwdriver",
+    "pipelines": [
+        {
+            "id": 123,
+            "scmUri": "github.com:12345:branchName",
+            "createTime": "2038-01-19T03:14:08.131Z",
+            "admins": {
+                "stjohn": true
+            }
+        },
+        {
+            "id": 124,
+            "scmUri": "github.com:12345:branchName",
+            "createTime": "2038-01-19T03:14:08.131Z",
+            "admins": {
+                "tkyi": true
+            }
+        },
+        {
+            "id": 125,
+            "scmUri": "github.com:12345:branchName",
+            "createTime": "2038-01-19T03:14:08.131Z",
+            "admins": {
+                "d2lam": true
+            }
+        }
+    ]
+}

--- a/test/plugins/data/collections.json
+++ b/test/plugins/data/collections.json
@@ -1,0 +1,23 @@
+[
+    {
+        "id": 12,
+        "name": "collection1",
+        "description": "pipelines for collection 1",
+        "userId": 34,
+        "pipelineIds": [123, 124, 125]
+    },
+    {
+        "id": 13,
+        "name": "collection2",
+        "description": "pipelines for collection 2",
+        "userId": 34,
+        "pipelineIds": [123, 124, 125]
+    },
+    {
+        "id": 14,
+        "name": "collection3",
+        "description": "pipelines for collection 3",
+        "userId": 34,
+        "pipelineIds": [123, 124, 125]
+    }
+]


### PR DESCRIPTION
## Context

For collections, we need to be able to LIST all of a user's collections as well as be able to GET a particular collection from the id.

## Objective

This PR adds the GET and LIST routes for collections

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Issue: #523 
PR regarding schema discussion: [screwdriver-cd/data-schema#162](https://github.com/screwdriver-cd/data-schema/pull/162)
