### PR TITLE
fix(collections): Fix error in collections functional test

### DIFF
--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -262,7 +262,7 @@ defineSupportCode(({ Before, Given, Then, When, After }) => {
     Then(/^they receive an error regarding unique collections$/, function step() {
         Assert.strictEqual(this.lastResponse.statusCode, 409);
         Assert.strictEqual(this.lastResponse.body.message,
-            'User already owns collection with this name');
+            `Collection already exists with the ID: ${this.firstCollectionId}`);
     });
 
     After('@collections', function hook() {


### PR DESCRIPTION
## Context

In my last PR for functional tests, I had changed the error message generated when a user tries to create a duplicate collection but forgot to update the functional test for it.

## Objective

This PR fixes the functional test that checks to make sure a user cannot create a duplicate collection with the same name.

## References

Previous PR: #731 

Issue: #523 
