### PR TITLE
fix: read scms config as json

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -106,25 +106,27 @@ executor:
                 database: QUEUE_REDIS_DATABASE
 
 scms:
-    github:
-        plugin: github
-        config:
-            # The client id used for OAuth with github. Look up GitHub OAuth for details
-            # https://developer.github.com/v3/oauth/
-            oauthClientId: SECRET_OAUTH_CLIENT_ID
-            # The client secret used for OAuth with github
-            oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
-            # You can also configure for use with GitHub enterprise
-            gheHost: SCM_GITHUB_GHE_HOST
-            # The username and email used for checkout with github
-            username: SCM_USERNAME
-            email: SCM_EMAIL
-            # Secret to add to GitHub webhooks so that we can validate them
-            secret: WEBHOOK_GITHUB_SECRET
-            # Whether it supports private repo: boolean value.
-            # If true, it will ask for read and write access to public and private repos
-            # https://developer.github.com/v3/oauth/#scopes
-            privateRepo: SCM_PRIVATE_REPO_SUPPORT
+    __name: SCM_SETTINGS
+    __format: json
+    # github:
+    #     plugin: github
+    #     config:
+    #         # The client id used for OAuth with github. Look up GitHub OAuth for details
+    #         # https://developer.github.com/v3/oauth/
+    #         oauthClientId: SECRET_OAUTH_CLIENT_ID
+    #         # The client secret used for OAuth with github
+    #         oauthClientSecret: SECRET_OAUTH_CLIENT_SECRET
+    #         # You can also configure for use with GitHub enterprise
+    #         gheHost: SCM_GITHUB_GHE_HOST
+    #         # The username and email used for checkout with github
+    #         username: SCM_USERNAME
+    #         email: SCM_EMAIL
+    #         # Secret to add to GitHub webhooks so that we can validate them
+    #         secret: WEBHOOK_GITHUB_SECRET
+    #         # Whether it supports private repo: boolean value.
+    #         # If true, it will ask for read and write access to public and private repos
+    #         # https://developer.github.com/v3/oauth/#scopes
+    #         privateRepo: SCM_PRIVATE_REPO_SUPPORT
     # bitbucket:
     #     plugin: bitbucket
     #     config:


### PR DESCRIPTION
We need scms config as json, so that when user wants to have multiple scms, they are not tied to the `github` one we currently have.

They can have multiple scms defined in SCM_SETTINGS.

I have updated beta and prod to have SCM_SETTINGS secret.