### PR TITLE
feat(827): add config for tolerations

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -85,7 +85,9 @@ executor:
                     high: K8S_MEMORY_HIGH
             # k8s tolerations for approprate pod scheduling.
             # Value is Array of format { key: 'key', value: 'value', effect: 'NoSchedule'}
-            tolerations: K8S_POD_TOLERATIONS
+            tolerations:
+              __name: K8S_POD_TOLERATIONS
+              __format: json
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
         # Prefix to the pod

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -83,6 +83,9 @@ executor:
                 memory:
                     low: K8S_MEMORY_LOW
                     high: K8S_MEMORY_HIGH
+            # k8s tolerations for approprate pod scheduling.
+            # Value is Array of format { key: 'key', value: 'value', effect: 'NoSchedule'}
+            tolerations: K8S_POD_TOLERATIONS
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
         # Prefix to the pod

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -142,6 +142,8 @@ executor:
                     # Memory in GB
                     low: 2
                     high: 12
+            # k8s tolerations for approprate pod scheduling
+            tolerations: []
         # Launcher container tag to use
         launchVersion: stable
 #     jenkins:


### PR DESCRIPTION
## Context

We intend to support k8s toleration when creating pods so that k8s admins can specify taints on k8s nodes where they want the builds to be scheduled 

## Objective

This adds config for toleration to be used in `executor-k8s-vm`

## References

#827 
