### PR TITLE
[DNM] fix: Fix /versions

### DIFF
--- a/plugins/versions.js
+++ b/plugins/versions.js
@@ -16,10 +16,10 @@ const VError = require('verror');
 exports.register = (server, options, next) => {
     // Designed to match Screwdriver specific packages
     const SD_REGEX = /^screwdriver-/;
-    let start = process.cwd();
+    let start = path.resolve(process.cwd(), '../..');
 
-    if (!fs.existsSync(path.resolve(process.cwd(), './node_modules'))) {
-        start = path.resolve(process.cwd(), '../..');
+    if (!fs.existsSync(path.resolve(start, './node_modules'))) {
+        start = process.cwd();
     }
 
     // Load licenses


### PR DESCRIPTION
## Context

The `/versions` endpoint only works locally, not in production, because node modules are stored differently locally. Need to default to checking for node modules two levels up, because there is always node modules locally.

## Objective

This PR defaults to checking two levels up for the node modules.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/986
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/485
