### PR TITLE
fix: update artifact-bookend package

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "node-env-file": "^0.1.8",
     "request": "^2.85.0",
     "requestretry": "^1.12.0",
-    "screwdriver-artifact-bookend": "^1.0.1",
+    "screwdriver-artifact-bookend": "^1.1.5",
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-command-validator": "^1.0.2",
     "screwdriver-config-parser": "^3.13.0",


### PR DESCRIPTION
## Context
I fixed `artifact-bookend` to be able to use multi-byte language in url when publishing artifacts to the store. So, I updated `package.json` to use latest `artifact-bookend` package.

## References
Related: https://github.com/screwdriver-cd/artifact-bookend/pull/10
