### PR TITLE
feat: add jwtEnv

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -10,6 +10,8 @@ auth:
     # Generate one by running
     # $ openssl rsa -in jwt.pem -pubout -out jwt.pub
     jwtPublicKey: SECRET_JWT_PUBLIC_KEY
+    # Environment of the JWTs. For example: 'prod' or 'beta'
+    jwtEnvironment: JWT_ENVIRONMENT
     # A password used for encrypting session data.
     # **Needs to be minimum 32 characters**
     cookiePassword: SECRET_COOKIE_PASSWORD

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -14,6 +14,8 @@ auth:
         -----BEGIN PUBLIC KEY-----
         YOUR-KEY-HERE
         -----END PUBLIC KEY-----
+    # Environment of JWTs
+    jwtEnvironment: ''
     # A password used for encrypting session data.
     # **Needs to be minimum 32 characters**
     cookiePassword: WOW-ANOTHER-INSECURE-PASSWORD!!!

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -28,11 +28,13 @@ const ALGORITHM = 'RS256';
  * @param  {String}   options.encryptionPassword     Password used for iron encrypting
  * @param  {Boolean}  options.https                  For setting the isSecure flag. Needs to be false for non-https
  * @param  {String}   options.jwtPrivateKey          Secret for signing JWTs
+ * @param  {String}  [options.jwtEnvironment]        Environment for the JWTs. Example: 'prod' or 'beta'
  * @param  {Object}   options.scm                    SCM class to setup Authentication
  * @param  {Function} next                           Function to call when done
  */
 exports.register = (server, options, next) => {
     const pluginOptions = joi.attempt(options, joi.object().keys({
+        jwtEnvironment: joi.string().default(''),
         https: joi.boolean().truthy('true').falsy('false').required(),
         cookiePassword: joi.string().min(32).required(),
         encryptionPassword: joi.string().min(32).required(),
@@ -55,7 +57,7 @@ exports.register = (server, options, next) => {
      */
     server.expose('generateProfile', (username, scmContext, scope, metadata) => {
         const profile = Object.assign({
-            username, scmContext, scope
+            username, scmContext, scope, environment: pluginOptions.jwtEnvironment
         }, metadata || {});
         const scm = server.root.app.userFactory.scm;
         const scmDisplayName = scm.getDisplayName({ scmContext });


### PR DESCRIPTION
Generate an additional field `jwtEnvironment` to indicates what environment this jwt should be generated for. By default it is `''`. We can set this to `test` or `beta` for our beta environment. 