### PR TITLE
fix: pin datastore-sequelize to major 4.X.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "screwdriver-command-validator": "^1.0.2",
     "screwdriver-config-parser": "^3.14.1",
     "screwdriver-data-schema": "^18.13.5",
-    "screwdriver-datastore-sequelize": "^5.0.1",
+    "screwdriver-datastore-sequelize": "^4.1.1",
     "screwdriver-executor-docker": "^2.3.2",
     "screwdriver-executor-k8s": "^10.7.2",
     "screwdriver-executor-k8s-vm": "^1.0.0",


### PR DESCRIPTION
datastore-sequelize 5.X introduces pagination change: https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L326

But models is not ready for it, it's only returning partial results now. It's giving us this err since it's trying to recreate a job that already exists:
```
 [request,server,error] data: SequelizeUniqueConstraintError: Validation error
 ```

