### PR TITLE
Fix username for ScottyFillups (Philip Scott)

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -37,7 +37,7 @@ auth:
         - github:petey
         - github:pranavrc
         - github:r3rastogi
-        - github:scottyfillups
+        - github:ScottyFillups
         - github:stjohnjohnson
         - github:tkyi
         # Automated Account


### PR DESCRIPTION
## Context

I'm not whitelisted for https://cd.screwdriver.cd.

## Objective

This PR will whitelist me, so I can use https://cd.screwdriver.cd
