### PR TITLE
fix: Email notifications allow username and password config

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -225,6 +225,8 @@ notifications:
     #     host: email-host
     #     port: email-port
     #     from: email-address-to-send-from
+    #     username: optional-username
+    #     password: optional-password
     # Slack notification when build finishes
     # slack:
     #     token: your-slack-bot-token

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "screwdriver-executor-queue": "^2.0.0",
     "screwdriver-executor-router": "^1.0.5",
     "screwdriver-models": "^27.0.0",
-    "screwdriver-notifications-email": "^1.1.2",
+    "screwdriver-notifications-email": "^1.1.4",
     "screwdriver-notifications-slack": "^2.1.2",
     "screwdriver-scm-github": "^6.0.2",
     "screwdriver-scm-router": "^3.0.0",


### PR DESCRIPTION
## Context

Need to pull in email notifications change to allow username and password in config.

## References

Related to https://github.com/screwdriver-cd/notifications-email/pull/11