### PR TITLE
fix(config): fix drewfish entry on whitelist

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -46,7 +46,7 @@ auth:
         # Pilots
         - github:aressem
         - github:bjorncs
-        - github: drewfish
+        - github:drewfish
         - github:gjoranv2
         - github:jpcollins
         - github:tonytamsf


### PR DESCRIPTION
## Context

It seems somehow a space got into the whitelist, which was preventing drewfish from logging in.

