### PR TITLE
feat: support new workflow in push event

### DIFF
--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -618,6 +618,22 @@ describe('auth plugin test', () => {
                     assert.notOk(reply.result.token, 'Token not returned');
                 })
             ));
+
+            it('catch err if buildFactory throws err', () => {
+                buildFactoryMock.get.rejects(new Error('build not found'));
+
+                server.inject({
+                    url: '/auth/token/474ee9ee179b0ecf0bc27408079a0b15eda4c99d',
+                    credentials: {
+                        username: 'batman',
+                        scmContext,
+                        scope: ['user', 'admin']
+                    }
+                }).then((reply) => {
+                    assert.equal(reply.statusCode, 500, 'build not found');
+                    assert.notOk(reply.result.token, 'Token not returned');
+                });
+            });
         });
     });
 


### PR DESCRIPTION
Support new workflow in `push` event:

If the pipeline has `workflow: undefined` then it's using the new workflow:
- Create new event with `workflow` field as `undefined` for now, will do `source, destination` later
- Start all jobs with `requires: '~commit' `

Added a test for `auth/token.js` to make coveralls happy!


Related to https://github.com/screwdriver-cd/screwdriver/issues/723
Blocked by: https://github.com/screwdriver-cd/models/pull/195