### PR TITLE
feat(937): restrict permissions for child pipelines

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -106,6 +106,10 @@ module.exports = () => ({
                                     payload.workflowGraph = parentEvent.workflowGraph;
                                     payload.sha = parentEvent.sha;
 
+                                    if (parentEvent.configPipelineSha) {
+                                        payload.configPipelineSha = parentEvent.configPipelineSha;
+                                    }
+
                                     if (prNum) {
                                         return scm.getPrInfo(scmConfig);
                                     }

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -35,6 +35,10 @@ module.exports = () => ({
                 if (!pipeline) {
                     throw boom.notFound('Pipeline does not exist');
                 }
+                if (pipeline.configPipelineId) {
+                    throw boom.unauthorized('Child pipeline can only be removed'
+                        + `by modifying scmUrls in config pipeline ${pipeline.configPipelineId}`);
+                }
                 if (!user) {
                     throw boom.notFound(`User ${username} does not exist`);
                 }

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -43,6 +43,11 @@ module.exports = () => ({
                             `Pipeline ${id} does not exist`);
                     }
 
+                    if (oldPipeline.configPipelineId) {
+                        throw boom.unauthorized('Child pipeline can only be removed by modifying '
+                            + `scmUrls in config pipeline ${oldPipeline.configPipelineId}`);
+                    }
+
                     // get the user token
                     return user.unsealToken()
                         // get the scm URI

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -334,6 +334,31 @@ describe('event plugin test', () => {
             });
         });
 
+        it('returns 201 when it creates an event with parent event for child pipeline', () => {
+            eventConfig.parentEventId = parentEventId;
+            eventConfig.workflowGraph = decorateEventMock(testEvent).workflowGraph;
+            eventConfig.sha = decorateEventMock(testEvent).sha;
+            testEvent.configPipelineSha = 'configPipelineSha';
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            options.payload.parentEventId = parentEventId;
+            eventFactoryMock.get.withArgs(parentEventId).resolves(decorateEventMock(testEvent));
+
+            return server.inject(options).then((reply) => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getCommitSha);
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
         it('returns 201 when it successfully creates a PR event', () => {
             eventConfig.startFrom = 'PR-1:main';
             eventConfig.prNum = '1';

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -350,6 +350,14 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 401 when the pipeline is child piepline', () => {
+            pipeline.configPipelineId = 123;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+            });
+        });
+
         it('returns 404 when pipeline does not exist', () => {
             const error = {
                 statusCode: 404,
@@ -1104,6 +1112,14 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 401 when the pipeline is child piepline', () => {
+            pipelineMock.configPipelineId = 123;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 401);
             });
         });
 


### PR DESCRIPTION
- A child pipeline cannot update its checkoutUrl and delete the pipeline.
- Pass `configPipelineSha` for child pipeline restart event 

Related to https://github.com/screwdriver-cd/screwdriver/issues/937
