### PR TITLE
fix: update build status

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -128,7 +128,18 @@ function handleNextBuild({ buildConfig, joinList, finishedBuilds, jobId }) {
         nextBuild.parentBuildId = successBuildsIds;
 
         return nextBuild.update();
-    }).then(nextBuild => (isJoinDone(joinList, finishedBuilds) ? nextBuild.start() : null));
+    }).then((b) => {
+        const done = isJoinDone(joinList, finishedBuilds);
+
+        if (!done) {
+            return null;
+        }
+
+        b.status = 'QUEUED';
+
+        return b.update()
+            .then(newBuild => newBuild.start());
+    });
 }
 
 /**

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1082,10 +1082,15 @@ describe('build plugin test', () => {
                 });
 
                 it('update parent build IDs', () => {
+                    const updatedBuildC = Object.assign({}, buildMock);
+
+                    updatedBuildC.start = sinon.stub().resolves();
+                    updatedBuildC.update = sinon.stub().resolves(updatedBuildC);
+
                     const buildC = {
                         jobId: 3, // build is already created
                         parentBuildId: [1, 2],
-                        update: sinon.stub().resolves(buildMock)
+                        update: sinon.stub().resolves(updatedBuildC)
                     };
 
                     eventMock.workflowGraph.edges = [
@@ -1103,13 +1108,13 @@ describe('build plugin test', () => {
                         status: 'SUCCESS'
                     }, buildC]);
 
-                    buildMock.start = sinon.stub().resolves();
-                    buildMock.update = sinon.stub().resolves(buildMock);
-
                     return server.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);
-                        assert.calledOnce(buildC.update);
+                        assert.calledOnce(buildMock.update); // current build
                         assert.deepEqual(buildC.parentBuildId, [1, 2]);
+                        assert.calledOnce(buildC.update);
+                        assert.calledOnce(updatedBuildC.update);
+                        assert.calledOnce(updatedBuildC.start);
                     });
                 });
 


### PR DESCRIPTION
Update the build status to QUEUED before starting

Related: https://github.com/screwdriver-cd/screwdriver/issues/904