### PR TITLE
fix: fix functional tests for the new workflow

### DIFF
--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -107,7 +107,7 @@ defineSupportCode(({ Before, Given, Then }) => {
             json: true
         })).then((resp) => {
             Assert.equal(resp.statusCode, 201);
-            this.buildId = resp.body.id;
+            this.buildId = resp.body[0].id;
         });
     });
 

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -85,35 +85,30 @@ defineSupportCode(({ Before, Given, Then }) => {
 
     Then(/^they can start the "main" job$/, { timeout: TIMEOUT }, function step() {
         return request({
-            uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/jobs`,
-            method: 'GET',
-            json: true,
+            uri: `${this.instance}/${this.namespace}/events`,
+            method: 'POST',
+            body: {
+                pipelineId: this.pipelineId,
+                startFrom: 'main'
+            },
             auth: {
                 bearer: this.jwt
-            }
-        })
-            .then((response) => {
-                Assert.equal(response.statusCode, 200);
-
-                this.jobId = response.body[0].id;
-            })
-            .then(() =>
-                request({
-                    uri: `${this.instance}/${this.namespace}/builds`,
-                    method: 'POST',
-                    body: {
-                        jobId: this.jobId
-                    },
-                    auth: {
-                        bearer: this.jwt
-                    },
-                    json: true
-                }).then((resp) => {
-                    Assert.equal(resp.statusCode, 201);
-
-                    this.buildId = resp.body.id;
-                })
-            );
+            },
+            json: true
+        }).then((resp) => {
+            Assert.equal(resp.statusCode, 201);
+            this.eventId = resp.body.id;
+        }).then(() => request({
+            uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+            method: 'GET',
+            auth: {
+                bearer: this.jwt
+            },
+            json: true
+        })).then((resp) => {
+            Assert.equal(resp.statusCode, 201);
+            this.buildId = resp.body.id;
+        });
     });
 
     Then(/^they can delete the pipeline$/, { timeout: TIMEOUT }, function step() {

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -68,7 +68,7 @@ defineSupportCode(({ Before, Given, When, Then, After }) => {
             json: true
         })).then((resp) => {
             Assert.equal(resp.statusCode, 201);
-            this.buildId = resp.body.id;
+            this.buildId = resp.body[0].id;
         });
     });
 

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -46,10 +46,11 @@ defineSupportCode(({ Before, Given, When, Then, After }) => {
 
     When(/^the "main" job is started$/, { timeout: TIMEOUT }, function step() {
         return request({
-            uri: `${this.instance}/${this.namespace}/builds`,
+            uri: `${this.instance}/${this.namespace}/events`,
             method: 'POST',
             body: {
-                jobId: this.jobId
+                pipelineId: this.pipelineId,
+                startFrom: 'main'
             },
             auth: {
                 bearer: this.jwt
@@ -57,9 +58,17 @@ defineSupportCode(({ Before, Given, When, Then, After }) => {
             json: true
         }).then((resp) => {
             Assert.equal(resp.statusCode, 201);
-
+            this.eventId = resp.body.id;
+        }).then(() => request({
+            uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+            method: 'GET',
+            auth: {
+                bearer: this.jwt
+            },
+            json: true
+        })).then((resp) => {
+            Assert.equal(resp.statusCode, 201);
             this.buildId = resp.body.id;
-            this.eventId = resp.body.eventId;
         });
     });
 


### PR DESCRIPTION
Currently, it's starting the wrong job:
![screen shot 2018-04-13 at 11 51 08 am](https://user-images.githubusercontent.com/3401924/38752698-ffa1cb40-3f10-11e8-9cd3-8e82901a26df.png)


the `/jobs` endpoint sorts by `workflow` if `workflow` is there, but since we don't have it anymore, the order is not guaranteed. We cannot get the first element and assume it's the `main` job. 

Instead, we can create a new event with `startFrom` as `main`, and it will create the `main` build. 