### PR TITLE
fix: find by jobId

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -99,10 +99,10 @@ function successBuildsInJoinList(joinList, finishedBuilds) {
  * @param  {String}   config.jobName            jobname for this build
  * @return {Promise}  the newly updated/created build
  */
-function handleNextBuild({ buildConfig, joinList, finishedBuilds, jobName }) {
+function handleNextBuild({ buildConfig, joinList, finishedBuilds, jobId }) {
     return Promise.resolve().then(() => {
         const noFailedBuilds = noFailureSoFar(joinList, finishedBuilds);
-        const nextBuild = finishedBuilds.filter(b => b.jobName === jobName)[0];
+        const nextBuild = finishedBuilds.filter(b => b.jobId === jobId)[0];
 
         // If anything failed so far, delete if nextBuild was created previously, or do nothing otherwise
         // [A B] -> C. A passed -> C created; B failed -> delete C
@@ -307,7 +307,7 @@ exports.register = (server, options, next) => {
                     buildConfig,
                     joinList,
                     finishedBuilds,
-                    jobName: nextJobName
+                    jobId: workflowGraph.nodes.find(node => node.name === nextJobName).id
                 }));
             }));
         });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -938,13 +938,11 @@ describe('build plugin test', () => {
 
                     const buildC = {
                         jobId: 3, // job c was previously created
-                        jobName: 'c',
                         remove: sinon.stub().resolves(null)
                     };
 
                     eventMock.getBuilds.resolves([{
                         jobId: 1,
-                        jobName: 'a',
                         status: 'FAILURE'
                     }, {
                         jobId: 4,
@@ -1086,7 +1084,6 @@ describe('build plugin test', () => {
                 it('update parent build IDs', () => {
                     const buildC = {
                         jobId: 3, // build is already created
-                        jobName: 'c',
                         parentBuildId: [1, 2],
                         update: sinon.stub().resolves(buildMock)
                     };
@@ -1100,12 +1097,10 @@ describe('build plugin test', () => {
 
                     eventMock.getBuilds.resolves([{
                         jobId: 1,
-                        status: 'SUCCESS',
-                        jobName: 'a'
+                        status: 'SUCCESS'
                     }, {
                         jobId: 2,
-                        status: 'SUCCESS',
-                        jobName: 'b'
+                        status: 'SUCCESS'
                     }, buildC]);
 
                     buildMock.start = sinon.stub().resolves();
@@ -1130,11 +1125,9 @@ describe('build plugin test', () => {
                     // job B failed
                     eventMock.getBuilds.resolves([{
                         jobId: 1,
-                        jobName: 'a',
                         status: 'SUCCESS'
                     }, {
                         jobId: 2,
-                        jobName: 'b',
                         status: 'FAILURE'
                     }]);
 


### PR DESCRIPTION
Currently, `nextBuild` is always `null`, so it doesn't go to `update` or `remove` at all. 
This PR fixes it to check if build exists based on `jobId` instead of `jobName`