### PR TITLE
fix: pass in scmContext to changedFiles

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -406,7 +406,8 @@ exports.register = (server, options, next) => {
                         .then(token => scm.getChangedFiles({
                             payload: request.payload,
                             type,
-                            token
+                            token,
+                            scmContext
                         }))
                         .then((changedFiles) => {
                             parsed.changedFiles = changedFiles;


### PR DESCRIPTION
`scm-router` needs `scmContext` to figure out which `scm` it is to call `getChangedFiles`: https://github.com/screwdriver-cd/scm-router/blob/master/index.js#L285

Related: screwdriver-cd/screwdriver#911