### PR TITLE
fix:need to pass in sha for both pr and commit

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -69,10 +69,11 @@ module.exports = () => ({
                             // Get commit sha
                             return scm.getCommitSha(scmConfig)
                                 .then((sha) => {
+                                    payload.sha = sha;
+
                                     // For PRs
                                     if (prNum) {
                                         payload.prNum = prNum;
-                                        payload.sha = sha; // pass sha to payload if it's a PR
                                         payload.type = 'pr';
 
                                         return scm.getPrInfo(scmConfig);

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -232,6 +232,7 @@ describe('event plugin test', () => {
                 pipelineId,
                 scmContext,
                 startFrom: '~commit',
+                sha: '58393af682d61de87789fb4961645c42180cec5a',
                 type: 'pipeline',
                 username
             };
@@ -261,7 +262,6 @@ describe('event plugin test', () => {
             eventConfig.startFrom = 'PR-1:main';
             eventConfig.prNum = '1';
             eventConfig.prRef = 'prref';
-            eventConfig.sha = '58393af682d61de87789fb4961645c42180cec5a';
             eventConfig.type = 'pr';
             options.payload.startFrom = 'PR-1:main';
 


### PR DESCRIPTION
`sha` is needed no matter is PR or not.

https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/builds/create.js#L81