### PR TITLE
fix: fix dfs join trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config/local.*
 .func_config
 .nyc_output
 data/*
+package-lock.json

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -72,6 +72,11 @@ function dfs(workflowGraph, start, builds, visited) {
     const jobId = workflowGraph.nodes.find(node => node.name === start).id;
     const nextJobs = workflowParser.getNextJobs(workflowGraph, { trigger: start });
 
+    // If the start job has no build in parentEvent then just return
+    if (!builds.find(build => build.jobId === jobId)) {
+        return visited;
+    }
+
     visited.add(builds.find(build => build.jobId === jobId).id);
     nextJobs.forEach(job => dfs(workflowGraph, job, builds, visited));
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -922,17 +922,7 @@ describe('build plugin test', () => {
                         {
                             id: 1,
                             jobId: 1,
-                            status: 'SUCCESS'
-                        },
-                        {
-                            id: 2,
-                            jobId: 2,
-                            status: 'SUCCESS'
-                        },
-                        {
-                            id: 3,
-                            jobId: 3,
-                            status: 'SUCCESS'
+                            status: 'FAILURE'
                         },
                         {
                             id: 4,
@@ -989,7 +979,7 @@ describe('build plugin test', () => {
                         {
                             id: 2,
                             jobId: 2,
-                            status: 'SUCCESS'
+                            status: 'FAILURE'
                         },
                         {
                             id: 3,


### PR DESCRIPTION
- fix a bug when the dfs function cannot end if there is a job has no build in parent event
- add package-lock.json to gitignore so that we can rerun pipelines to pull in new dependencies and not locked