### PR TITLE
fix: pass ecosystem vars properly to executors

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -36,7 +36,7 @@ const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem },
 const executorConfig = config.get('executor');
 const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
 const executor = new ExecutorPlugin(Object.assign(
-    hoek.clone(ecosystem),
+    { ecosystem: hoek.clone(ecosystem) },
     executorConfig[executorConfig.plugin].options
 ));
 


### PR DESCRIPTION
Context:
========
The docker executor (and likely others) require data from the api ecosystem when setting up

Objective:
----------
Properly pass ecosystem config object into executor.