### PR TITLE
[DNM] fix(969): Clean up templates and template tags when pipeline deleted

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -72,6 +72,7 @@ Example payload:
 ```
 
 #### Delete a pipeline
+* Deleting a pipeline will also delete all dependent templates and template tags
 
 `DELETE /pipelines/{id}`
 


### PR DESCRIPTION
## Context

From https://github.com/screwdriver-cd/screwdriver/issues/969:

> Templates are associated with a pipeline. Currently, when you delete a pipeline, Screwdriver _only_ deletes the pipeline. Any templates and template tags linked to that pipeline are not cleaned up: https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/pipelines/remove.js#L52

 > Since the pipeline model is used for checking build and user credentials, templates with deleted pipelines are essentially "unreachable"; you cannot delete or modify them.

## Objective

* Remove templates and template tags associated with a pipeline when it's deleted

## Related links

* Story: https://github.com/screwdriver-cd/screwdriver/issues/924