### PR TITLE
Fix PR restart event to pass on pr info

### DIFF
--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -343,6 +343,34 @@ describe('event plugin test', () => {
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 201);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.calledOnce(eventFactoryMock.scm.getCommitSha);
+                assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it successfully creates a PR event with parent event', () => {
+            eventConfig.parentEventId = parentEventId;
+            eventConfig.workflowGraph = decorateEventMock(testEvent).workflowGraph;
+            eventConfig.sha = decorateEventMock(testEvent).sha;
+            eventConfig.startFrom = 'PR-1:main';
+            eventConfig.prNum = '1';
+            eventConfig.prRef = 'prref';
+            eventConfig.type = 'pr';
+            options.payload.startFrom = 'PR-1:main';
+            options.payload.parentEventId = parentEventId;
+
+            return server.inject(options).then((reply) => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getCommitSha);
+                assert.calledOnce(eventFactoryMock.scm.getPrInfo);
             });
         });
 


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/screwdriver/issues/1064

When we restart a PR build, the parent event does not pass on the pr info to the subsequent calls, causing forked PR builds to fail.

## Objective

This PR fixes the event creation logic to pass on PR info to event creation.

## References

Github issue: https://github.com/screwdriver-cd/screwdriver/issues/1064