### PR TITLE
fix: increase timeout for sd-step functional test

### DIFF
--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -117,7 +117,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
         });
     });
 
-    Then(/^(.*) package is available via sd-step$/, { timeout: TIMEOUT }, function step(pkg) {
+    Then(/^(.*) package is available via sd-step$/, { timeout: 300 * 1000 }, function step(pkg) {
         return this.waitForBuild(this.buildId).then((response) => {
             Assert.equal(response.statusCode, 200);
             Assert.equal(response.body.status, 'SUCCESS');


### PR DESCRIPTION
The build actually passed https://beta.cd.screwdriver.cd/pipelines/375 but it just took a bit longer.
Bump the timeout to make the pipeline pass.

https://cd.screwdriver.cd/pipelines/1/builds/12495

