### PR TITLE
feat: trigger next job using workflow parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "screwdriver-scm-github": "^5.0.0",
     "screwdriver-scm-router": "^1.0.0",
     "screwdriver-template-validator": "^3.0.0",
+    "screwdriver-workflow-parser": "^1.1.1",
     "tinytim": "^0.1.1",
     "verror": "^1.6.1",
     "vision": "^4.1.0",

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -208,6 +208,17 @@ describe('build plugin test', () => {
                 id: pipelineId,
                 scmUri,
                 scmRepo,
+                workflowGraph: {
+                    nodes: [
+                        { name: '~pr' },
+                        { name: '~commit' },
+                        { name: 'main' }
+                    ],
+                    edges: [
+                        { src: '~pr', dest: 'main' },
+                        { src: '~commit', dest: 'main' }
+                    ]
+                },
                 sync: sinon.stub().resolves(),
                 syncPR: sinon.stub().resolves()
             };
@@ -548,7 +559,15 @@ describe('build plugin test', () => {
                         state: 'ENABLED'
                     };
 
-                    pipelineMock.workflow = ['main', 'publish', 'nerf_fight'];
+                    pipelineMock.workflowGraph = {
+                        nodes: [
+                            { name: 'main' },
+                            { name: 'publish' }
+                        ],
+                        edges: [
+                            { src: 'main', dest: 'publish' }
+                        ]
+                    };
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'publish' })
                         .resolves(publishJobMock);
                     buildMock.eventId = 'bbf22a3808c19dc50777258a253805b14fb3ad8b';
@@ -568,28 +587,7 @@ describe('build plugin test', () => {
                     });
                 });
 
-                it('skips triggering if the workflow is undefined', () => {
-                    const username = id;
-                    const status = 'SUCCESS';
-                    const options = {
-                        method: 'PUT',
-                        url: `/builds/${id}`,
-                        credentials: {
-                            username,
-                            scope: ['build']
-                        },
-                        payload: {
-                            status
-                        }
-                    };
-
-                    return server.inject(options).then((reply) => {
-                        assert.equal(reply.statusCode, 200);
-                        assert.notCalled(buildFactoryMock.create);
-                    });
-                });
-
-                it('skips triggering if the job is last in the workflow', () => {
+                it('skips triggering if there is no nextJobs ', () => {
                     const status = 'SUCCESS';
                     const options = {
                         method: 'PUT',
@@ -602,8 +600,6 @@ describe('build plugin test', () => {
                             status
                         }
                     };
-
-                    pipelineMock.workflow = ['main'];
 
                     return server.inject(options).then((reply) => {
                         assert.equal(reply.statusCode, 200);
@@ -626,8 +622,6 @@ describe('build plugin test', () => {
                     };
 
                     jobMock.name = 'PR-15';
-
-                    pipelineMock.workflow = ['main', 'publish'];
 
                     return server.inject(options).then((reply) => {
                         assert.equal(reply.statusCode, 200);
@@ -659,7 +653,15 @@ describe('build plugin test', () => {
                         state: 'DISABLED'
                     };
 
-                    pipelineMock.workflow = ['main', 'publish', 'nerf_fight'];
+                    pipelineMock.workflowGraph = {
+                        nodes: [
+                            { name: 'main' },
+                            { name: 'publish' }
+                        ],
+                        edges: [
+                            { src: 'main', dest: 'publish' }
+                        ]
+                    };
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'publish' })
                         .resolves(publishJobMock);
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -85,6 +85,7 @@ describe('build plugin test', () => {
             list: sinon.stub()
         };
         eventFactoryMock = {
+            get: sinon.stub(),
             create: sinon.stub()
         };
         secretAccessMock = sinon.stub().resolves(false);
@@ -192,6 +193,7 @@ describe('build plugin test', () => {
         };
         let buildMock;
         let pipelineMock;
+        let eventMock;
 
         beforeEach(() => {
             testBuild.status = 'QUEUED';
@@ -208,6 +210,13 @@ describe('build plugin test', () => {
                 id: pipelineId,
                 scmUri,
                 scmRepo,
+                sync: sinon.stub().resolves(),
+                syncPR: sinon.stub().resolves()
+            };
+
+            eventMock = {
+                id: 123,
+                pipelineId,
                 workflowGraph: {
                     nodes: [
                         { name: '~pr' },
@@ -218,10 +227,10 @@ describe('build plugin test', () => {
                         { src: '~pr', dest: 'main' },
                         { src: '~commit', dest: 'main' }
                     ]
-                },
-                sync: sinon.stub().resolves(),
-                syncPR: sinon.stub().resolves()
+                }
             };
+
+            eventFactoryMock.get.resolves(eventMock);
         });
 
         it('emits event buid_status', () => {
@@ -559,7 +568,7 @@ describe('build plugin test', () => {
                         state: 'ENABLED'
                     };
 
-                    pipelineMock.workflowGraph = {
+                    eventMock.workflowGraph = {
                         nodes: [
                             { name: 'main' },
                             { name: 'publish' }
@@ -653,7 +662,7 @@ describe('build plugin test', () => {
                         state: 'DISABLED'
                     };
 
-                    pipelineMock.workflowGraph = {
+                    eventMock.workflowGraph = {
                         nodes: [
                             { name: 'main' },
                             { name: 'publish' }


### PR DESCRIPTION
- Trigger next job using workflowGraph instead of workflow

When a build tries to update its status with `PUT /builds`, the pipeline must synced already and has the `workflowGraph` field. So this change is backward compatible and will work for both legacy and new config.

Will switch to user `pub-sub` to handle triggers in next pass.

Related to ttps://github.com/screwdriver-cd/screwdriver/issues/723

