### PR TITLE
fix(115): Add response schemas for versions, contexts, stats, and status

### DIFF
--- a/plugins/auth/contexts.js
+++ b/plugins/auth/contexts.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const schema = require('screwdriver-data-schema');
+
 /**
  * Get all auth contexts
  * @method login
@@ -36,6 +38,9 @@ module.exports = config => ({
             }
 
             return reply(contexts);
+        },
+        response: {
+            schema: schema.api.auth.contexts
         }
     }
 });

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -18,7 +18,7 @@ function addGuestRoute(server, config) {
         config: {
             description: 'Login as an guest user',
             notes: 'Authenticate an guest user',
-            tags: ['api', 'login'],
+            tags: ['api', 'auth', 'login'],
             auth: null,
             handler: (request, reply) => {
                 // Check if guest is allowed to login
@@ -64,7 +64,7 @@ function addOAuthRoutes(server, config) {
         config: {
             description: 'Login using oauth',
             notes: 'Authenticate user with oauth provider',
-            tags: ['api', 'login'],
+            tags: ['api', 'auth', 'login'],
             auth: {
                 strategy: `oauth_${scmContext}`,
                 mode: 'try'

--- a/plugins/auth/logout.js
+++ b/plugins/auth/logout.js
@@ -11,7 +11,7 @@ module.exports = () => ({
     config: {
         description: 'Logout of screwdriver',
         notes: 'Clears the cookie used for authentication',
-        tags: ['api', 'logout'],
+        tags: ['api', 'auth', 'logout'],
         auth: {
             strategies: ['token', 'session']
         },

--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -57,9 +57,6 @@ module.exports = () => ({
                 .then(build => reply(build.steps[stepIndex]).code(200))
                 .catch(err => reply(boom.wrap(err)));
         },
-        response: {
-            schema: schema.models.build.getStep
-        },
         validate: {
             params: schema.api.loglines.params,
             payload: schema.models.build.updateStep

--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -57,6 +57,9 @@ module.exports = () => ({
                 .then(build => reply(build.steps[stepIndex]).code(200))
                 .catch(err => reply(boom.wrap(err)));
         },
+        response: {
+            schema: schema.models.build.getStep
+        },
         validate: {
             params: schema.api.loglines.params,
             payload: schema.models.build.updateStep

--- a/plugins/stats.js
+++ b/plugins/stats.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const schema = require('screwdriver-data-schema');
+
 /**
  * Hapi interface for plugin to set up status endpoint (see Hapi docs)
  * @method register
@@ -17,7 +19,10 @@ exports.register = (server, options, next) => {
         config: {
             description: 'API stats',
             notes: 'Should return statistics for the entire system',
-            tags: ['api', 'stats']
+            tags: ['api', 'stats'],
+            response: {
+                schema: schema.api.stats
+            }
         },
         handler: (request, reply) => reply({
             executor: executor.stats(),

--- a/plugins/status.js
+++ b/plugins/status.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const schema = require('screwdriver-data-schema');
+
 /**
  * Hapi interface for plugin to set up status endpoint (see Hapi docs)
  * @method register
@@ -16,7 +18,10 @@ exports.register = (server, options, next) => {
         config: {
             description: 'API status',
             notes: 'Should respond with 200: ok',
-            tags: ['api']
+            tags: ['api'],
+            response: {
+                schema: schema.api.status
+            }
         }
     });
     next();

--- a/plugins/versions.js
+++ b/plugins/versions.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const process = require('process');
 const VError = require('verror');
+const schema = require('screwdriver-data-schema');
 
 /**
  * Hapi interface for plugin to return package list
@@ -51,7 +52,10 @@ exports.register = (server, options, next) => {
             config: {
                 description: 'API Package Versions',
                 notes: 'Returns list of Screwdriver package versions and third-party dependencies',
-                tags: ['api']
+                tags: ['api'],
+                response: {
+                    schema: schema.api.versions
+                }
             }
         });
 


### PR DESCRIPTION
## Context

There are response object schemas missing for several endpoints as detailed in screwdriver-cd/screwdriver#115

Pending merging of https://github.com/screwdriver-cd/data-schema/pull/222

## Objective

- [x] Add response object schemas for:
  - [x] versions
  - [x] contexts
  - [x] stats
  - [x] status 
- [x] Remove incorrect response schema for step update
- [x] Add auth tag to login and logout routes

## References

Swagger documentation:
https://api.screwdriver.cd/v4/documentation