### PR TITLE
fix: change default filename like sd-template.yaml

### DIFF
--- a/design/commands.md
+++ b/design/commands.md
@@ -143,13 +143,13 @@ All debug logs about the command lookup and execution are stored in `$SD_ARTIFAC
 ### Publish
 
 ```bash
-$ sd_cmd publish -f command_spec.yml
+$ sd_cmd publish -f sd-command.yaml
 1.0.4
 ```
 
 **Input:**
 
- - `command_spec.yml` is the command specification.
+ - `sd-command.yaml` is the command specification.
 
 **Output:**
 


### PR DESCRIPTION
## Context
We had discussed about filename of sd-cmd.
As a result, we'd like to use ```sd-command.yaml``` as a default filename.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Defining ```sd-command.yaml``` as the default filename of sd-cmd.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://screwdriver-cd.slack.com/messages/C8F6DMR7W/
