### PR TITLE
fix: pass info from parentEvent when create new event

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "screwdriver-executor-k8s-vm": "^1.0.0",
     "screwdriver-executor-queue": "^1.1.0",
     "screwdriver-executor-router": "^1.0.0",
-    "screwdriver-models": "^26.7.6",
+    "screwdriver-models": "^26.8.0",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-notifications-slack": "^2.1.0",
     "screwdriver-scm-github": "^5.0.0",

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -83,7 +83,14 @@ module.exports = () => ({
                             const buildsStatus = builds.reverse()
                                 .map(build => build.status.toLowerCase());
 
-                            for (let i = builds.length; i < lastEvent.workflow.length; i += 1) {
+                            let workflowLength = lastEvent.workflow.length;
+
+                            if (lastEvent.workflowGraph) {
+                                workflowLength = lastEvent.workflowGraph.nodes.filter(n =>
+                                    n.name !== '~commit' && n.name !== '~pr').length;
+                            }
+
+                            for (let i = builds.length; i < workflowLength; i += 1) {
                                 buildsStatus[i] = 'unknown';
                             }
 

--- a/test/plugins/data/events.json
+++ b/test/plugins/data/events.json
@@ -14,7 +14,21 @@
             "username": "imbatman"
         }
     },
-    "workflow": ["main", "publish", "beta"],
+    "workflow": [],
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" },
+            { "name": "beta" }
+        ],
+        "edges": [
+            { "src": "~commit", "dest": "main" },
+            { "src": "main", "dest": "publish" },
+            { "src": "publish", "dest": "beta" }
+        ]
+    },
     "causeMessage": "Merge pull request #26 from screwdriver-cd/models",
     "creator": {
         "avatar": "https://avatars.githubusercontent.com/u/2042?v=3",


### PR DESCRIPTION
## Context
We want to support user to restart from any event. To allow that, we need to pass in `sha` and `workflowGraph` from the `parentEvent` so that model can use those info to recreate the event.

## References
Related to https://github.com/screwdriver-cd/screwdriver/issues/806
Blcoked by: https://github.com/screwdriver-cd/models/pull/224
