### PR TITLE
fix: bump the wait time

### DIFF
--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -121,7 +121,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
     When(/^new changes are pushed to that pull request$/, {
         timeout: TIMEOUT
     }, function step() {
-        return this.promiseToWait(15) // Find & save the previous build
+        return this.promiseToWait(10) // Find & save the previous build
             .then(() =>
                 sdapi.searchForBuild({
                     instance: this.instance,

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -121,7 +121,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
     When(/^new changes are pushed to that pull request$/, {
         timeout: TIMEOUT
     }, function step() {
-        return this.promiseToWait(3) // Find & save the previous build
+        return this.promiseToWait(15) // Find & save the previous build
             .then(() =>
                 sdapi.searchForBuild({
                     instance: this.instance,


### PR DESCRIPTION
currently it's getting the status for the old PR builds and that's failing the function tests. Wait longer to get the right status

