### PR TITLE
feat: Allow users to specify a metric host in config files

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -254,6 +254,8 @@ ecosystem:
     badges: ECOSYSTEM_BADGES
     # Default registry to pull build containers from
     dockerRegistry: ECOSYSTEM_DOCKER_REGISTRY
+    # Hostname for metrics service, or pushgateway
+    metric_host: ECOSYSTEM_METRIC_HOST
     # Array of extra origins allowed to do CORS to API
     allowCors:
         __name: ECOSYSTEM_ALLOW_CORS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -255,7 +255,7 @@ ecosystem:
     # Default registry to pull build containers from
     dockerRegistry: ECOSYSTEM_DOCKER_REGISTRY
     # Hostname for metrics service, or pushgateway
-    metric_host: ECOSYSTEM_METRIC_HOST
+    metricHost: ECOSYSTEM_METRIC_HOST
     # Array of extra origins allowed to do CORS to API
     allowCors:
         __name: ECOSYSTEM_ALLOW_CORS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -254,8 +254,8 @@ ecosystem:
     badges: ECOSYSTEM_BADGES
     # Default registry to pull build containers from
     dockerRegistry: ECOSYSTEM_DOCKER_REGISTRY
-    # Hostname for metrics service, or pushgateway
-    metricHost: ECOSYSTEM_METRIC_HOST
+    # Pushgateway URL for Prometheus
+    pushgatewayUrl: ECOSYSTEM_PUSHGATEWAY_URL
     # Array of extra origins allowed to do CORS to API
     allowCors:
         __name: ECOSYSTEM_ALLOW_CORS

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -232,7 +232,7 @@ ecosystem:
     badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg
     # Default registry to pull build containers from. Uses Docker Hub if nothing/empty string is provided
     dockerRegistry: ""
-    # Hostname for metrics service, or pushgateway
-    metricHost: http://pushgateway.example.org:9091
+    # Pushgateway URL for Prometheus
+    pushgatewayUrl: http://pushgateway.example.org:9091
     # Extra origins allowed to do CORS to API
     allowCors: []

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -233,6 +233,6 @@ ecosystem:
     # Default registry to pull build containers from. Uses Docker Hub if nothing/empty string is provided
     dockerRegistry: ""
     # Pushgateway URL for Prometheus
-    pushgatewayUrl: http://pushgateway.example.org:9091
+    # pushgatewayUrl: http://pushgateway.example.org:9091
     # Extra origins allowed to do CORS to API
     allowCors: []

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -233,6 +233,6 @@ ecosystem:
     # Default registry to pull build containers from. Uses Docker Hub if nothing/empty string is provided
     dockerRegistry: ""
     # Hostname for metrics service, or pushgateway
-    metric_host: http://pushgateway.example.org:9091
+    metricHost: http://pushgateway.example.org:9091
     # Extra origins allowed to do CORS to API
     allowCors: []

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -232,5 +232,7 @@ ecosystem:
     badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg
     # Default registry to pull build containers from. Uses Docker Hub if nothing/empty string is provided
     dockerRegistry: ""
+    # Hostname for metrics service, or pushgateway
+    metric_host: http://pushgateway.example.org:9091
     # Extra origins allowed to do CORS to API
     allowCors: []


### PR DESCRIPTION
## Context

It would be convenient if users could specify a URL to send executor data to their metric services.

## Objective

Add an example of `metricHost` usage in `default.yaml` and read an environment variable, `ECOSYSTEM_METRIC_HOST`, in `custom-environment-variables.yaml`.

## References

Merge for executor-k8s-vm `metricHost` implementation: https://github.com/screwdriver-cd/executor-k8s-vm/pull/23