### PR TITLE
feat(677): Add list command endpoint

### DIFF
--- a/plugins/commands/README.md
+++ b/plugins/commands/README.md
@@ -29,6 +29,10 @@ server.register({
 
 #### Command
 
+##### Get all commands
+
+`GET /commands`
+
 ##### Get a single command
 
 You can get a single command by providing the command namespace, name and the specific version or the tag.

--- a/plugins/commands/index.js
+++ b/plugins/commands/index.js
@@ -2,6 +2,7 @@
 
 const createRoute = require('./create');
 const getRoute = require('./get');
+const listRoute = require('./list');
 
 /**
  * Command API Plugin
@@ -13,7 +14,8 @@ const getRoute = require('./get');
 exports.register = (server, options, next) => {
     server.route([
         createRoute(),
-        getRoute()
+        getRoute(),
+        listRoute()
     ]);
 
     next();

--- a/plugins/commands/list.js
+++ b/plugins/commands/list.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const listSchema = joi.array().items(schema.models.command.get).label('List of commands');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/commands',
+    config: {
+        description: 'Get commands with pagination',
+        notes: 'Returns all command records',
+        tags: ['api', 'commands'],
+        handler: (request, reply) => {
+            const factory = request.server.app.commandFactory;
+
+            return factory.list({
+                paginate: {
+                    page: request.query.page,
+                    count: request.query.count
+                },
+                sort: request.query.sort
+            })
+                .then(commands => reply(commands.map(p => p.toJson())))
+                .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: listSchema
+        },
+        validate: {
+            query: schema.api.pagination
+        }
+    }
+});

--- a/test/plugins/data/commands.json
+++ b/test/plugins/data/commands.json
@@ -1,0 +1,28 @@
+[{
+  "id": 7969,
+  "namespace": "foo",
+  "name": "bar",
+  "version": "1.0.0",
+  "description": "this is a habitat format command",
+  "maintainer": "foo@bar.com",
+  "format": "habitat",
+  "habitat": {
+    "mode": "remote",
+    "package": "core/git/2.14.1",
+    "command": "git"
+  },
+  "pipelineId": 123
+},
+{
+  "id": 7970,
+  "namespace": "foo",
+  "name": "foobar",
+  "version": "1.0.0",
+  "description": "this is a binary format command",
+  "maintainer": "foo@bar.com",
+  "format": "binary",
+  "binary": {
+    "file": "./foobar.sh"
+  },
+  "pipelineId": 456
+}]


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Like `template`, we need an endpoint that can get all commands to show all commands in UI.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Like `GET /templates` endpoint, I added an endpoint that gets all commands.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Related #677 