### PR TITLE
feat(870): Adding Guest Mode

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -21,6 +21,8 @@ auth:
     # A flag to set if the server is running over https.
     # Used as a flag for the OAuth flow
     https: IS_HTTPS
+    # A flag to set if you want guests to browse your pipelines
+    allowGuestAccess: AUTH_GUEST_ACCESS
     whitelist:
         __name: SECRET_WHITELIST
         __format: json

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -23,6 +23,8 @@ auth:
     # A flag to set if the server is running over https.
     # Used as a flag for the OAuth flow
     https: false
+    # A flag to set if you want guests to browse your pipelines
+    allowGuestAccess: false
     # Whitelist of users able to authenticate against the system
     # if empty, it allows everyone
     whitelist: []

--- a/plugins/auth/README.md
+++ b/plugins/auth/README.md
@@ -27,9 +27,13 @@ server.register({
 
 ### Routes
 
-#### Login
+#### Login (and redirect to token)
 
-`GET /auth/login` (for backward compatibility) or `GET /auth/login/{scmContext}` or `POST /auth/login/{scmContext}`
+This will generate a cookie with the JWT in it.
+
+ - OAuth: `GET /auth/login/{scmContext}` or `POST /auth/login/{scmContext}`
+ - Token: `GET /auth/login/key?token=YOUR_API_TOKEN`
+ - Guest: `GET /auth/login/guest`
 
 #### Get a token
 

--- a/plugins/auth/contexts.js
+++ b/plugins/auth/contexts.js
@@ -1,19 +1,19 @@
 'use strict';
 
 /**
- * Get all scm contexts
+ * Get all auth contexts
  * @method login
- * @param  {Object}      config           Configuration from the user
- * @param  {Array}       config.whitelist List of allowed users to the API
- * @return {Object}                       Hapi Plugin Route
+ * @param  {Object}      config                  Configuration from the user
+ * @param  {Boolean}     config.allowGuestAccess Letting users browse your system
+ * @return {Object}                              Hapi Plugin Route
  */
-module.exports = () => ({
+module.exports = config => ({
     method: ['GET'],
     path: '/auth/contexts',
     config: {
-        description: 'Get all scm contexts',
-        notes: 'Get all scm contexts',
-        tags: ['api', 'scmContext'],
+        description: 'Get all auth contexts',
+        notes: 'Get all auth contexts',
+        tags: ['api', 'auth', 'context'],
         handler: (request, reply) => {
             const scm = request.server.app.userFactory.scm;
             const scmContexts = scm.getScmContexts();
@@ -27,6 +27,13 @@ module.exports = () => ({
 
                 contexts.push(context);
             });
+
+            if (config.allowGuestAccess) {
+                contexts.push({
+                    context: 'guest',
+                    displayName: 'Guest Access'
+                });
+            }
 
             return reply(contexts);
         }

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const authjwt = require('hapi-auth-jwt2');
+const authJWT = require('hapi-auth-jwt2');
 const authToken = require('hapi-auth-bearer-token');
 const bell = require('bell');
 const contextsRoute = require('./contexts');
 const crumb = require('crumb');
 const crumbRoute = require('./crumb');
-const hoek = require('hoek');
 const joi = require('joi');
 const jwt = require('jsonwebtoken');
 const keyRoute = require('./key');
@@ -27,6 +26,7 @@ const ALGORITHM = 'RS256';
  * @param  {String}   options.cookiePassword         Password used for temporary encryption of cookie secrets
  * @param  {String}   options.encryptionPassword     Password used for iron encrypting
  * @param  {Boolean}  options.https                  For setting the isSecure flag. Needs to be false for non-https
+ * @param  {Boolean}  options.allowGuestAccess       Letting users browse your system
  * @param  {String}   options.jwtPrivateKey          Secret for signing JWTs
  * @param  {String}  [options.jwtEnvironment]        Environment for the JWTs. Example: 'prod' or 'beta'
  * @param  {Object}   options.scm                    SCM class to setup Authentication
@@ -38,13 +38,13 @@ exports.register = (server, options, next) => {
         https: joi.boolean().truthy('true').falsy('false').required(),
         cookiePassword: joi.string().min(32).required(),
         encryptionPassword: joi.string().min(32).required(),
+        allowGuestAccess: joi.boolean().truthy('true').falsy('false').default(false),
         jwtPrivateKey: joi.string().required(),
         jwtPublicKey: joi.string().required(),
         whitelist: joi.array().default([]),
         admins: joi.array().default([]),
         scm: joi.object().required()
     }), 'Invalid config for plugin-auth');
-    const scmContexts = server.root.app.userFactory.scm.getScmContexts();
 
     /**
      * Generates a profile for storage in cookie and jwt
@@ -89,19 +89,18 @@ exports.register = (server, options, next) => {
         jwtid: uuid()
     }));
 
-    const modules = [bell, sugar, authjwt, authToken, {
-        register: crumb,
-        options: {
-            restful: true,
-            skip: request =>
-                // Skip crumb validation when the request is authorized with jwt or the route is under webhooks
-                !!request.headers.authorization ||
-                !!request.route.path.includes('/webhooks') ||
-                !!request.route.path.includes('/auth/')
-        }
-    }];
-
-    return server.register(modules)
+    return server.register([
+        bell, sugar, authToken, authJWT, {
+            register: crumb,
+            options: {
+                restful: true,
+                skip: request =>
+                    // Skip crumb validation when the request is authorized with jwt or the route is under webhooks
+                    !!request.headers.authorization ||
+                    !!request.route.path.includes('/webhooks') ||
+                    !!request.route.path.includes('/auth/')
+            }
+        }])
         .then(() => pluginOptions.scm.getBellConfiguration())
         .then((bellConfigs) => {
             Object.keys(bellConfigs).forEach((scmContext) => {
@@ -140,14 +139,16 @@ exports.register = (server, options, next) => {
                 validateFunc: function _validateFunc(token, cb) {
                     // Token is an API token
                     // using function syntax makes 'this' the request
-                    // TODO: Should log that we're authenticating a user with a token
-                    const factory = this.server.app.userFactory;
+                    const request = this;
+                    const factory = request.server.app.userFactory;
 
                     return factory.get({ accessToken: token })
                         .then((user) => {
                             if (!user) {
                                 return cb(null, false, {});
                             }
+
+                            request.log(['auth'], `${user.username} has logged in via API keys`);
 
                             const profile = {
                                 username: user.username,
@@ -161,29 +162,12 @@ exports.register = (server, options, next) => {
                         });
                 }
             });
-
-            const loginRoutes = [];
-
-            scmContexts.forEach((scmContext) => {
-                const auth = {
-                    strategy: `oauth_${scmContext}`,
-                    mode: 'try'
-                };
-                const loginOptions = hoek.applyToDefaults(pluginOptions, { scmContext, auth });
-
-                loginRoutes.push(loginRoute(loginOptions));
-            });
-            // This login route for which scmContext isn't passed just redirects to a default login route, so this login route doesn't need to have any auth strategy
-            loginRoutes.push(loginRoute(hoek.applyToDefaults(pluginOptions, {
-                scmContext: '', auth: null
-            })));
-
-            server.route(loginRoutes.concat([
+            server.route(loginRoute(server, pluginOptions).concat([
                 logoutRoute(),
                 tokenRoute(),
                 crumbRoute(),
                 keyRoute(pluginOptions),
-                contextsRoute()
+                contextsRoute(pluginOptions)
             ]));
 
             next();

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -1,97 +1,145 @@
 'use strict';
 
 const boom = require('boom');
-const urlLib = require('url');
+const uuid = require('uuid/v4');
+
+/**
+ * Add a guest route for those who want to be in read-only mode
+ * @method addGuestRoute
+ * @param  {Hapi}     server                        Hapi Server
+ * @param  {Object}   config                        Configuration object
+ * @param  {Boolean}  config.allowGuestAccess       Letting users browse your system
+ * @return Array                                    List of new routes
+ */
+function addGuestRoute(server, config) {
+    return [{
+        method: ['GET'],
+        path: '/auth/login/guest/{web?}',
+        config: {
+            description: 'Login as an guest user',
+            notes: 'Authenticate an guest user',
+            tags: ['api', 'login'],
+            auth: null,
+            handler: (request, reply) => {
+                // Check if guest is allowed to login
+                if (!config.allowGuestAccess) {
+                    return reply(boom.forbidden('Guest users are not allowed access'));
+                }
+
+                const username = `guest/${uuid()}`;
+                const profile = request.server.plugins.auth.generateProfile(
+                    username, 'guest', ['user', 'guest'], {}
+                );
+
+                // Log that the user has authenticated
+                request.log(['auth'], `${username} has logged in`);
+
+                profile.token = request.server.plugins.auth.generateToken(profile);
+                request.cookieAuth.set(profile);
+
+                if (request.params.web === 'web') {
+                    return reply('<script>window.close();</script>');
+                }
+
+                return reply().redirect('/v4/auth/token');
+            }
+        }
+    }];
+}
+
+/**
+ * Add OAuth Routes for all SCM Contexts
+ * @method addOAuthRoutes
+ * @param  {Hapi}     server                 Hapi Server
+ * @param  {Object}   config                 Configuration object
+ * @param  {Array}  config.whitelist         List of users allowed into your system
+ * @return Array                             List of new routes
+ */
+function addOAuthRoutes(server, config) {
+    const scmContexts = server.root.app.userFactory.scm.getScmContexts();
+
+    return scmContexts.map(scmContext => ({
+        method: ['GET', 'POST'],
+        path: `/auth/login/${scmContext}/{web?}`,
+        config: {
+            description: 'Login using oauth',
+            notes: 'Authenticate user with oauth provider',
+            tags: ['api', 'login'],
+            auth: {
+                strategy: `oauth_${scmContext}`,
+                mode: 'try'
+            },
+            handler: (request, reply) => {
+                if (!request.auth.isAuthenticated) {
+                    return reply(boom.unauthorized(
+                        `Authentication failed due to: ${request.auth.error.message}`
+                    ));
+                }
+
+                const factory = request.server.app.userFactory;
+                const accessToken = request.auth.credentials.token;
+                const username = request.auth.credentials.profile.username;
+                const profile = request.server.plugins.auth
+                    .generateProfile(username, scmContext, ['user'], {});
+                const scmDisplayName = factory.scm.getDisplayName({ scmContext });
+                const userDisplayName = `${scmDisplayName}:${username}`;
+
+                // Check whitelist
+                if (config.whitelist.length > 0 && !config.whitelist.includes(userDisplayName)) {
+                    return reply(boom.forbidden(
+                        `User ${userDisplayName} is not allowed access`
+                    ));
+                }
+
+                // Log that the user has authenticated
+                request.log(['auth'], `${userDisplayName} has logged in via OAuth`);
+
+                profile.token = request.server.plugins.auth.generateToken(profile);
+                request.cookieAuth.set(profile);
+
+                return factory.get({ username, scmContext })
+                    // get success, so user exists
+                    .then((model) => {
+                        if (!model) {
+                            return factory.create({
+                                username,
+                                scmContext,
+                                token: accessToken
+                            });
+                        }
+
+                        return model.sealToken(accessToken)
+                            .then((encryptedAccessToken) => {
+                                model.token = encryptedAccessToken;
+
+                                return model.update();
+                            });
+                    })
+                    .then(() => {
+                        if (request.params.web === 'web') {
+                            return reply('<script>window.close();</script>');
+                        }
+
+                        return reply().redirect('/v4/auth/token');
+                    })
+                    .catch(err => reply(boom.wrap(err)));
+            }
+        }
+    }));
+}
 
 /**
  * Login to Screwdriver API
  * @method login
- * @param  {Object}      config           Configuration from the user
- * @param  {Array}       config.whitelist List of allowed users to the API
- * @return {Object}                       Hapi Plugin Route
+ * @param  {Object}      config                      Configuration from the user
+ * @param  {Array}       config.whitelist            List of allowed users to the system
+ * @param  {Boolean}     config.allowGuestAccess     Letting users browse your system
+ * @return {Array}                                   Hapi Plugin Routes
  */
-module.exports = config => ({
-    method: ['GET', 'POST'],
-    path: config.scmContext ? `/auth/login/${config.scmContext}/{web?}` : '/auth/login/{web?}',
-    config: {
-        description: 'Login using oauth',
-        notes: 'Authenticate user with oauth provider',
-        tags: ['api', 'login'],
-        auth: config.auth,
-        handler: (request, reply) => {
-            const pathNames = request.path.split('/');
-            const scmContext = pathNames[pathNames.indexOf('login') + 1];
+module.exports = (server, config) => [].concat(
+    // Guest: `GET /auth/login/guest`
+    addGuestRoute(server, config),
 
-            // Redirect to the default login path if request path doesn't have a context
-            if (!scmContext || scmContext === 'web') {
-                const defaultContext = request.server.root.app.userFactory.scm.getScmContexts()[0];
-                const prefix = request.route.realm.modifiers.route.prefix;
-                let pathName = `${prefix}/auth/login/${defaultContext}`;
-
-                if (request.params.web) {
-                    pathName += '/web';
-                }
-
-                const location = urlLib.format({
-                    host: request.headers.host,
-                    port: request.headers.port,
-                    protocol: request.server.info.protocol,
-                    pathname: pathName
-                });
-
-                return reply().header('Location', location).code(301);
-            }
-
-            if (!request.auth.isAuthenticated) {
-                return reply(boom.unauthorized(
-                    `Authentication failed due to: ${request.auth.error.message}`
-                ));
-            }
-
-            const factory = request.server.app.userFactory;
-            const accessToken = request.auth.credentials.token;
-            const username = request.auth.credentials.profile.username;
-            const profile = request.server.plugins.auth
-                .generateProfile(username, scmContext, ['user'], {});
-            const scmDisplayName = factory.scm.getDisplayName({ scmContext });
-            const userDisplayName = `${scmDisplayName}:${username}`;
-
-            // Check whitelist
-            if (config.whitelist.length > 0 && !config.whitelist.includes(userDisplayName)) {
-                return reply(boom.forbidden(
-                    `User ${userDisplayName} is not whitelisted to use the api`
-                ));
-            }
-
-            profile.token = request.server.plugins.auth.generateToken(profile);
-            request.cookieAuth.set(profile);
-
-            return factory.get({ username, scmContext })
-                // get success, so user exists
-                .then((model) => {
-                    if (!model) {
-                        return factory.create({
-                            username,
-                            scmContext,
-                            token: accessToken
-                        });
-                    }
-
-                    return model.sealToken(accessToken)
-                        .then((token) => {
-                            model.token = token;
-
-                            return model.update();
-                        });
-                })
-                .then(() => {
-                    if (request.params.web === 'web') {
-                        return reply('<script>window.close();</script>');
-                    }
-
-                    return reply().redirect('/v4/auth/token');
-                })
-                .catch(err => reply(boom.wrap(err)));
-        }
-    }
-});
+    // OAuth: `GET /auth/login/{scmContext}` or `POST /auth/login/oauth/{scmContext}`
+    addOAuthRoutes(server, config)
+);

--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -17,11 +17,11 @@ module.exports = config => ({
         tags: ['api', 'builds', 'artifacts'],
         auth: {
             strategies: ['session', 'token'],
-            scope: ['user']
+            scope: ['user', 'build']
         },
         plugins: {
             'hapi-swagger': {
-                security: [{ session: [] }]
+                security: [{ token: [] }]
             }
         },
         handler: (request, reply) => {

--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -12,8 +12,8 @@ module.exports = () => ({
         notes: 'Create and start a specific build',
         tags: ['api', 'builds'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/builds/get.js
+++ b/plugins/builds/get.js
@@ -13,6 +13,15 @@ module.exports = () => ({
         description: 'Get a single build',
         notes: 'Returns a build record',
         tags: ['api', 'builds'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.buildFactory;
 

--- a/plugins/builds/listSecrets.js
+++ b/plugins/builds/listSecrets.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Returns all secrets for a given build',
         tags: ['api', 'builds', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user', 'build']
+            strategies: ['token'],
+            scope: ['user', 'build', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/builds/steps/get.js
+++ b/plugins/builds/steps/get.js
@@ -11,6 +11,15 @@ module.exports = () => ({
         description: 'Get a step for a build',
         notes: 'Returns a step record',
         tags: ['api', 'builds', 'steps'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.buildFactory;
 

--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -14,6 +14,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['build']
         },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.buildFactory;
             const buildId = request.params.id;

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -14,8 +14,13 @@ module.exports = () => ({
         notes: 'Update a specific build',
         tags: ['api', 'builds'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user', 'build']
+            strategies: ['token'],
+            scope: ['build', 'user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const buildFactory = request.server.app.buildFactory;

--- a/plugins/collections/create.js
+++ b/plugins/collections/create.js
@@ -12,8 +12,8 @@ module.exports = () => ({
         notes: 'Creates a collection',
         tags: ['api', 'collections'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/collections/list.js
+++ b/plugins/collections/list.js
@@ -12,7 +12,7 @@ module.exports = () => ({
         notes: 'Returns all collection records belonging to the requesting user',
         tags: ['api', 'collections'],
         auth: {
-            strategies: ['token', 'session'],
+            strategies: ['token'],
             scope: ['user']
         },
         plugins: {

--- a/plugins/collections/remove.js
+++ b/plugins/collections/remove.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Returns null if successful',
         tags: ['api', 'collections'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/collections/update.js
+++ b/plugins/collections/update.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Update a specific collection',
         tags: ['api', 'collection'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/commands/create.js
+++ b/plugins/commands/create.js
@@ -14,8 +14,8 @@ module.exports = () => ({
         notes: 'Create a specific command',
         tags: ['api', 'commands'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['build']
+            strategies: ['token'],
+            scope: ['build', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/commands/createTag.js
+++ b/plugins/commands/createTag.js
@@ -17,8 +17,8 @@ module.exports = () => ({
         notes: 'Add or update a specific command',
         tags: ['api', 'commands'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['build']
+            strategies: ['token'],
+            scope: ['build', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -12,8 +12,8 @@ module.exports = () => ({
         notes: 'Create and start a specific event',
         tags: ['api', 'events'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/events/get.js
+++ b/plugins/events/get.js
@@ -13,6 +13,15 @@ module.exports = () => ({
         description: 'Get a single event',
         notes: 'Returns a event record',
         tags: ['api', 'events'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.eventFactory;
 

--- a/plugins/events/listBuilds.js
+++ b/plugins/events/listBuilds.js
@@ -12,6 +12,15 @@ module.exports = () => ({
         description: 'Get builds for a given event',
         notes: 'Returns builds for a given event',
         tags: ['api', 'events', 'builds'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.eventFactory;
 

--- a/plugins/jobs/get.js
+++ b/plugins/jobs/get.js
@@ -13,6 +13,15 @@ module.exports = () => ({
         description: 'Get a single job',
         notes: 'Returns a job record',
         tags: ['api', 'jobs'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.jobFactory;
 

--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -12,6 +12,15 @@ module.exports = () => ({
         description: 'Get builds for a given job',
         notes: 'Returns builds for a given job',
         tags: ['api', 'jobs', 'builds'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.jobFactory;
 

--- a/plugins/jobs/update.js
+++ b/plugins/jobs/update.js
@@ -13,8 +13,13 @@ module.exports = () => ({
         notes: 'Update a specific job',
         tags: ['api', 'jobs'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const factory = request.server.app.jobFactory;

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Create a specific pipeline',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/pipelines/get.js
+++ b/plugins/pipelines/get.js
@@ -13,6 +13,15 @@ module.exports = () => ({
         description: 'Get a single pipeline',
         notes: 'Returns a pipeline record',
         tags: ['api', 'pipelines'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.pipelineFactory;
 

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -12,6 +12,15 @@ module.exports = () => ({
         description: 'Get pipelines with pagination',
         notes: 'Returns all pipeline records',
         tags: ['api', 'pipelines'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.pipelineFactory;
             const scmContexts = factory.scm.getScmContexts();

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -12,6 +12,15 @@ module.exports = () => ({
         description: 'Get pipeline type events for this pipeline',
         notes: 'Returns pipeline events for the given pipeline',
         tags: ['api', 'pipelines', 'events'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.pipelineFactory;
 

--- a/plugins/pipelines/listJobs.js
+++ b/plugins/pipelines/listJobs.js
@@ -12,6 +12,15 @@ module.exports = () => ({
         description: 'Get all jobs for a given pipeline',
         notes: 'Returns all jobs for a given pipeline',
         tags: ['api', 'pipelines', 'jobs'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.pipelineFactory;
 

--- a/plugins/pipelines/listSecrets.js
+++ b/plugins/pipelines/listSecrets.js
@@ -13,8 +13,13 @@ module.exports = () => ({
         notes: 'Returns all secrets for a given pipeline',
         tags: ['api', 'pipelines', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const pipelineFactory = request.server.app.pipelineFactory;

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -13,8 +13,13 @@ module.exports = () => ({
         notes: 'Returns null if successful',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const pipelineFactory = request.server.app.pipelineFactory;

--- a/plugins/pipelines/sync.js
+++ b/plugins/pipelines/sync.js
@@ -13,8 +13,13 @@ module.exports = () => ({
         notes: 'Sync a specific pipeline',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const id = request.params.id;

--- a/plugins/pipelines/syncPRs.js
+++ b/plugins/pipelines/syncPRs.js
@@ -13,8 +13,13 @@ module.exports = () => ({
         notes: 'Add or update pull request jobs',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const id = request.params.id;

--- a/plugins/pipelines/syncWebhooks.js
+++ b/plugins/pipelines/syncWebhooks.js
@@ -13,8 +13,13 @@ module.exports = () => ({
         notes: 'Add or update Screwdriver API webhooks',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const id = request.params.id;

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -14,8 +14,8 @@ module.exports = () => ({
         notes: 'Update a specific pipeline',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/secrets/create.js
+++ b/plugins/secrets/create.js
@@ -12,8 +12,8 @@ module.exports = () => ({
         notes: 'Create a specific secret',
         tags: ['api', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/secrets/get.js
+++ b/plugins/secrets/get.js
@@ -14,8 +14,8 @@ module.exports = () => ({
         notes: 'Returns a secret record',
         tags: ['api', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user', 'build']
+            strategies: ['token'],
+            scope: ['user', 'build', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/secrets/remove.js
+++ b/plugins/secrets/remove.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Returns null if successful',
         tags: ['api', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/secrets/update.js
+++ b/plugins/secrets/update.js
@@ -13,8 +13,13 @@ module.exports = () => ({
         notes: 'Update a specific secret',
         tags: ['api', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
         },
         handler: (request, reply) => {
             const factory = request.server.app.secretFactory;

--- a/plugins/templates/create.js
+++ b/plugins/templates/create.js
@@ -15,7 +15,7 @@ module.exports = () => ({
         notes: 'Create a specific template',
         tags: ['api', 'templates'],
         auth: {
-            strategies: ['token', 'session'],
+            strategies: ['token'],
             scope: ['build']
         },
         plugins: {

--- a/plugins/templates/createTag.js
+++ b/plugins/templates/createTag.js
@@ -17,7 +17,7 @@ module.exports = () => ({
         notes: 'Add or update a specific template',
         tags: ['api', 'templates'],
         auth: {
-            strategies: ['token', 'session'],
+            strategies: ['token'],
             scope: ['build']
         },
         plugins: {

--- a/plugins/templates/get.js
+++ b/plugins/templates/get.js
@@ -15,6 +15,15 @@ module.exports = () => ({
         description: 'Get a single template given template name and version or tag',
         notes: 'Returns a template record',
         tags: ['api', 'templates'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const templateFactory = request.server.app.templateFactory;
             const { name, versionOrTag } = request.params;

--- a/plugins/templates/list.js
+++ b/plugins/templates/list.js
@@ -12,6 +12,15 @@ module.exports = () => ({
         description: 'Get templates with pagination',
         notes: 'Returns all template records',
         tags: ['api', 'templates'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.templateFactory;
 

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -13,6 +13,15 @@ module.exports = () => ({
         description: 'Get all template tags for a given template name',
         notes: 'Returns all template tags for a given template name',
         tags: ['api', 'templates', 'tags'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.templateTagFactory;
 

--- a/plugins/templates/listVersions.js
+++ b/plugins/templates/listVersions.js
@@ -13,6 +13,15 @@ module.exports = () => ({
         description: 'Get all template versions for a given template name with pagination',
         notes: 'Returns all template records for a given template name',
         tags: ['api', 'templates', 'versions'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
         handler: (request, reply) => {
             const factory = request.server.app.templateFactory;
 

--- a/plugins/templates/removeTag.js
+++ b/plugins/templates/removeTag.js
@@ -16,7 +16,7 @@ module.exports = () => ({
         notes: 'Delete a specific template',
         tags: ['api', 'templates'],
         auth: {
-            strategies: ['token', 'session'],
+            strategies: ['token'],
             scope: ['build']
         },
         plugins: {

--- a/plugins/tokens/create.js
+++ b/plugins/tokens/create.js
@@ -12,8 +12,8 @@ module.exports = () => ({
         notes: 'Create a specific token',
         tags: ['api', 'tokens'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/tokens/list.js
+++ b/plugins/tokens/list.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Returns all token records belonging to the current user',
         tags: ['api', 'tokens'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/tokens/refresh.js
+++ b/plugins/tokens/refresh.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Update the value of a token while preserving its other metadata',
         tags: ['api', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/tokens/remove.js
+++ b/plugins/tokens/remove.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Returns null if successful',
         tags: ['api', 'tokens'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -13,8 +13,8 @@ module.exports = () => ({
         notes: 'Update a specific tooken',
         tags: ['api', 'secrets'],
         auth: {
-            strategies: ['token', 'session'],
-            scope: ['user']
+            strategies: ['token'],
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {

--- a/test/plugins/collections.test.js
+++ b/test/plugins/collections.test.js
@@ -129,10 +129,9 @@ describe('collection plugin test', () => {
         });
 
         server.auth.scheme('custom', () => ({
-            authenticate: (request, reply) => reply.continue({})
+            authenticate: (request, reply) => reply.continue()
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         return server.register([{
             register: plugin

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -88,10 +88,13 @@ describe('command plugin test', () => {
         });
 
         server.auth.scheme('custom', () => ({
-            authenticate: (request, reply) => reply.continue({})
+            authenticate: (request, reply) => reply.continue({
+                credentials: {
+                    scope: ['user']
+                }
+            })
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         server.register([{
             register: plugin

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -85,10 +85,13 @@ describe('event plugin test', () => {
         });
 
         server.auth.scheme('custom', () => ({
-            authenticate: (request, reply) => reply.continue({})
+            authenticate: (request, reply) => reply.continue({
+                credentials: {
+                    scope: ['user']
+                }
+            })
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         server.register([{
             register: plugin

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -75,10 +75,13 @@ describe('job plugin test', () => {
         });
 
         server.auth.scheme('custom', () => ({
-            authenticate: (request, reply) => reply.continue({})
+            authenticate: (request, reply) => reply.continue({
+                credentials: {
+                    scope: ['user']
+                }
+            })
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         server.register([{
             register: plugin

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -167,10 +167,13 @@ describe('pipeline plugin test', () => {
         });
 
         server.auth.scheme('custom', () => ({
-            authenticate: (request, reply) => reply.continue({})
+            authenticate: (request, reply) => reply.continue({
+                credentials: {
+                    scope: ['user']
+                }
+            })
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         server.register([{
             register: plugin,

--- a/test/plugins/secrets.test.js
+++ b/test/plugins/secrets.test.js
@@ -82,10 +82,13 @@ describe('secret plugin test', () => {
         });
 
         server.auth.scheme('custom', () => ({
-            authenticate: (request, reply) => reply.continue({})
+            authenticate: (request, reply) => reply.continue({
+                credentials: {
+                    scope: ['user']
+                }
+            })
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         server.register([{
             register: plugin,

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -90,10 +90,13 @@ describe('template plugin test', () => {
         });
 
         server.auth.scheme('custom', () => ({
-            authenticate: (request, reply) => reply.continue({})
+            authenticate: (request, reply) => reply.continue({
+                credentials: {
+                    scope: ['user']
+                }
+            })
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         server.register([{
             register: plugin

--- a/test/plugins/tokens.test.js
+++ b/test/plugins/tokens.test.js
@@ -101,7 +101,6 @@ describe('token plugin test', () => {
             authenticate: (request, reply) => reply.continue({})
         }));
         server.auth.strategy('token', 'custom');
-        server.auth.strategy('session', 'custom');
 
         return server.register([{
             register: plugin


### PR DESCRIPTION
## Context

We're in a mixed mode right now, where anonymous browsing is allowed but logs and artifacts are not.  As per [this issue](https://github.com/screwdriver-cd/screwdriver/issues/870) our goal should be to allow server admins to chose wether guests can browse the site or not.  For example, cd.screwdriver.cd should allow guests to view the logs while internal deployments may not.

## Objective

This adds a configuration that will enable users to browse your pipelines, jobs, and builds without authenticating against a SCM.  It forces read-only access.

As a side effect, all routes (minus health check, stats, webhooks, and badges) now require token-based auth.  It also includes specific references as to what a build can access during a build.

## Breaking changes

 - Default routes of `/auth/login/` are no longer redirected to the first SCM.
 - Endpoints other than `/auth/token` no longer accept session-based auth.
 - Most endpoints now require authentication (except status, stats, webhooks, and badges)
 - Builds have explicit access to 19 routes.
 - Guests are forbidden from 26 routes.

## References

 - https://github.com/screwdriver-cd/screwdriver/issues/870
 - https://github.com/screwdriver-cd/screwdriver/issues/572