### PR TITLE
Whitelisting a really impressive-sounding user

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -55,6 +55,7 @@ auth:
         - github:manolama
         - github:31453
         - github:catto
+        - github:jer
     admins:
         - github:FenrirUnbound
         - github:d2lam


### PR DESCRIPTION
## Context

I would just like to have read access to Screwdriver's Screwdriver.

## Objective

This reverts the unnecessary removal of my api read access

## References

https://github.com/screwdriver-cd/screwdriver/commit/fff6300043d940e5ff0fd6bd9bed2f54a522d62a#diff-fe7044f2ecd69c76ce484ad03fabc12fL35
