### PR TITLE
fix: update scmContext and scmRepo when update pipeline

### DIFF
--- a/test/plugins/data/updatedPipeline.json
+++ b/test/plugins/data/updatedPipeline.json
@@ -1,9 +1,0 @@
-{
-  "id": 123,
-  "scmUri": "github.com:12345:master",
-  "scmContext": "github:github.com",
-  "createTime": "2038-01-19T03:14:08.131Z",
-  "admins": {
-    "d2lam": true
-  }
-}


### PR DESCRIPTION
Fixing this bug: https://github.com/screwdriver-cd/screwdriver/issues/780

**Notes:**
I deleted an assertion because it seems useless:
- `updatedPipeline` is read from `./data/updatedPipeline.json`
- We mock `pipeline.toJson` to return `updatedPipeline`
- We assert `reply.result` (which is what got returned from `pipeline.toJson`) to equal `updatedPipeline`. 

This assertion will always pass since we basically mock and then assert if it's equal to the mock. I'm opened to suggestions on how to test this better. 
