### PR TITLE
fix: add remote trigger for artifact bookend

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,7 +3,11 @@ shared:
 
 jobs:
     main:
-        requires: [~pr, ~commit]
+        requires: [
+            ~pr,
+            ~commit,
+            ~sd@73:publish #artifact-bookend https://cd.screwdriver.cd/pipelines/73
+        ]
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - install: npm install


### PR DESCRIPTION
## Contexts

API needs to be rebuilt after it's dependencies like `artifact-bookend` are published to npm.