### PR TITLE
fix: broken badge

### DIFF
--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -83,7 +83,11 @@ module.exports = () => ({
                             const buildsStatus = builds.reverse()
                                 .map(build => build.status.toLowerCase());
 
-                            let workflowLength = lastEvent.workflow.length;
+                            let workflowLength = 0;
+
+                            if (lastEvent.workflow) {
+                                workflowLength = lastEvent.workflow.length;
+                            }
 
                             if (lastEvent.workflowGraph) {
                                 workflowLength = lastEvent.workflowGraph.nodes.filter(n =>

--- a/test/plugins/data/events.json
+++ b/test/plugins/data/events.json
@@ -14,7 +14,6 @@
             "username": "imbatman"
         }
     },
-    "workflow": [],
     "workflowGraph": {
         "nodes": [
             { "name": "~pr" },


### PR DESCRIPTION
## Context

I found that badges for recent builds are broken because of inappropriate access to `workflow` object.
https://api.screwdriver.cd/v4/pipelines/1/badge
Currently, `workflow` is undefined for recent builds.
https://api.screwdriver.cd/v4/events/13472

## Objective

I fixed the badge feature by avoiding access to undefined object.
Also I removed `workflow` key from an event mock. I think it is time to remove `workflow` key due to deprecated config and there will be no development for that.
