### PR TITLE
fix: use environment variable on github.js

### DIFF
--- a/features/support/github.js
+++ b/features/support/github.js
@@ -3,7 +3,8 @@
 const Github = require('github');
 const github = new Github({
     host: process.env.TEST_SCM_HOSTNAME || 'api.github.com',
-    pathPrefix: process.env.TEST_SCM_HOSTNAME ? '/api/v3' : ''
+    pathPrefix: process.env.TEST_SCM_HOSTNAME ? '/api/v3' : '',
+    protocol: 'https'
 });
 
 const MAX_CONTENT_LENGTH = 354;

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const Github = require('github');
-const github = new Github();
+const github = new Github({
+    host: process.env.TEST_SCM_HOSTNAME || 'api.github.com',
+    pathPrefix: process.env.TEST_SCM_HOSTNAME ? '/api/v3' : ''
+});
 
 const MAX_CONTENT_LENGTH = 354;
 const MAX_FILENAME_LENGTH = 17;


### PR DESCRIPTION
## Context
In addition https://github.com/screwdriver-cd/screwdriver/pull/784, [node-github](https://github.com/octokit/node-github) should be also set configuration for using GHE.

## Objective
This PR adds configurations when create Github constractor. If `TEST_SCM_HOSTNAME` is not set, default values are used.

## References
https://github.com/octokit/node-github
