### PR TITLE
feat(queue): add config for queue

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -96,6 +96,14 @@ executor:
         launchVersion: LAUNCH_VERSION
         # Prefix to the container
         prefix: EXECUTOR_PREFIX
+    queue:
+        options:
+          # Configuration of the redis instance containing resque
+            redisConnection:
+                host: QUEUE_REDIS_HOST
+                port: QUEUE_REDIS_PORT
+                password: QUEUE_REDIS_PASSWORD
+                database: QUEUE_REDIS_DATABASE
 
 scms:
     github:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -120,6 +120,14 @@ executor:
 
         # Launcher container tag to use
         launchVersion: stable
+    queue:
+      options:
+        # Configuration of the redis instance containing resque
+        redisConnection:
+          host: "127.0.0.1"
+          port: 9999
+          password: "THIS-IS-A-PASSWORD"
+          database: 0
 
 scms:
     github:


### PR DESCRIPTION
## Context

The executor queue needs to be able to talk to redis in order to put jobs where the workers can see them.

## Objective

This PR adds configuration options to pass in information about redis.

## References

[Executor Queue](https://github.com/screwdriver-cd/executor-queue)
https://github.com/screwdriver-cd/screwdriver/issues/431
[ioredis (package we're using to connect to redis)](https://github.com/luin/ioredis/blob/master/API.md#new_Redis_new)
