### PR TITLE
refactor(collections): Add checks for CREATE and UPDATE routes

### DIFF
--- a/plugins/collections/update.js
+++ b/plugins/collections/update.js
@@ -43,6 +43,23 @@ module.exports = () => ({
 
                 Object.assign(oldCollection, request.payload);
 
+                // Check that all pipelines exist before updating the pipelineIds of
+                // the collection
+                if (request.payload.pipelineIds) {
+                    const { pipelineFactory } = request.server.app;
+
+                    return Promise.all(request.payload.pipelineIds.map(pipelineFactory.get))
+                    .then((pipelines) => {
+                        // If the pipeline exists, then add its id to the array of pipelineIds
+                        // in oldCollection
+                        oldCollection.pipelineIds = pipelines.filter(pipeline =>
+                            pipeline).map(pipeline => pipeline.id);
+
+                        return oldCollection.update()
+                        .then(updatedCollection => reply(updatedCollection.toJson()).code(200));
+                    });
+                }
+
                 return oldCollection.update()
                 .then(updatedCollection => reply(updatedCollection.toJson()).code(200));
             })

--- a/test/plugins/data/collection.json
+++ b/test/plugins/data/collection.json
@@ -3,5 +3,5 @@
     "name": "screwdriver",
     "description": "pipelines for screwdriver",
     "userId": 34,
-    "pipelineIds": [123, 124, 125, 126]
+    "pipelineIds": [123, 124, 125]
 }


### PR DESCRIPTION
## Context

Currently, the CREATE and UPDATE routes still pass in pipelineIds in the payload even though the ids might be invalid.

## Objective

This PR adds in checks to the CREATE and UDPATE routes for collections to ensure that only valid ids of pipelines will be passed in to the config to create / update the collection.

## References

Issue: #523 
