### PR TITLE
fix: Fix collection step_definitions

### DIFF
--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -137,7 +137,7 @@ defineSupportCode(({ Before, Given, Then, When, After }) => {
                 .then(() => {
                     const pipelineId = parseInt(this.pipelineId, 10);
 
-                    request({
+                    return request({
                         uri: `${this.instance}/${this.namespace}/collections/` +
                             `${this.firstCollectionId}`,
                         method: 'PUT',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In the step_definitions of collection, a request method does not be returned in 'they update the collection "myCollection" with that pipeline' step. Therefore, sometimes this step finishes before the request method is finished.
Because of this, Update Existing Collection test failed sometimes. (Like [this](https://cd.screwdriver.cd/pipelines/1/builds/10145))

## Objective

I fixed to return the request method.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
