### PR TITLE
fix: Pin Joi version to 13.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "hapi-swagger": "^7.0.0",
     "hoek": "^5.0.3",
     "inert": "^4.0.1",
-    "joi": "^13.0.0",
+    "joi": "13.1.2",
     "js-yaml": "^3.11.0",
     "jsonwebtoken": "^7.1.6",
     "license-checker": "^17.0.0",


### PR DESCRIPTION
## Context

Builds are currently failing due to a version mismatch with Joi; the `package-lock.json` file in the data-schema is set to `13.1.2`.

## Objective

* Fix issues related to `screwdriver-data-schema` by pinning Joi version