### PR TITLE
fix: Fix up functional test README and var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ Fork `functional-*` repositories to your organization from [screwdriver-cd-test]
 Add `.func_config` to the root of the Screwdriver API folder with your username, github token, access key, host, and organization for test:
 ```
 GIT_TOKEN=YOUR-GITHUB-TOKEN
-API_TOKEN=YOUR-API-TOKEN
-SD_API=YOUR-LOCAL-API-HOST
-TEST_ORG=OUR-TEST-ORGANIZATION
+SD_API_TOKEN=YOUR-SD-API-TOKEN
+SD_API_HOST=YOUR-SD-API-HOST
+SD_API_PROTOCOL=PROTOCOL-FOR-SD-API // e.g.PROTOCOL=http; by default it is https
+TEST_ORG=YOUR-TEST-ORGANIZATION
 TEST_USERNAME=YOUR-GITHUB-USERNAME
-PROTOCOL=PROTOCOL-FOR-SD-API // e.g.PROTOCOL=http; by default it is https
-
+TEST_SCM_CONTEXT=YOUR-TEST-SCM-CONTEXT // e.g.TEST_SCM_CONTEXT=bitbucket; by default it is github
 ```
 
 #### With environment variables
@@ -152,10 +152,13 @@ PROTOCOL=PROTOCOL-FOR-SD-API // e.g.PROTOCOL=http; by default it is https
 Set the environment variables:
 
 ```bash
-$ export API_TOKEN=YOUR-API-TOKEN
-$ export SD_API=YOUR-LOCAL-API-HOST
+$ export GIT_TOKEN=YOUR-GITHUB-TOKEN
+$ export SD_API_TOKEN=YOUR-SD-API-TOKEN
+$ export SD_API_HOST=YOUR-SD-API-HOST
+$ export SD_API_PROTOCOL=PROTOCOL-FOR-SD-API
 $ export TEST_ORG=YOUR-TEST-ORGANIZATION
-$ export PROTOCOL=PROTOCAL-FOR-SD-API
+$ export TEST_USERNAME=YOUR-GITHUB-USERNAME
+$ export TEST_SCM_CONTEXT=YOUR-TEST-SCM-CONTEXT
 ```
 
 Then run the cucumber tests:

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -95,12 +95,12 @@ function CustomWorld({ attach, parameters }) {
     this.parameters = parameters;
     env(path.join(__dirname, '../../.func_config'), { raise: false });
     this.gitToken = process.env.GIT_TOKEN;
-    this.apiToken = process.env.API_TOKEN;
-    this.protocol = process.env.PROTOCOL || 'https';
-    this.instance = `${this.protocol}://${process.env.SD_API}`;
+    this.apiToken = process.env.SD_API_TOKEN;
+    this.protocol = process.env.SD_API_PROTOCOL || 'https';
+    this.instance = `${this.protocol}://${process.env.SD_API_HOST}`;
     this.testOrg = process.env.TEST_ORG;
     this.username = process.env.TEST_USERNAME;
-    this.scmContext = process.env.TEST_SCM_CONTEXT;
+    this.scmContext = process.env.TEST_SCM_CONTEXT || 'github';
     this.namespace = 'v4';
     this.promiseToWait = time => promiseToWait(time);
     this.getJwt = apiToken =>


### PR DESCRIPTION
## Context

The README was missing a couple environment variables needed for local functional testing. The environment variable names were also kind of vague.

## Objective

This PR updates the README with functional testing changes and modifies the environment variables to be a little more easy to understand.
