### PR TITLE
feat: allow SSL/TLS configuration for datastore connection

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -56,6 +56,10 @@ datastore:
         port: DATASTORE_SEQUELIZE_PORT
         # Prefix to the table names
         prefix: DATASTORE_SEQUELIZE_PREFIX
+        # Configure SSL/TLS connection settings
+        ssl:
+          __name: DATASTORE_SEQUELIZE_SSL
+          __format: json
 
 executor:
     plugin: EXECUTOR_PLUGIN

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -86,6 +86,7 @@ datastore:
         dialect: sqlite
         # More arguments here:
         # http://docs.sequelizejs.com/en/latest/api/sequelize/
+        ssl: false
 
 executor:
     # Default executor


### PR DESCRIPTION
## Context

The NPM module `sequelize` allows a configuration object to be passed to the underlying constructor. Assuming the library/dialect we're using supports SSL/TLS connections, this means we can also enable settings for SSL/TLS. For example, Postgres uses the NPM module `pg` which uses SSL configurations passed in.

## Objective

Allow the ability to set SSL/TLS configurations for the database connection.

## References

* https://node-postgres.com/features/ssl
* `sequelize` references to passing SSL configurations
   * https://github.com/sequelize/sequelize/blob/3f5927f5bb47db85f5e0401d5a876f652fef1cd3/docs/migrations.md#dynamic-configuration
   * https://github.com/sequelize/sequelize/blob/4660d0c1c9396624a4799959432c43f9eb1c7ad4/docs/usage.md#options

