### PR TITLE
[523]fix: define feature scenarios for collections

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -1,0 +1,59 @@
+@collections
+Feature: User Collections
+
+    Users want to be able to view a set of pipelines that they most care about. These
+    pipelines can be grouped into collections that these users own and maintain.
+
+    Collections can be modified to include and exclude pipelines over their lifetimes.
+    These collections can also be shared between users, such as teammates sharing
+    collections they're responsible for.
+
+    Rules:
+        - Collections are unique by name and owner
+
+    Background:
+        Given an existing repository with these users and permissions:
+            | name          | permission  |
+            | calvin        | admin       |
+#            | miss wormwood | no access   |
+        And an existing pipeline with that repository
+
+    @ignore
+    Scenario: Create New Collection
+        And "calvin" is logged in
+        When they create a new collection "myCollection" with that pipeline
+        Then they can see that collection
+        And the collection contains that pipeline
+
+    @ignore
+    Scenario: Update Existing Collection
+        And "calvin" is logged in
+        When they create a new collection "myCollection"
+        Then they can see that collection
+        And the collection is empty
+        When they update the collection "myCollection" with that pipeline
+        Then they can see that collection
+        And the collection contains that pipeline
+
+    @ignore
+    Scenario: Listing A User's Collection
+        And "calvin" is logged in
+        And they have a collection "myCollection"
+        And they have a collection "anotherCollection"
+        When they fetch all their collections
+        Then they can see those collections
+
+    @ignore
+    Scenario: Deleting A Collection
+        And "calvin" is logged in
+        And they have a collection "myCollection"
+        When they delete that collection
+        Then that collection no longer exists
+        And that pipeline still exists
+
+    @ignore
+    Scenario: Collections Are Unique
+        And "calvin" is logged in
+        And they have a collection "myCollection"
+        When they create a new collection "myCollection"
+        Then they receive an error regarding unique collections


### PR DESCRIPTION
## Context

The team started working on the [homepage favorites](https://github.com/screwdriver-cd/screwdriver/issues/523) prior to creating a cucumber-js feature file. This feature file helps define scenarios that a user is expected to interact with the Screwdriver API and assert that the results are sane.

## Objective

Create a feature file for collections, asserting that the user can use the API in order to create, list, update, and delete collections.

## References

* Issue #523 

EDIT1: fixed link
