### PR TITLE
fix: Don't check admin list when in guest mode

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -64,14 +64,16 @@ exports.register = (server, options, next) => {
             profile.environment = pluginOptions.jwtEnvironment;
         }
 
-        const scm = server.root.app.userFactory.scm;
-        const scmDisplayName = scm.getDisplayName({ scmContext });
-        const userDisplayName = `${scmDisplayName}:${username}`;
+        if (scmContext) {
+            const scm = server.root.app.userFactory.scm;
+            const scmDisplayName = scm.getDisplayName({ scmContext });
+            const userDisplayName = `${scmDisplayName}:${username}`;
 
-        // Check admin
-        if (pluginOptions.admins.length > 0
+            // Check admin
+            if (pluginOptions.admins.length > 0
                 && pluginOptions.admins.includes(userDisplayName)) {
-            profile.scope.push('admin');
+                profile.scope.push('admin');
+            }
         }
 
         return profile;

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -28,7 +28,7 @@ function addGuestRoute(server, config) {
 
                 const username = `guest/${uuid()}`;
                 const profile = request.server.plugins.auth.generateProfile(
-                    username, 'guest', ['user', 'guest'], {}
+                    username, null, ['user', 'guest'], {}
                 );
 
                 // Log that the user has authenticated


### PR DESCRIPTION
## Context

When trying to login with Guest mode, we get the following message:
```
[request,server,error] data: TypeError: Uncaught error: Cannot read property 'getDisplayName' of undefined
    at ScmRouter.getDisplayName (/usr/src/app/node_modules/screwdriver-scm-router/index.js:353:45)
```

## Objective

Allow users to login via Guest Mode.

## References

 - https://github.com/screwdriver-cd/screwdriver/issues/870