### PR TITLE
fix: Revert Skip builds when commit message includes [skip ci]

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -398,12 +398,6 @@ exports.register = (server, options, next) => {
 
                     request.log(['webhook', hookId], `Received event type ${eventType}`);
 
-                    if (/\[(skip ci|ci skip)\]/.test(parsed.lastCommitMessage)) {
-                        request.log(['webhook', hookId], 'Skipping due to the commit message');
-
-                        return reply().code(204);
-                    }
-
                     if (eventType === 'pr') {
                         return pullRequestEvent(pluginOptions, request, reply, parsed);
                     }

--- a/test/plugins/webhooks/index.test.js
+++ b/test/plugins/webhooks/index.test.js
@@ -301,15 +301,6 @@ describe('github plugin test', () => {
                 });
             });
 
-            it('returns 204 when "[skip ci]"', () => {
-                parsed.lastCommitMessage = 'foo[skip ci]bar';
-                pipelineFactoryMock.scm.parseHook.withArgs(reqHeaders, payload).resolves(parsed);
-
-                return server.inject(options).then((reply) => {
-                    assert.equal(reply.statusCode, 204);
-                });
-            });
-
             it('returns 500 when failed', () => {
                 buildFactoryMock.create.rejects(new Error('Failed to start'));
 


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#649
It's breaking functional tests