### PR TITLE
fix(937): add start all child pipelines endpoint

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -28,9 +28,9 @@ server.register({
 ### Routes
 
 #### Get all pipelines
-`page` and `count` optional
+`page`, `count` and `configPipelineId` optional
 
-`GET /pipelines?page={pageNumber}&count={countNumber}`
+`GET /pipelines?page={pageNumber}&count={countNumber}&configPipelineId={configPipelineId}`
 
 #### Get single pipeline
 
@@ -106,6 +106,11 @@ Example payload:
 #### Get all pipeline secrets
 
 `GET /pipelines/{id}/secrets`
+
+#### Start all child pipelines belong to this pipeline
+* Start all child pipelines belong to this config pipeline all at once
+
+`POST /pipelines/{id}/startall`
 
 ### Access to Factory methods
 The server supplies factories to plugins in the form of server settings:

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -12,6 +12,7 @@ const badgeRoute = require('./badge');
 const listJobsRoute = require('./listJobs');
 const listSecretsRoute = require('./listSecrets');
 const listEventsRoute = require('./listEvents');
+const startAllRoute = require('./startAll');
 
 /**
  * Pipeline API Plugin
@@ -33,7 +34,8 @@ exports.register = (server, options, next) => {
         badgeRoute(),
         listJobsRoute(),
         listSecretsRoute(),
-        listEventsRoute()
+        listEventsRoute(),
+        startAllRoute()
     ]);
 
     next();

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -3,6 +3,7 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const idSchema = joi.reach(schema.models.pipeline.base, 'id');
 const listSchema = joi.array().items(schema.models.pipeline.get).label('List of Pipelines');
 
 module.exports = () => ({
@@ -27,10 +28,16 @@ module.exports = () => ({
             let pipelineArray = [];
 
             scmContexts.forEach((scmContext) => {
+                const params = {
+                    scmContext
+                };
+
+                if (request.query.configPipelineId) {
+                    params.configPipelineId = request.query.configPipelineId;
+                }
+
                 const pipelines = factory.list({
-                    params: {
-                        scmContext
-                    },
+                    params,
                     paginate: {
                         page: request.query.page,
                         count: request.query.count
@@ -50,7 +57,9 @@ module.exports = () => ({
             schema: listSchema
         },
         validate: {
-            query: schema.api.pagination
+            query: schema.api.pagination.concat(joi.object({
+                configPipelineId: idSchema
+            }))
         }
     }
 });

--- a/plugins/pipelines/startAll.js
+++ b/plugins/pipelines/startAll.js
@@ -22,12 +22,9 @@ module.exports = () => ({
             }
         },
         handler: (request, reply) => {
-            const pipelineFactory = request.server.app.pipelineFactory;
-            const eventFactory = request.server.app.eventFactory;
-            const userFactory = request.server.app.userFactory;
+            const { pipelineFactory, eventFactory, userFactory } = request.server.app;
+            const { username, scmContext } = request.auth.credentials;
             const id = request.params.id;
-            const username = request.auth.credentials.username;
-            const scmContext = request.auth.credentials.scmContext;
             const scm = pipelineFactory.scm;
 
             return Promise.all([

--- a/plugins/pipelines/startAll.js
+++ b/plugins/pipelines/startAll.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const idSchema = joi.reach(schema.models.pipeline.base, 'id');
+
+module.exports = () => ({
+    method: 'POST',
+    path: '/pipelines/{id}/startall',
+    config: {
+        description: 'Start all child pipelines given a specific pipeline',
+        notes: 'Start all child pipelines given a specific pipeline',
+        tags: ['api', 'pipelines'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const eventFactory = request.server.app.eventFactory;
+            const userFactory = request.server.app.userFactory;
+            const id = request.params.id;
+            const username = request.auth.credentials.username;
+            const scmContext = request.auth.credentials.scmContext;
+            const scm = pipelineFactory.scm;
+
+            return Promise.all([
+                pipelineFactory.get(id),
+                userFactory.get({ username, scmContext })
+            ])
+                .then(([pipeline, user]) => {
+                    if (!pipeline) {
+                        throw boom.notFound('Pipeline does not exist');
+                    }
+
+                    return user.getPermissions(pipeline.scmUri)
+                        // check if user has push access
+                        .then((permissions) => {
+                            if (!permissions.push) {
+                                throw boom.unauthorized(`User ${username} `
+                                    + 'does not have push permission for this repo');
+                            }
+                        });
+                })
+                .then(() => pipelineFactory.list({
+                    params: {
+                        configPipelineId: id
+                    }
+                }))
+                .then(pipelines => pipelines.map(p =>
+                    p.token.then(token => scm.getCommitSha({
+                        scmContext,
+                        scmUri: p.scmUri,
+                        token
+                    }))
+                        .then(sha => eventFactory.create({
+                            pipelineId: p.id,
+                            sha,
+                            username,
+                            scmContext,
+                            startFrom: '~commit',
+                            causeMessage: `Started by ${username}`
+                        }))))
+                .then(() => reply().code(201))
+                .catch(err => reply(boom.wrap(err)));
+        },
+        validate: {
+            params: {
+                id: idSchema
+            }
+        }
+    }
+});

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -44,8 +44,8 @@ module.exports = () => ({
                     }
 
                     if (oldPipeline.configPipelineId) {
-                        throw boom.unauthorized('Child pipeline can only be removed by modifying '
-                            + `scmUrls in config pipeline ${oldPipeline.configPipelineId}`);
+                        throw boom.unauthorized('Child pipeline checkoutUrl can only be modified by'
+                            + ` config pipeline ${oldPipeline.configPipelineId}`);
                     }
 
                     // get the user token

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -254,6 +254,37 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 and all pipelines with matched configPipelineId', () => {
+            options.url = '/pipelines?page=1&count=3&configPipelineId=123';
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'github:github.com',
+                    configPipelineId: 123
+                },
+                paginate: {
+                    page: 1,
+                    count: 3
+                },
+                sort: 'descending'
+            }).resolves(getPipelineMocks(testPipelines));
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'gitlab:mygitlab',
+                    configPipelineId: 123
+                },
+                paginate: {
+                    page: 1,
+                    count: 3
+                },
+                sort: 'descending'
+            }).resolves(getPipelineMocks(gitlabTestPipelines));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testPipelines.concat(gitlabTestPipelines));
+            });
+        });
+
         it('returns 500 when datastore fails', () => {
             pipelineFactoryMock.list.rejects(new Error('fittoburst'));
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -61,6 +61,7 @@ const decoratePipelineMock = (pipeline) => {
     mock.getJobs = sinon.stub();
     mock.getEvents = sinon.stub();
     mock.remove = sinon.stub();
+    mock.token = Promise.resolve('faketoken');
 
     return mock;
 };
@@ -122,6 +123,7 @@ const getUserMock = (user) => {
 describe('pipeline plugin test', () => {
     let pipelineFactoryMock;
     let userFactoryMock;
+    let eventFactoryMock;
     let scmMock;
     let plugin;
     let server;
@@ -144,11 +146,15 @@ describe('pipeline plugin test', () => {
             scm: {
                 getScmContexts: sinon.stub(),
                 parseUrl: sinon.stub(),
-                decorateUrl: sinon.stub()
+                decorateUrl: sinon.stub(),
+                getCommitSha: sinon.stub().resolves('sha')
             }
         };
         userFactoryMock = {
             get: sinon.stub()
+        };
+        eventFactoryMock = {
+            create: sinon.stub().resolves(null)
         };
 
         /* eslint-disable global-require */
@@ -156,6 +162,7 @@ describe('pipeline plugin test', () => {
         /* eslint-enable global-require */
         server = new hapi.Server();
         server.app = {
+            eventFactory: eventFactoryMock,
             pipelineFactory: pipelineFactoryMock,
             userFactory: userFactoryMock,
             ecosystem: {
@@ -1165,6 +1172,80 @@ describe('pipeline plugin test', () => {
             const testError = new Error('pipelineModelSyncError');
 
             pipelineMock.sync.rejects(testError);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('POST /pipelines/{id}/startall', () => {
+        const id = 123;
+        const username = 'd2lam';
+        const scmUri = 'github.com:12345:branchName';
+        let pipelineMock;
+        let userMock;
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'POST',
+                url: `/pipelines/${id}/startall`,
+                credentials: {
+                    username,
+                    scmContext,
+                    scope: ['user']
+                }
+            };
+
+            userMock = getUserMock({ username, scmContext });
+            userMock.getPermissions.withArgs(scmUri).resolves({ push: true });
+            userFactoryMock.get.withArgs({ username, scmContext }).resolves(userMock);
+
+            pipelineMock = getPipelineMocks(testPipeline);
+            pipelineMock.sync.resolves(null);
+            pipelineFactoryMock.get.withArgs(id).resolves(pipelineMock);
+            pipelineFactoryMock.list.resolves(getPipelineMocks(testPipelines));
+        });
+
+        it('returns 201 for starting all child pipelines', () =>
+            server.inject(options).then((reply) => {
+                assert.calledWith(pipelineFactoryMock.list, {
+                    params: {
+                        configPipelineId: pipelineMock.id
+                    }
+                });
+                assert.calledThrice(pipelineFactoryMock.scm.getCommitSha);
+                assert.calledThrice(eventFactoryMock.create);
+                assert.equal(reply.statusCode, 201);
+            })
+        );
+
+        it('returns 401 when user does not have admin permission', () => {
+            const error = {
+                statusCode: 401,
+                error: 'Unauthorized',
+                message: 'User d2lam does not have push permission for this repo'
+            };
+
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 401);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 404 for updating a pipeline that does not exist', () => {
+            pipelineFactoryMock.get.withArgs(id).resolves(null);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 500 when the datastore returns an error', () => {
+            pipelineFactoryMock.list.rejects(new Error('icantdothatdave'));
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 500);


### PR DESCRIPTION
- add start all child pipelines endpoint
- allow to list pipelines by `configPipelineId`

Related to: https://github.com/screwdriver-cd/screwdriver/issues/937

