### PR TITLE
fix(collections): Bump models version for last event bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "screwdriver-executor-k8s-vm": "^1.0.0",
     "screwdriver-executor-queue": "^1.1.0",
     "screwdriver-executor-router": "^1.0.0",
-    "screwdriver-models": "^25.1.0",
+    "screwdriver-models": "^26.0.2",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-github": "^5.0.0",
     "screwdriver-scm-router": "^1.0.0",


### PR DESCRIPTION
## Context

There was a bug fix merged in [screwdriver-cd/models#193](https://github.com/screwdriver-cd/models/pull/193) where the lastEventId for a pipeline should only be changed if it is a pipeline event and not a PR event. It got released under the new major version (26).


## Objective

This PR bumps the major version for model.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Issue: #523 
Related: [screwdriver-cd/models#193](https://github.com/screwdriver-cd/models/pull/193)