### PR TITLE
fix: add missing command factories registration.

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -63,6 +63,12 @@ bookends.teardown || [] // plugins required for the teardown- steps
 
 // Setup Model Factories
 const Models = require('screwdriver-models');
+const commandFactory = Models.CommandFactory.getInstance({
+    datastore
+});
+const commandTagFactory = Models.CommandTagFactory.getInstance({
+    datastore
+});
 const templateFactory = Models.TemplateFactory.getInstance({
     datastore
 });
@@ -116,6 +122,8 @@ datastore.setup()
         webhooks: webhooksConfig,
         notifications: notificationConfig,
         ecosystem,
+        commandFactory,
+        commandTagFactory,
         templateFactory,
         templateTagFactory,
         pipelineFactory,

--- a/lib/server.js
+++ b/lib/server.js
@@ -93,6 +93,8 @@ module.exports = (config) => {
     // Set the factorys within server.app
     // Instantiating the server with the factories will apply a shallow copy
     server.app = {
+        commandFactory: config.commandFactory,
+        commandTagFactory: config.commandTagFactory,
         templateFactory: config.templateFactory,
         templateTagFactory: config.templateTagFactory,
         triggerFactory: config.triggerFactory,


### PR DESCRIPTION
## Context

Sharing Commands feature.

## Objective

This PR add missing command factories (`commandFactory`, `commandTagFactory`) registration.

## References

none.
