### PR TITLE
fix: remove unnecessary check in functional tests

### DIFF
--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -215,9 +215,9 @@ defineSupportCode(({ Before, Given, Then, When, After }) => {
             },
             json: true
         })
-        .then((response) => {
-            Assert.strictEqual(response.statusCode, 204);
-        });
+            .then((response) => {
+                Assert.strictEqual(response.statusCode, 204);
+            });
     });
 
     Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step() {

--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -207,20 +207,17 @@ defineSupportCode(({ Before, Given, Then, When, After }) => {
     });
 
     When(/^they delete that collection$/, function step() {
-        return this.ensurePipelineExists({ repoName: this.repoName })
-            .then(() =>
-                request({
-                    uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
-                    method: 'DELETE',
-                    auth: {
-                        bearer: this.jwt
-                    },
-                    json: true
-                })
-            )
-            .then((response) => {
-                Assert.strictEqual(response.statusCode, 204);
-            });
+        return request({
+            uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+            method: 'DELETE',
+            auth: {
+                bearer: this.jwt
+            },
+            json: true
+        })
+        .then((response) => {
+            Assert.strictEqual(response.statusCode, 204);
+        });
     });
 
     Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step() {


### PR DESCRIPTION
Delete a collection shouldn't need to check if pipeline exists. This is making the step flaky.

