### PR TITLE
fix(collections): Fix bug in CREATE and UPDATE collections

### DIFF
--- a/plugins/collections/create.js
+++ b/plugins/collections/create.js
@@ -36,7 +36,8 @@ module.exports = () => ({
                     if (request.payload.pipelineIds) {
                         const { pipelineFactory } = request.server.app;
 
-                        return Promise.all(request.payload.pipelineIds.map(pipelineFactory.get))
+                        return Promise.all(request.payload.pipelineIds.map(pipelineId =>
+                            pipelineFactory.get(pipelineId)))
                         .then((pipelines) => {
                             // If the pipeline exists, then add it to pipelineIds
                             config.pipelineIds = pipelines.filter(pipeline =>

--- a/plugins/collections/update.js
+++ b/plugins/collections/update.js
@@ -48,7 +48,8 @@ module.exports = () => ({
                 if (request.payload.pipelineIds) {
                     const { pipelineFactory } = request.server.app;
 
-                    return Promise.all(request.payload.pipelineIds.map(pipelineFactory.get))
+                    return Promise.all(request.payload.pipelineIds.map(pipelineId =>
+                        pipelineFactory.get(pipelineId)))
                     .then((pipelines) => {
                         // If the pipeline exists, then add its id to the array of pipelineIds
                         // in oldCollection

--- a/test/plugins/collections.test.js
+++ b/test/plugins/collections.test.js
@@ -228,6 +228,17 @@ describe('collection plugin test', () => {
             });
         });
 
+        it('makes sure that pipelineFactory calls the pipelineFactory get method', () => {
+            pipelineFactoryMock.get = sinon.spy();
+
+            return server.inject(options)
+            .then(() => {
+                // This makes sure that the object that calls the get method of pipelineFactory
+                // is infact pipelineFactory, so the `this` context is set to pipelineFactory.
+                assert.isTrue(pipelineFactoryMock.get.calledOn(pipelineFactoryMock));
+            });
+        });
+
         it('returns 404 when the user does not exist', () => {
             userFactoryMock.get.withArgs({ username }).resolves(null);
 
@@ -402,6 +413,17 @@ describe('collection plugin test', () => {
                 assert.deepEqual(reply.result, expectedOutput);
                 assert.calledOnce(collectionMock.update);
                 assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('makes sure that pipelineFactory calls the pipelineFactory get method', () => {
+            pipelineFactoryMock.get = sinon.spy();
+
+            return server.inject(options)
+            .then(() => {
+                // This makes sure that the object that calls the get method of pipelineFactory
+                // is infact pipelineFactory, so the `this` context is set to pipelineFactory.
+                assert.isTrue(pipelineFactoryMock.get.calledOn(pipelineFactoryMock));
             });
         });
 


### PR DESCRIPTION
## Context

Currently, when the API route is calling the `pipelineFactory.get` method, the calling object is the map function which causes an error:
![image](https://user-images.githubusercontent.com/12389411/28841467-34af6f84-76af-11e7-8801-c70a354ed094.png)


## Objective

This PR makes sure that the calling object for the `pipelineFactory.get` method is `pipelineFactory`

## References

Issue: #523 
