### PR TITLE
fix: activate auth when create command

### DIFF
--- a/plugins/commands/README.md
+++ b/plugins/commands/README.md
@@ -50,7 +50,7 @@ Creating a command will store the command data (`namespace`, `name`, `version`, 
 
 `version` will be auto-bumped. For example, if `foo/bar@1.0.0` already exists and the version passed in is `1.0`, the newly created command will be version `1.0.1`. 
 
-*Note: This endpoint will be only accessible in `build` scope and the permission is tied to the pipeline that first creates the command in the near future.*
+*Note: This endpoint only accessible in `build` scope and the permission is tied to the pipeline that first creates the command.*
 
 `POST /commands`
 

--- a/plugins/commands/create.js
+++ b/plugins/commands/create.js
@@ -13,11 +13,10 @@ module.exports = () => ({
         description: 'Create a new command',
         notes: 'Create a specific command',
         tags: ['api', 'commands'],
-        // TODO: activate authorization in the phase 2 or later.
-        // auth: {
-        //     strategies: ['token', 'session'],
-        //     scope: ['build']
-        // },
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['build']
+        },
         plugins: {
             'hapi-swagger': {
                 security: [{ token: [] }]

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -174,6 +174,7 @@ describe('command plugin test', () => {
                 url: '/commands',
                 payload: COMMAND_VALID,
                 credentials: {
+                    scope: ['build']
                 }
             };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To get `pipelineId` from `request.auth.credential`, we have to activate auth in config.
And also add `scope: ['build']` to make `POST/ commands` endpoint only accessible in `build` scope.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Activate authorization in `POST/ commands` endpoint.
Fix commands README.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
