### PR TITLE
feat(677): Add listVersion command endpoint

### DIFF
--- a/plugins/commands/README.md
+++ b/plugins/commands/README.md
@@ -33,6 +33,12 @@ server.register({
 
 `GET /commands`
 
+##### Get all command versions
+
+You can get all versions of commands by providing the command namespace and name.
+
+`GET /commands/{namespace}/{name}`
+
 ##### Get a single command
 
 You can get a single command by providing the command namespace, name and the specific version or the tag.

--- a/plugins/commands/index.js
+++ b/plugins/commands/index.js
@@ -3,6 +3,7 @@
 const createRoute = require('./create');
 const getRoute = require('./get');
 const listRoute = require('./list');
+const listVersionsRoute = require('./listVersions');
 
 /**
  * Command API Plugin
@@ -15,7 +16,8 @@ exports.register = (server, options, next) => {
     server.route([
         createRoute(),
         getRoute(),
-        listRoute()
+        listRoute(),
+        listVersionsRoute()
     ]);
 
     next();

--- a/plugins/commands/listVersions.js
+++ b/plugins/commands/listVersions.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const listSchema = joi.array().items(schema.models.command.get).label('List of commands');
+const nameSchema = joi.reach(schema.models.command.base, 'name');
+const namespaceSchema = joi.reach(schema.models.command.base, 'namespace');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/commands/{namespace}/{name}',
+    config: {
+        description: 'Get all command versions for a given command namespace/name with pagination',
+        notes: 'Returns all command records for a given command namespace/name',
+        tags: ['api', 'commands', 'versions'],
+        handler: (request, reply) => {
+            const factory = request.server.app.commandFactory;
+
+            return factory.list({
+                params: { namespace: request.params.namespace, name: request.params.name },
+                paginate: {
+                    page: request.query.page,
+                    count: request.query.count
+                },
+                sort: request.query.sort
+            }).then((commands) => {
+                if (commands.length === 0) {
+                    throw boom.notFound('Command does not exist');
+                }
+
+                reply(commands.map(p => p.toJson()));
+            })
+                .catch(err => reply(boom.wrap(err)));
+        },
+        response: {
+            schema: listSchema
+        },
+        validate: {
+            params: {
+                namespace: namespaceSchema,
+                name: nameSchema
+            },
+            query: schema.api.pagination
+        }
+    }
+});

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -8,7 +8,7 @@ const urlLib = require('url');
 const hoek = require('hoek');
 const testcommand = require('./data/command.json');
 const testcommands = require('./data/commands.json');
-const testcommandversions = require('./data/commandVersions.json');
+const testcommandVersions = require('./data/commandVersions.json');
 const testpipeline = require('./data/pipeline.json');
 const COMMAND_INVALID = require('./data/command-validator.missing-version.json');
 const COMMAND_VALID = require('./data/command-validator.input.json');
@@ -209,11 +209,11 @@ describe('command plugin test', () => {
         });
 
         it('returns 200 and all command versions for a command namespace/name', () => {
-            commandFactoryMock.list.resolves(getCommandMocks(testcommandversions));
+            commandFactoryMock.list.resolves(getCommandMocks(testcommandVersions));
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 200);
-                assert.deepEqual(reply.result, testcommandversions);
+                assert.deepEqual(reply.result, testcommandVersions);
                 assert.calledWith(commandFactoryMock.list, {
                     params: {
                         namespace: 'screwdriver',

--- a/test/plugins/data/commandVersions.json
+++ b/test/plugins/data/commandVersions.json
@@ -1,0 +1,43 @@
+[{
+  "id": 7969,
+  "namespace": "screwdriver",
+  "name": "build",
+  "version": "0.0.0",
+  "description": "this is a habitat format command",
+  "maintainer": "foo@bar.com",
+  "format": "habitat",
+  "habitat": {
+    "mode": "remote",
+    "package": "core/git/2.14.1",
+    "command": "git"
+  },
+  "pipelineId": 123
+},
+{
+  "id": 7970,
+  "namespace": "screwdriver",
+  "name": "build",
+  "version": "1.0.2",
+  "description": "this is a binary format command",
+  "maintainer": "foo@bar.com",
+  "format": "binary",
+  "binary": {
+    "file": "./foobar.sh"
+  },
+  "pipelineId": 123
+},
+{
+  "id": 7974,
+  "namespace": "screwdriver",
+  "name": "build",
+  "version": "3.2.1",
+  "description": "this is a habitat format command",
+  "maintainer": "foo@bar.com",
+  "format": "habitat",
+  "habitat": {
+    "mode": "remote",
+    "package": "core/git/2.14.1",
+    "command": "git"
+  },
+  "pipelineId": 123
+}]


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Like `template`, we need an endpoint that can get all versions of commands to show all versions of commands in UI.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Like `GET /templates/{name}` endpoint, I added an endpoint that gets all versions of commands.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Related #677 