### PR TITLE
feat(677): Add store to cors

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -64,7 +64,7 @@ module.exports = (config) => {
     // Hapi Cross-origin resource sharing configuration
     // See http://hapijs.com/api for available options
 
-    let corsOrigins = [config.ecosystem.ui];
+    let corsOrigins = [config.ecosystem.ui, config.ecosystem.store];
 
     if (Array.isArray(config.ecosystem.allowCors)) {
         corsOrigins = corsOrigins.concat(config.ecosystem.allowCors);

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -9,6 +9,7 @@ describe('server case', () => {
     let hapiEngine;
     const ecosystem = {
         ui: 'http://example.com',
+        store: 'http://store.example.com',
         allowCors: ['http://mycors.com']
     };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When storing binary files to screwdriver-store, screwdriver-store has to access to screwdriver-api(https://github.com/screwdriver-cd/store/pull/30). For this reason, screwdriver-store has to be added to corsOrigin.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I added screwdriver-store to corsOrigin so that screwdriver-store can access to screwdriver-api.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/store/pull/30