### PR TITLE
fix: do not generate jwt with empty environment

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -57,8 +57,13 @@ exports.register = (server, options, next) => {
      */
     server.expose('generateProfile', (username, scmContext, scope, metadata) => {
         const profile = Object.assign({
-            username, scmContext, scope, environment: pluginOptions.jwtEnvironment
+            username, scmContext, scope
         }, metadata || {});
+
+        if (pluginOptions.jwtEnvironment) {
+            profile.environment = pluginOptions.jwtEnvironment;
+        }
+
         const scm = server.root.app.userFactory.scm;
         const scmDisplayName = scm.getDisplayName({ scmContext });
         const userDisplayName = `${scmDisplayName}:${username}`;

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -230,7 +230,7 @@ describe('auth plugin test', () => {
             expect(profile.scmContext).to.contain('github:github.com');
             expect(profile.scope).to.contain('user');
             expect(profile.scope).to.contain('admin');
-            expect(profile.environment).to.equal('');
+            expect(profile.environment).to.equal(undefined);
         });
 
         it('does not add admin scope for non-admins', () => {
@@ -241,7 +241,7 @@ describe('auth plugin test', () => {
             expect(profile.scmContext).to.contain('github:mygithub.com');
             expect(profile.scope).to.contain('user');
             expect(profile.scope).to.not.contain('admin');
-            expect(profile.environment).to.equal('');
+            expect(profile.environment).to.equal(undefined);
         });
     });
 
@@ -540,8 +540,7 @@ describe('auth plugin test', () => {
                     scope: ['user'],
                     token: jwt.sign({
                         username: 'robin',
-                        scope: ['user'],
-                        environment: ''
+                        scope: ['user']
                     }, jwtPrivateKey, {
                         algorithm: 'RS256',
                         expiresIn: '2h',
@@ -558,8 +557,6 @@ describe('auth plugin test', () => {
                     .with.lengthOf(1);
                 expect(reply.result.token).to.be.a.jwt
                     .and.deep.property('scope[0]', 'user');
-                expect(reply.result.token).to.be.a.jwt
-                    .and.deep.property('environment', '');
             })
         ));
 


### PR DESCRIPTION
Only generate this field if the value is not empty