### PR TITLE
fix: Adding guid to JWT and changing timeout to 2h

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "dependencies": {
-    "aguid": "^2.0.0",
     "async": "^2.0.1",
     "bell": "^8.0.0",
     "boom": "^4.0.0",
@@ -101,6 +100,7 @@
     "screwdriver-template-validator": "^3.0.0",
     "screwdriver-workflow-parser": "^1.1.1",
     "tinytim": "^0.1.1",
+    "uuid": "^3.1.0",
     "verror": "^1.6.1",
     "vision": "^4.1.0",
     "winston": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "dependencies": {
+    "aguid": "^2.0.0",
     "async": "^2.0.1",
     "bell": "^8.0.0",
     "boom": "^4.0.0",

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -110,7 +110,7 @@ exports.register = (server, options, next) => {
 
             server.auth.strategy('session', 'cookie', {
                 cookie: 'sid',
-                ttl: 12 * 60 * 60 * 1000, // 12 hours in milliseconds
+                ttl: 2 * 60 * 60 * 1000, // 2 hours in milliseconds
                 password: pluginOptions.cookiePassword,
                 isSecure: pluginOptions.https
             });

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -1,21 +1,22 @@
 'use strict';
 
+const authjwt = require('hapi-auth-jwt2');
 const authToken = require('hapi-auth-bearer-token');
 const bell = require('bell');
-const sugar = require('hapi-auth-cookie');
-const authjwt = require('hapi-auth-jwt2');
-const crumb = require('crumb');
-const jwt = require('jsonwebtoken');
-const joi = require('joi');
-const hoek = require('hoek');
-const logoutRoute = require('./logout');
-const loginRoute = require('./login');
-const tokenRoute = require('./token');
-const keyRoute = require('./key');
-const crumbRoute = require('./crumb');
 const contextsRoute = require('./contexts');
+const crumb = require('crumb');
+const crumbRoute = require('./crumb');
+const guid = require('aguid');
+const hoek = require('hoek');
+const joi = require('joi');
+const jwt = require('jsonwebtoken');
+const keyRoute = require('./key');
+const loginRoute = require('./login');
+const logoutRoute = require('./logout');
+const sugar = require('hapi-auth-cookie');
+const tokenRoute = require('./token');
 
-const EXPIRES_IN = '12h';
+const EXPIRES_IN = '2h';
 const ALGORITHM = 'RS256';
 
 /**
@@ -70,14 +71,15 @@ exports.register = (server, options, next) => {
     });
 
     /**
-     * Generates a jwt that is signed and has a 12h lifespan
+     * Generates a jwt that is signed and has a 2h lifespan
      * @method generateToken
      * @param  {Object} profile Object from generateProfile
      * @return {String}         Signed jwt that includes that profile
      */
     server.expose('generateToken', profile => jwt.sign(profile, pluginOptions.jwtPrivateKey, {
         algorithm: ALGORITHM,
-        expiresIn: EXPIRES_IN
+        expiresIn: EXPIRES_IN,
+        jwtid: guid()
     }));
 
     const modules = [bell, sugar, authjwt, authToken, {

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -6,7 +6,6 @@ const bell = require('bell');
 const contextsRoute = require('./contexts');
 const crumb = require('crumb');
 const crumbRoute = require('./crumb');
-const guid = require('aguid');
 const hoek = require('hoek');
 const joi = require('joi');
 const jwt = require('jsonwebtoken');
@@ -15,6 +14,7 @@ const loginRoute = require('./login');
 const logoutRoute = require('./logout');
 const sugar = require('hapi-auth-cookie');
 const tokenRoute = require('./token');
+const uuid = require('uuid/v1');
 
 const EXPIRES_IN = '2h';
 const ALGORITHM = 'RS256';
@@ -79,7 +79,7 @@ exports.register = (server, options, next) => {
     server.expose('generateToken', profile => jwt.sign(profile, pluginOptions.jwtPrivateKey, {
         algorithm: ALGORITHM,
         expiresIn: EXPIRES_IN,
-        jwtid: guid()
+        jwtid: uuid()
     }));
 
     const modules = [bell, sugar, authjwt, authToken, {


### PR DESCRIPTION
## Context

We would like to issue one time use build JWT tokens for improved security.

## Objective

This PR adds a guid to the JWT token and changes the timeout from 12h to 2h.

## References

Design doc: https://github.com/screwdriver-cd/screwdriver/blob/master/design/auth.md
Related to: https://github.com/screwdriver-cd/hapi-auth-dynamic-jwt/blob/master/index.js#L163
jsonwebtoken npm: https://www.npmjs.com/package/jsonwebtoken
uuid npm: https://www.npmjs.com/package/uuid