### PR TITLE
feat(tokens): use pbkdf2 to securely store tokens

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -103,7 +103,8 @@ const secretFactory = Models.SecretFactory.getInstance({
     password: authConfig.encryptionPassword
 });
 const tokenFactory = Models.TokenFactory.getInstance({
-    datastore
+    datastore,
+    password: authConfig.encryptionPassword
 });
 const eventFactory = Models.EventFactory.getInstance({
     datastore,

--- a/features/scripts/create-test-user.js
+++ b/features/scripts/create-test-user.js
@@ -62,7 +62,8 @@ function createTestUser() {
         password: authConfig.encryptionPassword
     });
     const tokenFactory = Models.TokenFactory.getInstance({
-        datastore
+        datastore,
+        password: authConfig.encryptionPassword
     });
 
     // Setup datastore and create test user

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "screwdriver-executor-k8s-vm": "^1.0.0",
     "screwdriver-executor-queue": "^1.1.0",
     "screwdriver-executor-router": "^1.0.0",
-    "screwdriver-models": "^25.1.0",
+    "screwdriver-models": "^26.0.2",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-scm-github": "^5.0.0",
     "screwdriver-scm-router": "^1.0.0",


### PR DESCRIPTION
## Context

Tokens were previously hashed with SHA256, which is too fast to be resilient to brute force attacks.

`screwdriver-models@26.0.0` changes how tokens are stored to use PBKDF2, a more secure algorithm. It also takes in a server-side salt.

## Objective

Use PBKDF2 to hash tokens in a more secure manner.

## References

https://github.com/screwdriver-cd/models/pull/191
