### PR TITLE
fix: Do not set PR to DISABLED when PR is closed

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -91,7 +91,6 @@ function pullRequestClosed(options, request, reply) {
     const updatePRJobs = (job => stopJob(job)
         .then(() => request.log(['webhook', hookId, job.id], `${job.name} stopped`))
         .then(() => {
-            job.state = 'DISABLED';
             job.archived = true;
 
             return job.update();

--- a/test/plugins/webhooks/index.test.js
+++ b/test/plugins/webhooks/index.test.js
@@ -615,7 +615,7 @@ describe('github plugin test', () => {
                         assert.equal(reply.statusCode, 200);
                         assert.calledOnce(pipelineMock.sync);
                         assert.calledOnce(jobMock.update);
-                        assert.strictEqual(jobMock.state, 'DISABLED');
+                        assert.strictEqual(jobMock.state, 'ENABLED');
                         assert.isTrue(jobMock.archived);
                     })
                 );
@@ -634,7 +634,7 @@ describe('github plugin test', () => {
                         assert.equal(reply.statusCode, 500);
                         assert.calledOnce(pipelineMock.sync);
                         assert.calledOnce(jobMock.update);
-                        assert.strictEqual(jobMock.state, 'DISABLED');
+                        assert.strictEqual(jobMock.state, 'ENABLED');
                     });
                 });
             });


### PR DESCRIPTION
## Context

There was a bug introduced when we made changes to the workflow that sets a closed PR to DISABLED when a PR is closed. Since we never explicitly set the PR back to `ENABLED`, subsequently run PRs will fail if they are reopened.

## Objective

This PR does not set the PR job to `DISABLED` when a PR is closed.

## References
Related to https://github.com/screwdriver-cd/screwdriver/pull/756
