### PR TITLE
fix: do not allow PR to publish templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config/local.*
 .nyc_output
 data/*
 package-lock.json
+docker-compose.yml

--- a/plugins/templates/create.js
+++ b/plugins/templates/create.js
@@ -34,6 +34,7 @@ module.exports = () => ({
                 const pipelineFactory = request.server.app.pipelineFactory;
                 const templateFactory = request.server.app.templateFactory;
                 const pipelineId = request.auth.credentials.pipelineId;
+                const isPR = request.auth.credentials.isPR;
 
                 return Promise.all([
                     pipelineFactory.get(pipelineId),
@@ -51,7 +52,7 @@ module.exports = () => ({
 
                     // If template name exists, but this build's pipelineId is not the same as template's pipelineId
                     // Then this build does not have permission to publish
-                    if (pipeline.id !== templates[0].pipelineId) {
+                    if (pipeline.id !== templates[0].pipelineId || isPR) {
                         throw boom.unauthorized('Not allowed to publish this template');
                     }
 

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -529,6 +529,14 @@ describe('template plugin test', () => {
             });
         });
 
+        it('returns 401 if it is a PR build', () => {
+            options.credentials.isPR = true;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+            });
+        });
+
         it('creates template if template does not exist yet', () => {
             templateFactoryMock.list.resolves([]);
 


### PR DESCRIPTION
We shouldn't allow PR to publish templates.
We store if the build JWT is from PR inside the field `isPR`.
https://github.com/screwdriver-cd/models/blob/0f8868e4645628429e2efd416dc25265db90aa4b/lib/build.js#L163