### PR TITLE
feat(523): Add UPDATE route for collections

### DIFF
--- a/plugins/collections/README.md
+++ b/plugins/collections/README.md
@@ -53,3 +53,23 @@ Example payload:
     "pipelineIds": [12, 35, 47, 89]
 }
 ```
+
+#### Update a collection
+You can update the name, description, or pipelineIds of a collection.
+
+`PUT /collections/{id}`
+
+**Arguments**
+
+* `name` - An optional new name for the collection. Names must be unique.
+* `description` - An optional new description for the collection.
+* `pipelineIds` - An optional new array of ids of pipelines for the collection.
+
+Example payload:
+```json
+{
+    "name": "foo",
+    "description": "bar",
+    "pipelineIds": [1, 2, 5]
+}
+```

--- a/plugins/collections/get.js
+++ b/plugins/collections/get.js
@@ -31,7 +31,7 @@ module.exports = () => ({
 
                     return Promise.all(collectionPipelines)
                         .then((pipelines) => {
-                            const result = collection.toJson();
+                            const result = Object.assign({}, collection.toJson());
 
                             // Iterate over all the fetched pipelines, skip if null
                             // else add it to the result object

--- a/plugins/collections/index.js
+++ b/plugins/collections/index.js
@@ -3,6 +3,7 @@
 const createRoute = require('./create');
 const getRoute = require('./get');
 const listRoute = require('./list');
+const updateRoute = require('./update');
 
 /**
  * Collections API Plugin
@@ -15,7 +16,8 @@ exports.register = (server, options, next) => {
     server.route([
         createRoute(),
         getRoute(),
-        listRoute()
+        listRoute(),
+        updateRoute()
     ]);
 
     next();

--- a/plugins/collections/update.js
+++ b/plugins/collections/update.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const idSchema = joi.reach(schema.models.collection.base, 'id');
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/collections/{id}',
+    config: {
+        description: 'Update a collection',
+        notes: 'Update a specific collection',
+        tags: ['api', 'collection'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const { id } = request.params;
+            const { collectionFactory, userFactory } = request.server.app;
+            const { username } = request.auth.credentials;
+
+            // get the collection and user
+            return Promise.all([
+                collectionFactory.get({ id }),
+                userFactory.get({ username })
+            ])
+            .then(([oldCollection, user]) => {
+                if (!oldCollection) {
+                    throw boom.notFound(`Collection ${id} does not exist`);
+                }
+
+                // Check if user owns collection
+                if (oldCollection.userId !== user.id) {
+                    throw boom.unauthorized(`User ${username} does not own this collection`);
+                }
+
+                Object.assign(oldCollection, request.payload);
+
+                return oldCollection.update()
+                .then(updatedCollection => reply(updatedCollection.toJson()).code(200));
+            })
+            .catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            params: {
+                id: idSchema
+            },
+            payload: schema.models.collection.update
+        }
+    }
+});

--- a/test/plugins/data/updatedCollection.json
+++ b/test/plugins/data/updatedCollection.json
@@ -1,0 +1,7 @@
+{
+    "id": 12,
+    "name": "updated name",
+    "description": "updated description",
+    "userId": 34,
+    "pipelineIds": [123, 124]
+}


### PR DESCRIPTION
## Objective

This PR adds an UPDATE route for collections so that you can modify the name, description, or pipelineIds for the pipelines in the collection

## References

Issue: #523 
