### PR TITLE
fix(tokens): use pbkdf2 to store tokens

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -103,7 +103,8 @@ const secretFactory = Models.SecretFactory.getInstance({
     password: authConfig.encryptionPassword
 });
 const tokenFactory = Models.TokenFactory.getInstance({
-    datastore
+    datastore,
+    password: authConfig.encryptionPassword
 });
 const eventFactory = Models.EventFactory.getInstance({
     datastore,

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "screwdriver-executor-k8s-vm": "^1.0.0",
     "screwdriver-executor-queue": "^0.1.0",
     "screwdriver-executor-router": "^1.0.0",
-    "screwdriver-models": "^24.0.0",
+    "screwdriver-models": "^24.0.1",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-router": "^1.0.0",
     "screwdriver-scm-github": "^5.0.0",


### PR DESCRIPTION
## Context

After taking a security workshop, I learned that sha256 is not a secure way to store passwords. PBKDF2 is much better, as it takes longer (making it harder to crack).

This new algorithm will invalidate all previously generated tokens, of which there are about 5 on cd.screwdriver.cd (all of which belong to us).

## Objective

This PR pulls in the new `models` package to make use of the more secure password hashing algorithm for tokens.

## References

https://github.com/screwdriver-cd/models/pull/185
