### PR TITLE
fix: bumping timeout for sd-step

### DIFF
--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -117,7 +117,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
         });
     });
 
-    Then(/^(.*) package is available via sd-step$/, { timeout: 300 * 1000 }, function step(pkg) {
+    Then(/^(.*) package is available via sd-step$/, { timeout: 500 * 1000 }, function step(pkg) {
         return this.waitForBuild(this.buildId).then((response) => {
             Assert.equal(response.statusCode, 200);
             Assert.equal(response.body.status, 'SUCCESS');


### PR DESCRIPTION
I checked the functional build. It actually passed, but for some reason took a long time. So the functional test failed. Temporarily changing this value to unblock the pipeline. 