### PR TITLE
Adding Vespa team members for pilot

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -50,6 +50,10 @@ auth:
         - github:tonytamsf
         - github:pranavrc
         - github:awick
+        - github:frodelu
+        - github:mortent
+        - github:bratseth
+        - github:jonmv
     admins:
         - github:FenrirUnbound
         - github:cynthiax


### PR DESCRIPTION
## Context

Hoping to experiment with cd.screwdriver.cd for Vespa open source builds.

## Objective

Preparing to run Vespa open source builds on cd.screwdriver.cd.

@stjohnjohnson : FYI