### PR TITLE
fix: set docker_tag with latest npm tag

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -21,7 +21,9 @@ jobs:
             - install-ci: npm install npm-auto-version
             - publish-npm: ./ci/publish.sh
             - publish-docker: ./ci/docker.sh
-            - save-tag-to-meta: meta set docker_tag `git describe --tags`
+            - save-tag-to-meta: |
+                NPM_PKG_VERSION=`npm dist-tag ls | awk -F: '{ print $2 }' | tr -d '[:space:]'`
+                meta set docker_tag "v$NPM_PKG_VERSION"
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
         secrets:


### PR DESCRIPTION
## Context
If you have multiple tags attached to same `sha`, `git describe --tags ` will give you the oldest one. That makes it impossible to re-run the pipeline and pull in dependencies without code change. 

## Objective
This PR will use the latest npm tag instead. 
`npm dist-tag ls` will give you the latest tag like this `latest: 0.5.278`.
We will parse it and make it `v0.5.278` eventually

