### PR TITLE
Fix redis connection

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -102,7 +102,8 @@ executor:
             redisConnection:
                 host: QUEUE_REDIS_HOST
                 port: QUEUE_REDIS_PORT
-                password: QUEUE_REDIS_PASSWORD
+                options:
+                    password: QUEUE_REDIS_PASSWORD
                 database: QUEUE_REDIS_DATABASE
 
 scms:


### PR DESCRIPTION
## Context

The example configuration given for node-redis is incorrect, `password` needs to be inside an `options` object.

## References
https://github.com/screwdriver-cd/queue-worker/pull/14/files