### PR TITLE
feat: limit pipeline that can update command

### DIFF
--- a/test/plugins/data/command.json
+++ b/test/plugins/data/command.json
@@ -10,5 +10,6 @@
     "mode": "remote",
     "package": "core/git/2.14.1",
     "command": "git"
-  }
+  },
+  "pipelineId": 123
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Like `template`, to limit a pipeline which updates the command only a pipeline which created the command, I add a `pipelineId` to the `command`. Then, I use `pipelineId` in API to deny publishing command from unauthorized pipeline.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Like `plugins/templates/create.js`, it compares request's pipelineId and command's pipelineId to deny publishing command from unauthorized pipeline.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Related PRs
- data-schema https://github.com/screwdriver-cd/data-schema/pull/199
- models https://github.com/screwdriver-cd/models/pull/211

## Note
Unit tests will fail for the moment, because it requires new `command` data-schema.
https://github.com/screwdriver-cd/data-schema/pull/199
