### PR TITLE
fix(545): Add default build timeout settings

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -80,6 +80,10 @@ executor:
                     micro: 1
                     low: 2
                     high: 12
+            # Default build timeout for all builds in this cluster (in minutes)
+            buildTimeout: 90
+            # Default max build timeout (in minutes)
+            maxBuildTimeout: 120
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}
@@ -127,6 +131,10 @@ executor:
                     micro: 1
                     low: 2
                     high: 12
+            # Default build timeout for all builds in this cluster (in minutes)
+            buildTimeout: 90
+            # Default max build timeout (in minutes)
+            maxBuildTimeout: 120
             # k8s node selectors for approprate pod scheduling
             nodeSelectors: {}
             preferredNodeSelectors: {}


### PR DESCRIPTION
Forgot to add default build timeout values

Related to https://github.com/screwdriver-cd/screwdriver/pull/1031, https://github.com/screwdriver-cd/screwdriver/issues/545