### PR TITLE
feat(677): Add create or update command tag endpoint

### DIFF
--- a/plugins/commands/README.md
+++ b/plugins/commands/README.md
@@ -93,3 +93,15 @@ Example payload:
 }
 ```
 
+#### Command Tag
+Command Tag allows fetching on command version by tag. For example, command `mynamespace/mycommand@1.2.0` as `stable`.
+
+##### Create/Update a tag
+
+If the command tag already exists, it will update the tag with the version. If the command tag doesn't exist yet, this endpoint will create the tag.
+
+*Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the command.*
+
+`PUT /commands/{namespace}/{name}/tags/{tagName}` with the following payload
+
+* `version` - Exact version of the command (ex: `1.1.0`)

--- a/plugins/commands/createTag.js
+++ b/plugins/commands/createTag.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const baseSchema = schema.models.commandTag.base;
+const urlLib = require('url');
+
+/* Currently, only build scope is allowed to tag command due to security reasons.
+ * The same pipeline that publishes the command has the permission to tag it.
+ */
+module.exports = () => ({
+    method: 'PUT',
+    path: '/commands/{namespace}/{name}/tags/{tagName}',
+    config: {
+        description: 'Add or update a command tag',
+        notes: 'Add or update a specific command',
+        tags: ['api', 'commands'],
+        auth: {
+            strategies: ['token', 'session'],
+            scope: ['build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const commandFactory = request.server.app.commandFactory;
+            const commandTagFactory = request.server.app.commandTagFactory;
+            const pipelineId = request.auth.credentials.pipelineId;
+            const namespace = request.params.namespace;
+            const name = request.params.name;
+            const tag = request.params.tagName;
+            const version = request.payload.version;
+
+            return Promise.all([
+                pipelineFactory.get(pipelineId),
+                commandFactory.get({ namespace, name, version }),
+                commandTagFactory.get({ namespace, name, tag })
+            ]).then(([pipeline, command, commandTag]) => {
+                // If command doesn't exist, throw error
+                if (!command) {
+                    throw boom.notFound(`Command ${namespace}/${name}@${version} not found`);
+                }
+
+                // If command exists, but this build's pipelineId is not the same as command's pipelineId
+                // Then this build does not have permission to tag the command
+                if (pipeline.id !== command.pipelineId) {
+                    throw boom.unauthorized('Not allowed to tag this command');
+                }
+
+                // If command tag exists, then the only thing it can update is the version
+                if (commandTag) {
+                    commandTag.version = version;
+
+                    return commandTag.update().then(newTag => reply(newTag.toJson()).code(200));
+                }
+
+                // If command exists, then create the tag
+                return commandTagFactory.create({ namespace, name, tag, version })
+                    .then((newTag) => {
+                        const location = urlLib.format({
+                            host: request.headers.host,
+                            port: request.headers.port,
+                            protocol: request.server.info.protocol,
+                            pathname: `${request.path}/${newTag.id}`
+                        });
+
+                        return reply(newTag.toJson()).header('Location', location).code(201);
+                    });
+            }).catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            params: {
+                namespace: joi.reach(baseSchema, 'namespace'),
+                name: joi.reach(baseSchema, 'name'),
+                tagName: joi.reach(baseSchema, 'tag')
+            },
+            payload: {
+                version: joi.reach(baseSchema, 'version')
+            }
+        }
+    }
+});

--- a/plugins/commands/index.js
+++ b/plugins/commands/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const createRoute = require('./create');
+const createTagRoute = require('./createTag');
 const getRoute = require('./get');
 const listRoute = require('./list');
 const listVersionsRoute = require('./listVersions');
@@ -15,6 +16,7 @@ const listVersionsRoute = require('./listVersions');
 exports.register = (server, options, next) => {
     server.route([
         createRoute(),
+        createTagRoute(),
         getRoute(),
         listRoute(),
         listVersionsRoute()

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -364,4 +364,116 @@ describe('command plugin test', () => {
             });
         });
     });
+
+    describe('PUT /commands/namespace/name/tags', () => {
+        let options;
+        let commandMock;
+        let pipelineMock;
+        const payload = {
+            version: '1.2.0'
+        };
+        const testCommandTag = decorateObj(hoek.merge({ id: 1 }, payload));
+
+        beforeEach(() => {
+            options = {
+                method: 'PUT',
+                url: '/commands/screwdriver/test/tags/stable',
+                payload,
+                credentials: {
+                    scope: ['build']
+                }
+            };
+
+            commandMock = getCommandMocks(testcommand);
+            commandFactoryMock.get.resolves(commandMock);
+
+            commandTagFactoryMock.get.resolves(null);
+
+            pipelineMock = getPipelineMocks(testpipeline);
+            pipelineFactoryMock.get.resolves(pipelineMock);
+        });
+
+        it('returns 401 when pipelineId does not match', () => {
+            commandMock.pipelineId = 8888;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+            });
+        });
+
+        it('returns 404 when command does not exist', () => {
+            commandFactoryMock.get.resolves(null);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('creates commands tag if has good permission and tag does not exist', () => {
+            commandTagFactoryMock.create.resolves(testCommandTag);
+
+            return server.inject(options).then((reply) => {
+                const expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/1`
+                };
+
+                assert.deepEqual(reply.result, hoek.merge({ id: 1 }, payload));
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledWith(commandFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    version: '1.2.0'
+                });
+                assert.calledWith(commandTagFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    tag: 'stable'
+                });
+                assert.calledWith(commandTagFactoryMock.create, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    tag: 'stable',
+                    version: '1.2.0'
+                });
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('update command tag if has good permission and tag exists', () => {
+            const command = hoek.merge({
+                update: sinon.stub().resolves(testCommandTag)
+            }, testCommandTag);
+
+            commandTagFactoryMock.get.resolves(command);
+
+            return server.inject(options).then((reply) => {
+                assert.calledWith(commandFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    version: '1.2.0'
+                });
+                assert.calledWith(commandTagFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    tag: 'stable'
+                });
+                assert.calledOnce(command.update);
+                assert.notCalled(commandTagFactoryMock.create);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 500 when the command tag model fails to create', () => {
+            const testError = new Error('commandModelCreateError');
+
+            commandTagFactoryMock.create.rejects(testError);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
 });

--- a/test/plugins/data/commandTags.json
+++ b/test/plugins/data/commandTags.json
@@ -1,0 +1,14 @@
+[{
+    "id": 7969,
+    "namespace": "screwdriver",
+    "name": "build",
+    "tag": "stable",
+    "version": "0.0.1"
+},
+{
+    "id": 7970,
+    "namespace": "screwdriver",
+    "name": "build",
+    "tag": "latest",
+    "version": "1.0.2"
+}]


### PR DESCRIPTION
## Context
Like `template`, we need an endpoint that can create or update command tag.

## Objective
Like `PUT /templates/{name}/tags/{tagName}` endpoint, I added an endpoint that create or update command tag.

## References
related #677 
