### PR TITLE
fix(771): allow meta to be passed for external triggered

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -70,14 +70,15 @@ exports.register = (server, options, next) => {
     /**
      * Create event for downstream pipeline that need to be rebuilt
      * @method triggerEvent
-     * @param {Object}  config              Configuration object
-     * @param {String}  config.pipelineId   Pipeline to be rebuilt
-     * @param {String}  config.startFrom    Job to be rebuilt
-     * @param {String}  config.causeMessage Caused message, e.g. triggered by 1234(buildId)
-     * @return {Promise}                    Resolves to the newly created event
+     * @param {Object}  config               Configuration object
+     * @param {String}  config.pipelineId    Pipeline to be rebuilt
+     * @param {String}  config.startFrom     Job to be rebuilt
+     * @param {String}  config.causeMessage  Caused message, e.g. triggered by 1234(buildId)
+     * @param {String}  config.parentBuildId ID of the build that triggers this event
+     * @return {Promise}                     Resolves to the newly created event
      */
     server.expose('triggerEvent', (config) => {
-        const { pipelineId, startFrom, causeMessage } = config;
+        const { pipelineId, startFrom, causeMessage, parentBuildId } = config;
         const eventFactory = server.root.app.eventFactory;
         const pipelineFactory = server.root.app.pipelineFactory;
         const userFactory = server.root.app.userFactory;
@@ -87,7 +88,8 @@ exports.register = (server, options, next) => {
             pipelineId,
             startFrom,
             type: 'pipeline',
-            causeMessage
+            causeMessage,
+            parentBuildId
         };
 
         return pipelineFactory.get(pipelineId)

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -113,7 +113,8 @@ module.exports = () => ({
                                     triggerEvent({
                                         pipelineId: parseInt(pipelineId, 10),
                                         startFrom: src,
-                                        causeMessage: `Triggered by build ${username}`
+                                        causeMessage: `Triggered by build ${username}`,
+                                        parentBuildId: build.id
                                     })
                                 )));
                         })))

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -646,6 +646,7 @@ describe('build plugin test', () => {
                         // The first event should group 456:main and 456:second
                         assert.calledTwice(eventFactoryMock.create);
                         assert.calledWith(eventFactoryMock.create.firstCall, {
+                            parentBuildId: 12345,
                             causeMessage: 'Triggered by build 12345',
                             pipelineId: 456,
                             startFrom: src,
@@ -655,6 +656,7 @@ describe('build plugin test', () => {
                             sha: 'sha'
                         });
                         assert.calledWith(eventFactoryMock.create.secondCall, {
+                            parentBuildId: 12345,
                             causeMessage: 'Triggered by build 12345',
                             pipelineId: 789,
                             startFrom: src,


### PR DESCRIPTION
## Context
To allow meta to be passed when triggered by an external pipeline

## Objective
When create an event, also pass in the current build id, this will be the `parentBuildId` to create builds with. 

## References
https://github.com/screwdriver-cd/screwdriver/issues/771