### PR TITLE
fix(718): Add ENV variables to disable executor mechanisms

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -36,7 +36,7 @@ const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem },
 const executorConfig = config.get('executor');
 const ExecutorPlugin = require('screwdriver-executor-router');
 const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName) => {
-    if (keyName !== 'plugin') {
+    if (keyName !== 'plugin' && executorConfig[keyName].enabled !== 'false') {
         aggregator.push(Object.assign({
             name: keyName
         }, executorConfig[keyName]));
@@ -44,6 +44,7 @@ const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName)
 
     return aggregator;
 }, []);
+
 const executor = new ExecutorPlugin({
     defaultPlugin: executorConfig.plugin,
     executor: executorPlugins,
@@ -65,9 +66,10 @@ const artifact = new ArtifactPlugin(ecosystem.store);
 const bookends = config.get('bookends');
 const bookend = new Bookend({
     scm,
-    'screwdriver-artifact-bookend': artifact },
-    bookends.setup || [],      // plugins required for the setup- steps
-    bookends.teardown || []    // plugins required for the teardown- steps
+    'screwdriver-artifact-bookend': artifact
+},
+bookends.setup || [], // plugins required for the setup- steps
+bookends.teardown || [] // plugins required for the teardown- steps
 );
 
 // Setup Model Factories

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -61,6 +61,7 @@ executor:
     plugin: EXECUTOR_PLUGIN
     # The NPM module object(s) for the executor plugin(s)
     k8s:
+      enabled: EXECUTOR_K8S_ENABLED
       options:
         kubernetes:
             # The host or IP of the kubernetes cluster
@@ -73,6 +74,7 @@ executor:
         # Prefix to the pod
         prefix: EXECUTOR_PREFIX
     docker:
+      enabled: EXECUTOR_DOCKER_ENABLED
       options:
         # Configuration of Docker
         docker:
@@ -83,6 +85,7 @@ executor:
         # Prefix to the container
         prefix: EXECUTOR_PREFIX
     k8s-vm:
+      enabled: EXECUTOR_K8SVM_ENABLED
       options:
         # Configuration of Docker
         kubernetes:
@@ -97,6 +100,7 @@ executor:
         # Prefix to the container
         prefix: EXECUTOR_PREFIX
     jenkins:
+      enabled: EXECUTOR_JENKINS_ENABLED
       options:
         jenkins:
             host: EXECUTOR_JENKINS_HOST
@@ -126,6 +130,7 @@ executor:
         # Interval to detect the stopped job (seconds)
         cleanupWatchInterval: EXECUTOR_JENKINS_CLEANUP_WATCH_INTERVAL
     queue:
+        enabled: EXECUTOR_QUEUE_ENABLED
         options:
           # Configuration of the redis instance containing resque
             redisConnection:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -89,6 +89,7 @@ executor:
     # Default executor
     plugin: k8s
     k8s:
+      enabled: true
       options:
         kubernetes:
             # The host or IP of the kubernetes cluster
@@ -99,6 +100,7 @@ executor:
         # Container tags to use
         launchVersion: stable
     docker:
+      enabled: true
       options:
         # Dockerode configuration https://github.com/apocas/dockerode#getting-started
         docker: {}
@@ -106,6 +108,7 @@ executor:
         # Container tags to use
         launchVersion: stable
     k8s-vm:
+      enabled: true
       options:
         # Configuration of Docker
         kubernetes:
@@ -125,6 +128,7 @@ executor:
 #             username: screwdriver
 #             password: "WOW-AN-EVEN-MORE-INSECURE-PASSWORD!!!!"
     queue:
+      enabled: true
       options:
         # Configuration of the redis instance containing resque
         redisConnection:

--- a/in-a-box.py
+++ b/in-a-box.py
@@ -37,6 +37,7 @@ services:
             DATASTORE_SEQUELIZE_DIALECT: sqlite
             DATASTORE_SEQUELIZE_STORAGE: /tmp/sd-data/storage.db
             EXECUTOR_PLUGIN: docker
+            EXECUTOR_QUEUE_ENABLED: "false"
             SECRET_WHITELIST: "[]"
             EXECUTOR_DOCKER_DOCKER: |
                 {


### PR DESCRIPTION
Context:
=========
Running screwdriver api locally via sd-in-a-box or `npm start` will result in errors like the following:
```
api_1    | [ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:9999
api_1    |     at Object.exports._errnoException (util.js:1020:11)
api_1    |     at exports._exceptionWithHostPort (util.js:1043:20)
api_1    |     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1086:14)
```

Objective:
----------
Allow executors to not be loaded by providing an environment variable for each executor. When the value of the env variable is false, the executor will not be loaded.
Example:
```
export EXECUTOR_QUEUE_ENABLED="false"
```
This allows the queue configuration to be easily disabled even in the docker container.

Addresses: https://github.com/screwdriver-cd/screwdriver/issues/718