### PR TITLE
fix: save docker_tag in meta

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -21,6 +21,7 @@ jobs:
             - install-ci: npm install npm-auto-version
             - publish-npm: ./ci/publish.sh
             - publish-docker: ./ci/docker.sh
+            - save-tag-to-meta: meta set docker_tag `git describe --tags`
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
         secrets:
@@ -36,9 +37,8 @@ jobs:
         requires: [publish]
         steps:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
-            - get-tag: ./ci/git-latest.sh
-            - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
-            - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
+            - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
+            - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
             - test: npm install && npm run functional
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
@@ -65,9 +65,8 @@ jobs:
         requires: [beta]
         steps:
             - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
-            - get-tag: ./ci/git-latest.sh
-            - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
-            - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
+            - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
+            - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
             - test: npm install && npm run functional
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver


### PR DESCRIPTION
Currently, in beta and prod deployment jobs, we always get the latest tag and try to deploy that version. That way we cannot really roll back to a previous event.

This PR will save `docker_tag` in meta during publish job. Beta and prod will just read from that meta.