### PR TITLE
fix: Preventing users from renewing their existing JWTs

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -142,11 +142,15 @@ exports.register = (server, options, next) => {
                                 return cb(null, false, {});
                             }
 
-                            return cb(null, true, {
+                            const profile = {
                                 username: user.username,
                                 scmContext: user.scmContext,
                                 scope: ['user']
-                            });
+                            };
+
+                            profile.token = server.plugins.auth.generateToken(profile);
+
+                            return cb(null, true, profile);
                         });
                 }
             });

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -63,6 +63,7 @@ module.exports = config => ({
                 ));
             }
 
+            profile.token = request.server.plugins.auth.generateToken(profile);
             request.cookieAuth.set(profile);
 
             return factory.get({ username, scmContext })

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -28,6 +28,7 @@ module.exports = () => ({
             let profile = request.auth.credentials;
             const username = profile.username;
             const scope = profile.scope;
+            const token = profile.token;
             const buildFactory = request.server.app.buildFactory;
             const jobFactory = request.server.app.jobFactory;
             const pipelineFactory = request.server.app.pipelineFactory;
@@ -49,18 +50,14 @@ module.exports = () => ({
                             pipeline.scmContext,
                             ['build', 'impersonated']
                         );
-                        const token = request.server.plugins.auth.generateToken(profile);
+                        profile.token = request.server.plugins.auth.generateToken(profile);
 
                         request.cookieAuth.set(profile);
 
-                        return reply({ token });
+                        return reply({ token: profile.token });
                     })
                     .catch(err => reply(boom.wrap(err)));
             }
-
-            const token = request.server.plugins.auth.generateToken(profile);
-
-            request.cookieAuth.set(profile);
 
             return reply({ token });
         },


### PR DESCRIPTION
## Context

Currently, if you have an existing JWT you can renew it by hitting `/auth/tokens`.  This defeats the expiration that was put into place.

## Objective

Give back the single JWT that was generated.  Don't give out new tokens.