### PR TITLE
feat(972): add preferredNodeSelectors config to api

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -98,6 +98,16 @@ executor:
             nodeSelectors:
               __name: K8S_NODE_SELECTORS
               __format: json
+            # k8s preferred node selectors for try to approprate build pod scheduling
+            # but if it’s not possible, then allow some to run elsewhere.
+            # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+            # Value is Object of format { label: 'value' } See
+            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
+            # Eg: { dedicated: 'screwdriver' } try to schedule pods on nodes having
+            # label-value of dedicated=screwdriver
+            preferredNodeSelectors:
+              __name: K8S_PREFERRED_NODE_SELECTORS
+              __format: json
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION
         # Prefix to the pod
@@ -159,6 +169,16 @@ executor:
             # label-value of dedicated=screwdriver
             nodeSelectors:
               __name: K8S_NODE_SELECTORS
+              __format: json
+            # k8s preferred node selectors for try to approprate build pod scheduling
+            # but if it’s not possible, then allow some to run elsewhere.
+            # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
+            # Value is Object of format { label: 'value' } See
+            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
+            # Eg: { dedicated: 'screwdriver' } try to schedule pods on nodes having
+            # label-value of dedicated=screwdriver
+            preferredNodeSelectors:
+              __name: K8S_PREFERRED_NODE_SELECTORS
               __format: json
         # Launcher container tag to use
         launchVersion: LAUNCH_VERSION

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -98,13 +98,8 @@ executor:
             nodeSelectors:
               __name: K8S_NODE_SELECTORS
               __format: json
-            # k8s preferred node selectors for try to approprate build pod scheduling
-            # but if it’s not possible, then allow some to run elsewhere.
+            # k8s preferred node selectors for build pod scheduling
             # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-            # Value is Object of format { label: 'value' } See
-            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
-            # Eg: { dedicated: 'screwdriver' } try to schedule pods on nodes having
-            # label-value of dedicated=screwdriver
             preferredNodeSelectors:
               __name: K8S_PREFERRED_NODE_SELECTORS
               __format: json
@@ -170,13 +165,8 @@ executor:
             nodeSelectors:
               __name: K8S_NODE_SELECTORS
               __format: json
-            # k8s preferred node selectors for try to approprate build pod scheduling
-            # but if it’s not possible, then allow some to run elsewhere.
+            # k8s preferred node selectors for build pod scheduling
             # See https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature
-            # Value is Object of format { label: 'value' } See
-            # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#step-one-attach-label-to-the-node
-            # Eg: { dedicated: 'screwdriver' } try to schedule pods on nodes having
-            # label-value of dedicated=screwdriver
             preferredNodeSelectors:
               __name: K8S_PREFERRED_NODE_SELECTORS
               __format: json

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -80,6 +80,7 @@ executor:
                     high: 12
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
+            preferredNodeSelectors: {}
         # Container tags to use
         launchVersion: stable
     # nomad:
@@ -124,6 +125,7 @@ executor:
                     high: 12
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
+            preferredNodeSelectors: {}
         # Launcher container tag to use
         launchVersion: stable
 #     jenkins:


### PR DESCRIPTION
Add an ability to configure preferred node affinity like https://github.com/screwdriver-cd/screwdriver/issues/827.

This PR adds `preferredNodeSelectors` to be able to use `preferredDuringSchedulingIgnoredDuringExecution` config in the pod execution.

- Related: https://github.com/screwdriver-cd/screwdriver/issues/972
- Similar PR: https://github.com/screwdriver-cd/screwdriver/pull/828
- [Node affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity-beta-feature)
