### PR TITLE
fix: Create APIs of commands & templates not return useful error message

### DIFF
--- a/plugins/commands/create.js
+++ b/plugins/commands/create.js
@@ -26,7 +26,8 @@ module.exports = () => ({
             .then((config) => {
                 if (config.errors.length > 0) {
                     throw boom.badRequest(
-                        'Command has invalid format: ', config.errors.toString());
+                        `Command has invalid format: ${config.errors.length} error(s).`,
+                        config.errors);
                 }
 
                 const commandFactory = request.server.app.commandFactory;

--- a/plugins/templates/create.js
+++ b/plugins/templates/create.js
@@ -27,7 +27,8 @@ module.exports = () => ({
             .then((config) => {
                 if (config.errors.length > 0) {
                     throw boom.badRequest(
-                        'Template has invalid format: ', config.errors.toString());
+                        `Template has invalid format: ${config.errors.length} error(s).`,
+                        config.errors);
                 }
 
                 const pipelineFactory = request.server.app.pipelineFactory;


### PR DESCRIPTION
## Context

Currently, create APIs of commands and templates do not return useful error messages to a malformatted request like the following example.

- POST data sample
```
{"yaml":"{\"namespace\":\"foo\",\"invalid name\":\"bar\",\"version\":\"1.1.2\",\"description\":\"Command for habitat git\\nExecutes git commands\\n\",\"maintainer\":\"foo@bar.com\",\"format\":\"habitat\",\"habitat\":{\"mode\":\"remote\",\"package\":\"core/git/2.14.1\",\"command\":\"git\"}}"}
```

- Response body
```
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Command has invalid format: ",
    "data": "[object Object],[object Object]"
}
```

## Objective

This PR enables APIs to return the following response to the same request.

```
{
    "statusCode": 400,
    "error": "Bad Request",
    "message": "Command has invalid format: 2 error(s).",
    "data": [
        {
            "message": "\"name\" is required",
            "path": "name",
            "type": "any.required",
            "context": {
                "key": "name"
            }
        },
        {
            "message": "\"invalid name\" is not allowed",
            "path": "invalid name",
            "type": "object.allowUnknown",
            "context": {
                "child": "invalid name",
                "key": "invalid name"
            }
        }
    ]
}
```

## References

None.
