### PR TITLE
fix: functional-git create files inside testfiles

### DIFF
--- a/features/support/github.js
+++ b/features/support/github.js
@@ -137,7 +137,7 @@ function createFile(token, branch, repoOwner, repoName) {
     return github.repos.createFile({
         owner,
         repo,
-        path: filename,
+        path: `testfiles/${filename}`,
         message: (new Date()).toString(), // commit message is the current time
         content: content.toString('base64'), // content needs to be transmitted in base64
         branch


### PR DESCRIPTION
It was a pain deleting them: https://github.com/screwdriver-cd-test/functional-git/pull/3803
Now creating the files under `testfiles` directory so once in a while we just need to clean up the directory while keeping other necessary files. 