### PR TITLE
fix: Only return pipelines that match the cluster's scmContexts

### DIFF
--- a/test/plugins/data/pipelinesFromGitlab.json
+++ b/test/plugins/data/pipelinesFromGitlab.json
@@ -1,0 +1,12 @@
+[
+    {
+        "id": 9999,
+        "scmUri": "mygitlab:12345:branchName",
+        "scmContext": "gitlab:mygitlab",
+        "createTime": "2038-01-19T03:14:08.131Z",
+        "admins": {
+            "stjohn": true
+        },
+        "lastEventId": 222
+    }
+]


### PR DESCRIPTION
## Context

Sometimes a DB might be shared by multiple clusters. It's confusing when pipelines with scmContexts that are not configured for that specific cluster show up on the UI. 

## Objective

This PR changes the pipeline `/pipelines` endpoint to only return pipelines that match the cluster's configured scmContexts.

## References


  