### PR TITLE
Revert "fix(tokens): use pbkdf2 to store tokens"

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -103,8 +103,7 @@ const secretFactory = Models.SecretFactory.getInstance({
     password: authConfig.encryptionPassword
 });
 const tokenFactory = Models.TokenFactory.getInstance({
-    datastore,
-    password: authConfig.encryptionPassword
+    datastore
 });
 const eventFactory = Models.EventFactory.getInstance({
     datastore,

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "screwdriver-executor-k8s-vm": "^1.0.0",
     "screwdriver-executor-queue": "^0.1.0",
     "screwdriver-executor-router": "^1.0.0",
-    "screwdriver-models": "^24.0.1",
+    "screwdriver-models": "^24.0.0",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-router": "^1.0.0",
     "screwdriver-scm-github": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "screwdriver-executor-k8s-vm": "^1.0.0",
     "screwdriver-executor-queue": "^0.1.0",
     "screwdriver-executor-router": "^1.0.0",
-    "screwdriver-models": "^24.0.0",
+    "screwdriver-models": "24.0.0",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-router": "^1.0.0",
     "screwdriver-scm-github": "^5.0.0",


### PR DESCRIPTION
## Context

Missed one change in the `models` that didn't get caught because I also forgot to modify the tests for it. Reverting https://github.com/screwdriver-cd/screwdriver/pull/697 so that the pipeline isn't blocked while I fix things.

Tokens will still be functional after this revert, but will not use the new hashing algorithm yet.

## Objective

Reverts https://github.com/screwdriver-cd/screwdriver/pull/697
