### PR TITLE
feat(796): add possibility of pr to type property of event objects

### DIFF
--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -23,20 +23,20 @@ module.exports = () => ({
         },
         handler: (request, reply) => {
             const factory = request.server.app.pipelineFactory;
-            
+
             return factory.get(request.params.id)
                 .then((pipeline) => {
                     if (!pipeline) {
                         throw boom.notFound('Pipeline does not exist');
                     }
-                    
+
                     let eventType = 'pipeline';
 
                     if (request.query.type) {
                         eventType = request.query.type;
                     }
 
-                    return pipeline.getEvents({params: {type: eventType}});
+                    return pipeline.getEvents({ params: { type: eventType } });
                 })
                 .then(events => reply(events.map(e => e.toJson())))
                 .catch(err => reply(boom.wrap(err)));

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -23,14 +23,20 @@ module.exports = () => ({
         },
         handler: (request, reply) => {
             const factory = request.server.app.pipelineFactory;
-
+            
             return factory.get(request.params.id)
                 .then((pipeline) => {
                     if (!pipeline) {
                         throw boom.notFound('Pipeline does not exist');
                     }
+                    
+                    let eventType = 'pipeline';
 
-                    return pipeline.getEvents();
+                    if (request.query.type) {
+                        eventType = request.query.type;
+                    }
+
+                    return pipeline.getEvents({params: {type: eventType}});
                 })
                 .then(events => reply(events.map(e => e.toJson())))
                 .catch(err => reply(boom.wrap(err)));

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -609,12 +609,15 @@ describe('pipeline plugin test', () => {
             pipelineFactoryMock.get.resolves(pipelineMock);
         });
 
-        it('returns 200 for getting events', () =>
+        it('returns 200 for getting events', () => {
+            options.url = `/pipelines/${id}/events?type=pr`;
             server.inject(options).then((reply) => {
                 assert.calledOnce(pipelineMock.getEvents);
+                assert.calledWith(pipelineMock.getEvents, { params: { type: 'pr' } });
                 assert.deepEqual(reply.result, testEvents);
                 assert.equal(reply.statusCode, 200);
-            })
+            });
+        }
         );
 
         it('returns 404 for pipeline that does not exist', () => {


### PR DESCRIPTION
## Context

so that we could identify what type of event we have, whether it's pipeline or pr

## Objective

to allow us to have prs in the type property of event objects

## References

https://github.com/screwdriver-cd/screwdriver/issues/796
