### PR TITLE
feat(614): delete pipelineId before adding it to data-schema

### DIFF
--- a/plugins/tokens/list.js
+++ b/plugins/tokens/list.js
@@ -38,6 +38,7 @@ module.exports = () => ({
                     const output = token.toJson();
 
                     delete output.userId;
+                    delete output.pipelineId;
 
                     return output;
                 })))


### PR DESCRIPTION
## Context
I added a pipelineId with [this PR](https://github.com/screwdriver-cd/data-schema/pull/250) to implement pipeline API token. 
But the functional test failed due to this change.
https://cd.screwdriver.cd/pipelines/1/builds/41213

This is an error because [getSchema](https://github.com/screwdriver-cd/data-schema/blob/master/models/token.js#L65-L72) does not allow pipelineId. 
In user token, pipelineId should be empty, but the property itself exists.
So the getSchema validation failed.
```
 [request,server,error] data: Error: "value" at position 0 fails because ["pipelineId" is not allowed]
```
## Objective
This PR guarantees to delete pipelineId in token list API so that error does not occur with validation of getSchema.

## References
https://github.com/screwdriver-cd/screwdriver/issues/614
https://github.com/screwdriver-cd/data-schema/pull/250
