### PR TITLE
fix: bump artifact-bookend version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "node-env-file": "^0.1.8",
     "request": "^2.85.0",
     "requestretry": "^1.12.0",
-    "screwdriver-artifact-bookend": "^1.1.5",
+    "screwdriver-artifact-bookend": "^1.1.7",
     "screwdriver-build-bookend": "^2.0.1",
     "screwdriver-command-validator": "^1.0.2",
     "screwdriver-config-parser": "^3.14.1",


### PR DESCRIPTION
I fixed artifact-bookend, so I updated package.json to use latest artifact-bookend package.

Related: https://github.com/screwdriver-cd/artifact-bookend/pull/13