### PR TITLE
fix: regexp dos with hapi-auth-jwt

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "hapi": "^16.4.3",
     "hapi-auth-bearer-token": "^4.3.0",
     "hapi-auth-cookie": "^6.1.1",
-    "hapi-auth-jwt": "^4.0.0",
+    "hapi-auth-jwt2": "^7.3.0",
     "hapi-swagger": "^7.0.0",
     "hoek": "^4.0.1",
     "inert": "^4.0.1",

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -3,7 +3,7 @@
 const authToken = require('hapi-auth-bearer-token');
 const bell = require('bell');
 const sugar = require('hapi-auth-cookie');
-const authjwt = require('hapi-auth-jwt');
+const authjwt = require('hapi-auth-jwt2');
 const crumb = require('crumb');
 const jwt = require('jsonwebtoken');
 const joi = require('joi');
@@ -117,6 +117,11 @@ exports.register = (server, options, next) => {
                 verifyOptions: {
                     algorithms: [ALGORITHM],
                     maxAge: EXPIRES_IN
+                },
+                // This function is run once the Token has been decoded with signature
+                validateFunc(decoded, request, cb) {
+                    // TODO: figure out what to do here
+                    cb(null, true);
                 }
             });
             server.auth.strategy('auth_token', 'bearer-access-token', {

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -145,7 +145,7 @@ describe('auth plugin test', () => {
         });
 
         it('registers the hapi-auth-cookie plugin', () => {
-            assert.isOk(server.registrations['hapi-auth-jwt']);
+            assert.isOk(server.registrations['hapi-auth-jwt2']);
         });
 
         it('registers the auth_token plugin', () => {


### PR DESCRIPTION
Context:
========
`hapi-auth-jwt` requires an old version of jsonwebtoken (5.x), which depends on ms which has a ReDoS vulnerability.

Objective:
----------
Replace `hapi-auth-jwt` with `hapi-auth-jwt2` which is being actively maintained.