### PR TITLE
fix: Remove Github scm from default yaml

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -129,26 +129,26 @@ executor:
           password: "THIS-IS-A-PASSWORD"
           database: 0
 
-scms:
-    github:
-        plugin: github
-        config:
-            # The client id used for OAuth with github. Look up GitHub OAuth for details
-            # https://developer.github.com/v3/oauth/
-            oauthClientId: YOU-PROBABLY-WANT-SOMETHING-HERE
-            # The client secret used for OAuth with github
-            oauthClientSecret: AGAIN-SOMETHING-HERE-IS-USEFUL
-            # You can also configure for use with GitHub enterprise
-            # gheHost: github.screwdriver.cd
-            # The username and email used for checkout with github
-            username: sd-buildbot
-            email: dev-null@screwdriver.cd
-            # Secret to add to GitHub webhooks so that we can validate them
-            secret: SUPER-SECRET-SIGNING-THING
-            # Whether it supports private repo: boolean value.
-            # If true, it will ask for read and write access to public and private repos
-            # https://developer.github.com/v3/oauth/#scopes
-            privateRepo: false
+# scms:
+#     github:
+#         plugin: github
+#         config:
+#             # The client id used for OAuth with github. Look up GitHub OAuth for details
+#             # https://developer.github.com/v3/oauth/
+#             oauthClientId: YOU-PROBABLY-WANT-SOMETHING-HERE
+#             # The client secret used for OAuth with github
+#             oauthClientSecret: AGAIN-SOMETHING-HERE-IS-USEFUL
+#             # You can also configure for use with GitHub enterprise
+#             # gheHost: github.screwdriver.cd
+#             # The username and email used for checkout with github
+#             username: sd-buildbot
+#             email: dev-null@screwdriver.cd
+#             # Secret to add to GitHub webhooks so that we can validate them
+#             secret: SUPER-SECRET-SIGNING-THING
+#             # Whether it supports private repo: boolean value.
+#             # If true, it will ask for read and write access to public and private repos
+#             # https://developer.github.com/v3/oauth/#scopes
+#             privateRepo: false
 #     bitbucket:
 #         plugin: bitbucket
 #         config:


### PR DESCRIPTION
## Context

When a user specifies a different yaml, the default is merged with theirs. This can lead to issues if users have scm preferences that don't involve the default (Github).

## Objective

This PR comments out the default Github scm so that users are not forced to have it.

## References

Related to multiple SCMs.
