### PR TITLE
fix: remove unnecessary func test step

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -45,7 +45,6 @@ Feature: User Collections
         And they have a collection "myCollection"
         When they delete that collection
         Then that collection no longer exists
-        And that pipeline still exists
 
     Scenario: Collections Are Unique
         And "calvin" is logged in

--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -234,20 +234,6 @@ defineSupportCode(({ Before, Given, Then, When, After }) => {
         });
     });
 
-    Then(/^that pipeline still exists$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
-            Assert.strictEqual(response.body.scmRepo.name, `${this.testOrg}/${this.repoName}`);
-        });
-    });
-
     When(/^they create another collection with the same name "myCollection"$/,
         { timeout: TIMEOUT }, function step() {
             return createCollection.call(this, { name: 'myCollection' })


### PR DESCRIPTION
We're only deleting the collection. No need to do the extra check for pipelines otherwise we need to always make sure that pipeline exists