### PR TITLE
fix: pull in new scm-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Have a look at our guidelines, as well as pointers on where to start making chan
 
 ### Prerequisites
 
-- Node v6.0.0 or higher
+- Node v8.0.0 or higher
 - [Kubernetes][kubectl] or [Docker][docker]
 
 ### From Source

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-notifications-slack": "^2.1.2",
     "screwdriver-scm-github": "^5.3.2",
-    "screwdriver-scm-router": "^1.0.0",
+    "screwdriver-scm-router": "^2.0.0",
     "screwdriver-template-validator": "^3.0.0",
     "screwdriver-workflow-parser": "^1.1.1",
     "tinytim": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "screwdriver-models": "^26.8.6",
     "screwdriver-notifications-email": "^1.1.2",
     "screwdriver-notifications-slack": "^2.1.2",
-    "screwdriver-scm-github": "^5.3.2",
+    "screwdriver-scm-github": "^6.0.0",
     "screwdriver-scm-router": "^2.0.0",
     "screwdriver-template-validator": "^3.0.0",
     "screwdriver-workflow-parser": "^1.1.1",


### PR DESCRIPTION
Pull in the new `scm-router`, which has the new `scm-base`

Blocked by: https://github.com/screwdriver-cd/scm-router/pull/6
Related: https://github.com/screwdriver-cd/screwdriver/issues/911