### PR TITLE
fix: still need to install npm-auto-version

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -18,6 +18,7 @@ jobs:
         requires: [main]
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
+            - install-ci: npm install npm-auto-version
             - publish-npm-and-git-tag: ./ci/publish.sh
             - publish-docker: |
                 export DOCKER_TAG=`cat VERSION`


### PR DESCRIPTION
build failed due to cannot find npm-auto-version
https://cd.screwdriver.cd/pipelines/1/builds/20940

