### PR TITLE
feat(842): Add route for getting template tags

### DIFF
--- a/plugins/templates/index.js
+++ b/plugins/templates/index.js
@@ -4,6 +4,7 @@ const createRoute = require('./create');
 const createTagRoute = require('./createTag');
 const getRoute = require('./get');
 const listRoute = require('./list');
+const listTagsRoute = require('./listTags');
 const listVersionsRoute = require('./listVersions');
 const removeTagRoute = require('./removeTag');
 
@@ -20,6 +21,7 @@ exports.register = (server, options, next) => {
         createTagRoute(),
         getRoute(),
         listRoute(),
+        listTagsRoute(),
         listVersionsRoute(),
         removeTagRoute()
     ]);

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -25,7 +25,7 @@ module.exports = () => ({
                 sort: request.query.sort
             }).then((templates) => {
                 if (templates.length === 0) {
-                    throw boom.notFound('Template does not exist');
+                    throw boom.notFound('No tags found for template');
                 }
 
                 reply(templates.map(p => p.toJson()));

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -11,7 +11,7 @@ module.exports = () => ({
     path: '/templates/{name}/tags',
     config: {
         description: 'Get all template tags for a given template name with pagination',
-        notes: 'Returns all template records for a given template name',
+        notes: 'Returns all template tags for a given template name',
         tags: ['api', 'templates', 'tags'],
         handler: (request, reply) => {
             const factory = request.server.app.templateTagFactory;

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -23,12 +23,12 @@ module.exports = () => ({
                     count: request.query.count
                 },
                 sort: request.query.sort
-            }).then((templates) => {
-                if (templates.length === 0) {
+            }).then((tags) => {
+                if (tags.length === 0) {
                     throw boom.notFound('No tags found for template');
                 }
 
-                reply(templates.map(p => p.toJson()));
+                reply(tags.map(p => p.toJson()));
             })
                 .catch(err => reply(boom.wrap(err)));
         },

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -10,7 +10,7 @@ module.exports = () => ({
     method: 'GET',
     path: '/templates/{name}/tags',
     config: {
-        description: 'Get all template tags for a given template name with pagination',
+        description: 'Get all template tags for a given template name',
         notes: 'Returns all template tags for a given template name',
         tags: ['api', 'templates', 'tags'],
         handler: (request, reply) => {

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const listSchema = joi.array().items(schema.models.templateTag.base).label('List of templates');
+const nameSchema = joi.reach(schema.models.templateTag.base, 'name');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/templates/{name}/tags',
+    config: {
+        description: 'Get all template tags for a given template name with pagination',
+        notes: 'Returns all template records for a given template name',
+        tags: ['api', 'templates', 'tags'],
+        handler: (request, reply) => {
+            const factory = request.server.app.templateTagFactory;
+
+            return factory.list({
+                params: { name: request.params.name },
+                paginate: {
+                    page: request.query.page,
+                    count: request.query.count
+                },
+                sort: request.query.sort
+            }).then((templates) => {
+                if (templates.length === 0) {
+                    throw boom.notFound('Template does not exist');
+                }
+
+                reply(templates.map(p => p.toJson()));
+            })
+                .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: listSchema
+        },
+        validate: {
+            params: {
+                name: nameSchema
+            },
+            query: schema.api.pagination
+        }
+    }
+});

--- a/test/plugins/data/templateTags.json
+++ b/test/plugins/data/templateTags.json
@@ -7,12 +7,6 @@
 {
     "id": 7970,
     "name": "screwdriver/build",
-    "tag": "stable",
+    "tag": "latest",
     "version": "1.0.2"
-},
-{
-    "id": 7971,
-    "name": "screwdriver/build",
-    "tag": "stable",
-    "version": "3.2.1"
 }]

--- a/test/plugins/data/templateTags.json
+++ b/test/plugins/data/templateTags.json
@@ -1,0 +1,18 @@
+[{
+    "id": 7969,
+    "name": "screwdriver/build",
+    "tag": "stable",
+    "version": "0.0.1"
+},
+{
+    "id": 7970,
+    "name": "screwdriver/build",
+    "tag": "stable",
+    "version": "1.0.2"
+},
+{
+    "id": 7971,
+    "name": "screwdriver/build",
+    "tag": "stable",
+    "version": "3.2.1"
+}]


### PR DESCRIPTION
## Context

It's hard for users to figure out what tags are available for each template and what versions they correspond to. It would be nice to have an endpoint where we could list the available tags for a specific template name.

## Objective

Create an endpoint, GET `/templates/{name}/tags`, which returns template tags.
