### PR TITLE
fix: fix validator tests with workflowGraph

### DIFF
--- a/test/plugins/data/validator.output.json
+++ b/test/plugins/data/validator.output.json
@@ -70,5 +70,18 @@
     "workflow": [
         "main",
         "publish"
-    ]
+    ],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "main" },
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" }
+        ]
+    }
 }


### PR DESCRIPTION
Fix broken tests:

Now we generate `workflowGraph` in the parsed config. 