### PR TITLE
fix: get buildIds

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -84,9 +84,13 @@ function noFailureSoFar(joinList, finishedBuilds) {
  * @return {Array}                     success builds in join
  */
 function successBuildsInJoinList(joinList, finishedBuilds) {
-    const successBuilds = finishedBuilds.filter(b => b.status === 'SUCCESS').map(b => b.jobId);
+    const successBuilds = finishedBuilds
+        .filter(b => b.status === 'SUCCESS')
+        .map(b => ({ id: b.id, jobId: b.jobId }));
 
-    return joinList.filter(j => successBuilds.includes(j.id));
+    const joinListJobIds = joinList.map(j => j.id);
+
+    return successBuilds.filter(b => joinListJobIds.includes(b.jobId));
 }
 
 /**

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1088,8 +1088,9 @@ describe('build plugin test', () => {
                     updatedBuildC.update = sinon.stub().resolves(updatedBuildC);
 
                     const buildC = {
+                        id: 333,
                         jobId: 3, // build is already created
-                        parentBuildId: [1, 2],
+                        parentBuildId: [111],
                         update: sinon.stub().resolves(updatedBuildC)
                     };
 
@@ -1101,9 +1102,11 @@ describe('build plugin test', () => {
                     ];
 
                     eventMock.getBuilds.resolves([{
+                        id: 111,
                         jobId: 1,
                         status: 'SUCCESS'
                     }, {
+                        id: 222,
                         jobId: 2,
                         status: 'SUCCESS'
                     }, buildC]);
@@ -1111,7 +1114,7 @@ describe('build plugin test', () => {
                     return server.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);
                         assert.calledOnce(buildMock.update); // current build
-                        assert.deepEqual(buildC.parentBuildId, [1, 2]);
+                        assert.deepEqual(buildC.parentBuildId, [111, 222]);
                         assert.calledOnce(buildC.update);
                         assert.calledOnce(updatedBuildC.update);
                         assert.calledOnce(updatedBuildC.start);


### PR DESCRIPTION
Sorry there was a bug. It's getting `jobId` instead of `buildId` since `joinList` actually contains only the job ids. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/904
