### PR TITLE
feat(725): remove executor router from api

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -34,22 +34,11 @@ const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem },
 
 // Setup Executor
 const executorConfig = config.get('executor');
-const ExecutorPlugin = require('screwdriver-executor-router');
-const executorPlugins = Object.keys(executorConfig).reduce((aggregator, keyName) => {
-    if (keyName !== 'plugin' && executorConfig[keyName].enabled !== 'false') {
-        aggregator.push(Object.assign({
-            name: keyName
-        }, executorConfig[keyName]));
-    }
-
-    return aggregator;
-}, []);
-
-const executor = new ExecutorPlugin({
-    defaultPlugin: executorConfig.plugin,
-    executor: executorPlugins,
-    ecosystem
-});
+const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
+const executor = new ExecutorPlugin(Object.assign(
+    hoek.clone(ecosystem),
+    executorConfig[executorConfig.plugin].options
+));
 
 // Source Code Plugin
 const scmConfig = { scms: config.get('scms') };


### PR DESCRIPTION
Context:
========
We want the queue workers to be reponsible for routing to the correct executor instead of the API.

Objective:
----------
Make the api executor configuration setup the default executor directly and remove the executor router. This will cause the job's executor annotations to be ignored until they are processed by queue workers. This should not have any effect on api installations that are using a default executor that is not queue, e.g. sd-in-a-box.