### PR TITLE
feat: ignore commits made by certain users (bots)

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -190,6 +190,10 @@ scms:
 webhooks:
     # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
     username: SCM_USERNAME
+    # Ignore commits made by these users
+    ignoreCommitsBy:
+        __name: IGNORE_COMMITS_BY
+        __format: json
 
 bookends:
     # List of module names, or objects { name, config } for instantiation to use in sd-setup

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -180,6 +180,8 @@ scms: {}
 webhooks:
     # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
     username: sd-buildbot
+    # Ignore commits made by these users
+    ignoreCommitsBy: []
 
 bookends:
     # Plugins for build setup

--- a/test/plugins/webhooks/index.test.js
+++ b/test/plugins/webhooks/index.test.js
@@ -76,7 +76,8 @@ describe('github plugin test', () => {
         server.register([{
             register: plugin,
             options: {
-                username: 'sd-buildbot'
+                username: 'sd-buildbot',
+                ignoreCommitsBy: ['batman', 'superman']
             }
         }], (err) => {
             server.app.buildFactory.apiUri = apiUri;
@@ -317,6 +318,14 @@ describe('github plugin test', () => {
                 });
             });
 
+            it('returns 204 when commits made by ignoreCommitsBy user', () => {
+                parsed.username = 'batman';
+
+                return server.inject(options).then((reply) => {
+                    assert.equal(reply.statusCode, 204);
+                });
+            });
+
             it('returns 500 when failed', () => {
                 buildFactoryMock.create.rejects(new Error('Failed to start'));
 
@@ -369,6 +378,15 @@ describe('github plugin test', () => {
                 pipelineFactoryMock.scm.parseHook.withArgs(reqHeaders, payload).resolves(parsed);
                 pipelineFactoryMock.get.resolves(null);
                 options.payload = testPayloadOpen;
+
+                return server.inject(options).then((reply) => {
+                    assert.equal(reply.statusCode, 204);
+                });
+            });
+
+            it('returns 204 when commits made by ignoreCommitsBy user', () => {
+                parsed.username = 'batman';
+                pipelineFactoryMock.scm.parseHook.withArgs(reqHeaders, payload).resolves(parsed);
 
                 return server.inject(options).then((reply) => {
                     assert.equal(reply.statusCode, 204);


### PR DESCRIPTION
## Context
Some projects would have bots commit back to the repo, for example, to update a package.json, etc. This will cause builds to run indefinitely. 

This PR allows ignoring commits made by certain users