### PR TITLE
fix: add an example for slack config

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -220,6 +220,9 @@ notifications:
     #     host: email-host
     #     port: email-port
     #     from: email-address-to-send-from
+    # Slack notification when build finishes
+    # slack:
+    #     token: your-slack-bot-token
 ecosystem:
     # Externally routable URL for the User Interface
     ui: https://cd.screwdriver.cd


### PR DESCRIPTION
add an example for slack config
Related to https://github.com/screwdriver-cd/screwdriver/issues/687