### PR TITLE
fix(tokens): don't show params on GET /auth/token

### DIFF
--- a/plugins/tokens/filter.js
+++ b/plugins/tokens/filter.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const { Transform } = require('stream');
-const tokenRegex = /(^|[^a-zA-Z0-9_-])[a-zA-Z0-9_-]{43}([^a-zA-Z0-9_-]|$)/g;
+const tokenRegex = /\/v4\/auth\/token {.*}/g;
 
 module.exports = new Transform({
     transform(chunk, encoding, callback) {
-        callback(null, chunk.toString().replace(tokenRegex, '$1(API Token Suppressed)$2'));
+        callback(null, chunk.toString().replace(tokenRegex, '/v4/auth/token {}'));
     }
 });

--- a/test/plugins/tokens.test.js
+++ b/test/plugins/tokens.test.js
@@ -442,16 +442,16 @@ describe('token plugin test', () => {
     });
 
     describe('Logging suppresses API tokens', () => {
-        it('does not print API tokens in logs', (done) => {
+        it('does not print API tokens in GET /auth/token', (done) => {
             const source = new PassThrough({ objectMode: true });
             const result = new PassThrough({ objectMode: true });
 
-            source.write(`This is a string with a token in it! ${testTokenWithValue.value}`);
+            source.write(`GET /v4/auth/token {"api_token":"${testValue}"} (200)`);
 
             source.pipe(suppressAPITokens).pipe(result);
 
             result.on('data', (chunk) => {
-                assert.equal(chunk, 'This is a string with a token in it! (API Token Suppressed)');
+                assert.equal(chunk, 'GET /v4/auth/token {} (200)');
                 done();
             });
         });


### PR DESCRIPTION
## Context

In my [last pull request](https://github.com/screwdriver-cd/screwdriver/pull/642) I removed anything that looked like a token from the logging, but forgot that some tokens were the incorrect length because they were generated before [this PR](https://github.com/screwdriver-cd/models/pull/181)

## Objective

Rather than looking for "things that look like tokens", the log will now just suppress any parameters that get passed to `GET /v4/auth/token`.

## References

https://github.com/screwdriver-cd/screwdriver/pull/642
https://github.com/screwdriver-cd/models/pull/181