### PR TITLE
fix: improve command format spec.

### DIFF
--- a/design/commands.md
+++ b/design/commands.md
@@ -45,12 +45,14 @@ habitat:
     # If local
     # mode: local
     # package: ./foobar.hart
-    binary:  git
+    command: git
 
 # Docker specific config
 # if format: docker
 docker:
-    image: node:1.2.3
+    image: chefdk:1.2.3
+    # Optional, default: ""
+    command: knife
 
 # Binary specific config
 # if format: binary


### PR DESCRIPTION
## Context

I am implementing commands data-schemas now.
https://github.com/screwdriver-cd/data-schema/pull/195

## Objective

I think we should add `command` optional key  to the Docker format that allows users not to set an extra executable (knife, ...).
And we should rename `binary` key of the Habitat format to `command`.
Please review it.

## References

https://github.com/screwdriver-cd/data-schema/pull/195#discussion_r157115519
