### PR TITLE
fix(775): add module field to notification modules.

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -67,13 +67,14 @@ function registerResourcePlugins(server, config, callback) {
 /**
  * Require notification plugin
  * @method requireNotificationPlugin
- * @param  {Object}    config           Configuration object for notification plugins.
- * @param  {String}    plugin           Notification plugin name.
- * @return {Function}                   Function of notifier
+ * @param  {Object}    config                         Configuration object for notification plugins.
+ * @param  {String}    config.scopedPackage           Package name with scope (optional).
+ * @param  {String}    plugin                         Notification plugin name.
+ * @return {Function}                                 Function of notifier
  */
 function requireNotificationPlugin(config, plugin) {
-    if (config[plugin].module) {
-        return require(config[plugin].module);
+    if (config.scopedPackage) {
+        return require(config.scopedPackage);
     }
 
     return require(`screwdriver-notifications-${plugin}`);
@@ -96,7 +97,7 @@ module.exports = (server, config) => (
         const notificationConfig = config.notifications || {};
 
         return Object.keys(notificationConfig).forEach((plugin) => {
-            const Plugin = requireNotificationPlugin(notificationConfig, plugin);
+            const Plugin = requireNotificationPlugin(notificationConfig[plugin], plugin);
             let notificationPlugin;
 
             if (notificationConfig[plugin].config) {

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -65,20 +65,6 @@ function registerResourcePlugins(server, config, callback) {
 }
 
 /**
- * Revise npm packages's scope name
- * @method reviseScope
- * @param  {String} scope           Name of npm package's scope
- * @return {String}                 Revised scope name
- */
-function reviseScope(scope) {
-    if (/^[@].*/.test(scope)) {
-        return scope;
-    }
-
-    return `@${scope}`;
-}
-
-/**
  * Require notification plugin
  * @method requireNotificationPlugin
  * @param  {Object}    config           Configuration object for notification plugins.
@@ -86,8 +72,8 @@ function reviseScope(scope) {
  * @return {Function}                   Function of notifier
  */
 function requireNotificationPlugin(config, plugin) {
-    if (config[plugin].scope) {
-        return require(`${reviseScope(config[plugin].scope)}/screwdriver-notifications-${plugin}`);
+    if (config[plugin].module) {
+        return require(config[plugin].module);
     }
 
     return require(`screwdriver-notifications-${plugin}`);
@@ -111,7 +97,13 @@ module.exports = (server, config) => (
 
         return Object.keys(notificationConfig).forEach((plugin) => {
             const Plugin = requireNotificationPlugin(notificationConfig, plugin);
-            const notificationPlugin = new Plugin(notificationConfig[plugin]);
+            let notificationPlugin;
+
+            if (notificationConfig[plugin].config) {
+                notificationPlugin = new Plugin(notificationConfig[plugin].config);
+            } else {
+                notificationPlugin = new Plugin(notificationConfig[plugin]);
+            }
 
             notificationPlugin.events.forEach((event) => {
                 server.on(event, buildData => notificationPlugin.notify(buildData));

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -149,13 +149,13 @@ describe('Register Unit Test Case', () => {
                     config: {
                         foo: 'abc'
                     },
-                    module: '@module/screwdriver-notifications-email'
+                    scopedPackage: '@module/screwdriver-notifications-email'
                 },
                 slack: {
                     config: {
                         baz: 'def'
                     },
-                    module: '@module/screwdriver-notifications-slack'
+                    scopedPackage: '@module/screwdriver-notifications-slack'
                 }
             }
         };

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -146,12 +146,16 @@ describe('Register Unit Test Case', () => {
         const newConfig = {
             notifications: {
                 email: {
-                    foo: 'abc',
-                    scope: 'module'
+                    config: {
+                        foo: 'abc'
+                    },
+                    module: '@module/screwdriver-notifications-email'
                 },
                 slack: {
-                    baz: 'def',
-                    scope: '@module'
+                    config: {
+                        baz: 'def'
+                    },
+                    module: '@module/screwdriver-notifications-slack'
                 }
             }
         };


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/screwdriver/pull/772 enabled to use scoped packages for notification modules. But when scope is set, validation error is happened. 
I think we should not fix all notification modules. So this PR changes notifications schema.

## Objective
New notifications schema is like below:
```
email:
  config:
    host: foo
    port: bar
    from: baz
  scopedPackage: '@module/package'
```
If "scopedPackage" is set, the "module" is required. If "config" is set, the contents of "config" is passed to a notification module.
The previous schema is also accepted for backward compatibility.

## References
Related: https://github.com/screwdriver-cd/screwdriver/issues/775
