### PR TITLE
fix: remove default whitelist/admins

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,45 +25,8 @@ auth:
     https: false
     # Whitelist of users able to authenticate against the system
     # if empty, it allows everyone
-    # @TODO Move this content to our configuration and change the default to []
-    whitelist:
-        # Screwdriver Team Members
-        - github:FenrirUnbound
-        - github:cynthiax
-        - github:d2lam
-        - github:dvdizon
-        - github:jithin1987
-        - github:minz1027
-        - github:petey
-        - github:pranavrc
-        - github:r3rastogi
-        - github:ScottyFillups
-        - github:stjohnjohnson
-        - github:tkyi
-        # Automated Account
-        - github:sd-buildbot
-        # Pilots
-        - github:aressem
-        - github:bjorncs
-        - github:drewfish
-        - github:gjoranv2
-        - github:awick
-        - github:frodelu
-        - github:mortent
-        - github:bratseth
-        - github:jonmv
-        - github:manolama
-        - github:31453
-        - github:catto
-        - github:jer
-    admins:
-        - github:FenrirUnbound
-        - github:d2lam
-        - github:jithin1987
-        - github:minz1027
-        - github:petey
-        - github:stjohnjohnson
-        - github:tkyi
+    whitelist: []
+    admins: []
 
 httpd:
     # Port to listen on


### PR DESCRIPTION
## Context
per @stjohnjohnson's request. 
This is specific to our cluster (cd.screwdriver.cd) and shouldn't be configured by default. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/901

~~Blocked by: I need to set some configurations first before merging this~~