### PR TITLE
fix: add resources config in executor config

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -73,6 +73,16 @@ executor:
             # The jwt token used for authenticating kubernetes requests
             token: K8S_TOKEN
             jobsNamespace: K8S_JOBS_NAMESPACE
+            # Resources for build pod
+            resources:
+                # Number of cpu cores
+                cpu:
+                    low: K8S_CPU_LOW
+                    high: K8S_CPU_HIGH
+                # Memory in GB
+                memory:
+                    low: K8S_MEMORY_LOW
+                    high: K8S_MEMORY_HIGH
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
         # Prefix to the pod
@@ -99,6 +109,16 @@ executor:
             token: K8S_TOKEN
             jobsNamespace: K8S_JOBS_NAMESPACE
             baseImage: K8S_BASE_IMAGE
+            # Resources for build pod
+            resources:
+                # Number of cpu cores
+                cpu:
+                    low: K8S_CPU_LOW
+                    high: K8S_CPU_HIGH
+                # Memory in GB
+                memory:
+                    low: K8S_MEMORY_LOW
+                    high: K8S_MEMORY_HIGH
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
         # Prefix to the container

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -103,7 +103,16 @@ executor:
             host: kubernetes.default
             # The jwt token used for authenticating kubernetes requests
             # Loaded from /var/run/secrets/kubernetes.io/serviceaccount/token by default
-
+            # Resources for build pod
+            resources:
+                cpu:
+                    # Number of cpu cores
+                    low: 1
+                    high: 6
+                memory:
+                    # Memory in GB
+                    low: 2
+                    high: 12
         # Container tags to use
         launchVersion: stable
     docker:
@@ -123,7 +132,16 @@ executor:
             host: kubernetes.default
             # The jwt token used for authenticating kubernetes requests
             # Loaded from /var/run/secrets/kubernetes.io/serviceaccount/token by default
-
+            # Resources for build pod
+            resources:
+                cpu:
+                    # Number of cpu cores
+                    low: 2
+                    high: 6
+                memory:
+                    # Memory in GB
+                    low: 2
+                    high: 12
         # Launcher container tag to use
         launchVersion: stable
 #     jenkins:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -107,7 +107,7 @@ executor:
             resources:
                 cpu:
                     # Number of cpu cores
-                    low: 1
+                    low: 2
                     high: 6
                 memory:
                     # Memory in GB


### PR DESCRIPTION
Pass in resources config in executor config.
That way we can override the hard coded default value inside the executor plugin.

Waiting for: https://github.com/screwdriver-cd/executor-k8s/pull/68