### PR TITLE
feat: configuration flag for enabling Redis TLS communication

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -138,6 +138,7 @@ executor:
                 port: QUEUE_REDIS_PORT
                 options:
                     password: QUEUE_REDIS_PASSWORD
+                    tls: QUEUE_REDIS_TLS_ENABLED
                 database: QUEUE_REDIS_DATABASE
 
 scms:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -136,7 +136,9 @@ executor:
         redisConnection:
           host: "127.0.0.1"
           port: 9999
-          password: "THIS-IS-A-PASSWORD"
+          options:
+            password: "THIS-IS-A-PASSWORD"
+            tls: false
           database: 0
 
 scms: {}


### PR DESCRIPTION
## Context

Although the Redis server may have a TLS proxy in front of it, the clients must also be configured to communicate to it via TLS. This change allows a configuration flag to be available for cluster maintainers to enable this feature.

This feature does _NOT_ support self-signed certificates.

## Objective

Allow a flag for configuring the Redis client to communicate with the Redis server via TLS.
