### PR TITLE
fix: Update functional test with new PR job name

### DIFF
--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -46,7 +46,7 @@ function findBuilds(config) {
             let result = [];
 
             if (pullRequestNumber) {
-                result = jobData.filter(job => job.name === `PR-${pullRequestNumber}`);
+                result = jobData.filter(job => job.name.startsWith(`PR-${pullRequestNumber}`));
             } else {
                 result = jobData.filter(job => job.name === 'main');
             }


### PR DESCRIPTION
## Context

The current functional git flow tests are failing because they are hardcoded to look for job name `PR-number`. 

## Objective

This PR changes the function to look for job names that start with `PR-number`.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/723