### PR TITLE
fix(694): save statusMessage to build during update

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "screwdriver-artifact-bookend": "^1.0.1",
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-config-parser": "^3.13.0",
-    "screwdriver-data-schema": "^18.5.1",
+    "screwdriver-data-schema": "^18.9.0",
     "screwdriver-datastore-sequelize": "^4.0.0",
     "screwdriver-executor-docker": "^2.2.2",
     "screwdriver-executor-k8s": "^10.3.3",

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -21,6 +21,7 @@ module.exports = () => ({
             const buildFactory = request.server.app.buildFactory;
             const id = request.params.id;
             const desiredStatus = request.payload.status;
+            const statusMessage = request.payload.statusMessage;
             const triggerFactory = request.server.app.triggerFactory;
             const username = request.auth.credentials.username;
             const scmContext = request.auth.credentials.scmContext;
@@ -70,6 +71,9 @@ module.exports = () => ({
 
                     // Everyone is able to update the status
                     build.status = desiredStatus;
+                    if (statusMessage) {
+                        build.statusMessage = statusMessage;
+                    }
 
                     // Only trigger next build on success
                     return build.update()

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -461,11 +461,12 @@ describe('build plugin test', () => {
                 eventFactoryMock.scm.getCommitSha.resolves('sha');
             });
 
-            it('saves status and meta updates', () => {
+            it('saves status, statusMessage and meta updates', () => {
                 const meta = {
                     foo: 'bar'
                 };
                 const status = 'SUCCESS';
+                const statusMessage = 'Oh the build passed';
                 const options = {
                     method: 'PUT',
                     url: `/builds/${id}`,
@@ -475,7 +476,8 @@ describe('build plugin test', () => {
                     },
                     payload: {
                         meta,
-                        status
+                        status,
+                        statusMessage
                     }
                 };
 
@@ -485,6 +487,7 @@ describe('build plugin test', () => {
                     assert.calledOnce(buildMock.update);
                     assert.strictEqual(buildMock.status, status);
                     assert.deepEqual(buildMock.meta, meta);
+                    assert.deepEqual(buildMock.statusMessage, statusMessage);
                     assert.isDefined(buildMock.endTime);
                 });
             });


### PR DESCRIPTION
save statusMessage to build during update if there is one

Related to https://github.com/screwdriver-cd/screwdriver/issues/694
https://github.com/screwdriver-cd/data-schema/pull/194 merged