### PR TITLE
fix: pull in new executor-k8s-vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "screwdriver-datastore-sequelize": "^4.1.1",
     "screwdriver-executor-docker": "^2.3.2",
     "screwdriver-executor-k8s": "^11.1.0",
-    "screwdriver-executor-k8s-vm": "^1.0.0",
+    "screwdriver-executor-k8s-vm": "^2.0.0",
     "screwdriver-executor-nomad": "^1.0.2",
     "screwdriver-executor-queue": "^2.0.0",
     "screwdriver-executor-router": "^1.0.0",


### PR DESCRIPTION
Pull in new executor-k8s-vm.
Version 2 has been out for a while... 