### PR TITLE
fix: use only token strategy for auth

### DIFF
--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -67,7 +67,7 @@ module.exports = config => ({
         notes: 'Returns the logs for a step',
         tags: ['api', 'builds', 'steps', 'log'],
         auth: {
-            strategies: ['token', 'session'],
+            strategies: ['token'],
             scope: ['user']
         },
         plugins: {


### PR DESCRIPTION
## Context

Session strategy is interfering with token strategy and proxy requests to store are failing. Trying to see if removing session strategy will make hapi to populate headers.