### PR TITLE
fix: Put empty object as default scms

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -129,7 +129,7 @@ executor:
           password: "THIS-IS-A-PASSWORD"
           database: 0
 
-# scms:
+scms: {}
 #     github:
 #         plugin: github
 #         config:


### PR DESCRIPTION
Seeing error after merging https://github.com/screwdriver-cd/screwdriver/pull/704:
```
Error: Configuration property "scms" is not defined
```

This PR is trying to fix that error.