### PR TITLE
feat(845): add config for tolerations to k8s

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -90,6 +90,14 @@ executor:
                 memory:
                     low: K8S_MEMORY_LOW
                     high: K8S_MEMORY_HIGH
+            # k8s node selectors for approprate build pod scheduling.
+            # Value is Object of format { label: 'value' } See
+            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
+            # Eg: { dedicated: 'screwdriver' } to schedule pods on nodes having
+            # label-value of dedicated=screwdriver
+            nodeSelectors:
+              __name: K8S_NODE_SELECTORS
+              __format: json
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
         # Prefix to the pod

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -78,6 +78,8 @@ executor:
                     # Memory in GB
                     low: 2
                     high: 12
+            # k8s node selectors for approprate pod scheduling
+            nodeSelectors: {}
         # Container tags to use
         launchVersion: stable
     # nomad:


### PR DESCRIPTION
## Context
`executor-k8s` does not support adding tolerations config.

## Objective
This PR adds tolerations config.

## References
Related: https://github.com/screwdriver-cd/screwdriver/issues/845
Similar Update: https://github.com/screwdriver-cd/screwdriver/pull/828
