### PR TITLE
fix: allow to search any build

### DIFF
--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -27,6 +27,7 @@ function promiseToWait(timeToWait) {
  * @param  {String}  config.instance            Screwdriver instance to test against
  * @param  {String}  config.pipelineId          Pipeline ID to find the build in
  * @param  {String}  [config.pullRequestNumber] The PR number associated with build we're looking for
+ * @param  {String}  [config.jobName]           The job name we're looking for
  * @return {Promise}                            A promise that resolves to an array of builds that
  *                                              fulfill the given criteria. If nothing is found, an
  *                                              empty array is returned
@@ -80,6 +81,7 @@ function findBuilds(config) {
  * @param  {String}  [config.pullRequestNumber] The PR number associated with build we're looking for
  * @param  {String}  [config.desiredSha]        The SHA that the build is running against
  * @param  {String}  [config.desiredStatus]     The build status that the build should have
+ * @param  {String}  [config.jobName]           The job name we're looking for
  * @return {Promise}                            A build that fulfills the given criteria
  */
 function searchForBuild(config) {

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -35,6 +35,7 @@ function findBuilds(config) {
     const instance = config.instance;
     const pipelineId = config.pipelineId;
     const pullRequestNumber = config.pullRequestNumber;
+    const jobName = config.jobName;
 
     return request({
         json: true,
@@ -48,7 +49,7 @@ function findBuilds(config) {
             if (pullRequestNumber) {
                 result = jobData.filter(job => job.name.startsWith(`PR-${pullRequestNumber}`));
             } else {
-                result = jobData.filter(job => job.name === 'main');
+                result = jobData.filter(job => job.name === jobName);
             }
 
             if (result.length === 0) {
@@ -87,11 +88,13 @@ function searchForBuild(config) {
     const pullRequestNumber = config.pullRequestNumber;
     const desiredSha = config.desiredSha;
     const desiredStatus = config.desiredStatus;
+    const jobName = config.jobName || 'main';
 
     return findBuilds({
         instance,
         pipelineId,
-        pullRequestNumber
+        pullRequestNumber,
+        jobName
     }).then((buildData) => {
         let result = buildData.body || [];
 


### PR DESCRIPTION
## Context
Now Screwdriver uses new workflow and not to need to use main. But in tests we can't find builds without main. 
Sometime this make it difficult to create new acceptance tests.

## Objective
Add jobName option to searchForBuild and allow user to find any job.
