### PR TITLE
fix: use node:8 as image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8
 
 # Screwdriver Version
 ARG VERSION=latest

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8
 
 # Create our application directory
 RUN mkdir -p /usr/src/app

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,7 +5,7 @@ jobs:
     main:
         requires: [~pr, ~commit]
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - install: npm install
             - duplicate: NPM_FILTER=screwdriver- ./ci/npm-dups.sh
             - test: npm test


### PR DESCRIPTION
## Context
We are having security vulnerabilities in some of our packages. But some of the latest pkgs require node:8.
