### PR TITLE
feat(1113): Pass in meta from payload for create event and build

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -28,6 +28,7 @@ module.exports = () => ({
             const scm = buildFactory.scm;
             const username = request.auth.credentials.username;
             const scmContext = request.auth.credentials.scmContext;
+            const meta = request.payload.meta;
             const payload = {
                 jobId: request.payload.jobId,
                 apiUri: request.server.info.uri,
@@ -35,6 +36,10 @@ module.exports = () => ({
                 scmContext
             };
             const isValidToken = request.server.plugins.pipelines.isValidToken;
+
+            if (meta) {
+                payload.meta = meta;
+            }
 
             // Fetch the job and user models
             return Promise.all([
@@ -102,6 +107,7 @@ module.exports = () => ({
 
                                     return eventFactory.create({
                                         pipelineId: pipeline.id,
+                                        meta,
                                         type,
                                         username,
                                         scmContext,

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -30,6 +30,7 @@ module.exports = () => ({
             const scmContext = request.auth.credentials.scmContext;
             const username = request.auth.credentials.username;
             const isValidToken = request.server.plugins.pipelines.isValidToken;
+            const meta = request.payload.meta;
 
             return Promise.resolve().then(() => {
                 const buildId = request.payload.buildId;
@@ -66,6 +67,10 @@ module.exports = () => ({
 
                 if (parentBuildId) {
                     payload.parentBuildId = parentBuildId;
+                }
+
+                if (meta) {
+                    payload.meta = meta;
                 }
 
                 // Match PR-prNum, then extract prNum

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1237,13 +1237,6 @@ describe('build plugin test', () => {
         const checkoutUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
         const scmUri = 'github.com:12345:branchName';
         const scmContext = 'github:github.com';
-        const eventConfig = {
-            type: 'pr',
-            pipelineId,
-            username,
-            scmContext,
-            sha: testBuild.sha
-        };
 
         let options;
         let buildMock;
@@ -1251,14 +1244,21 @@ describe('build plugin test', () => {
         let pipelineMock;
         let userMock;
         let eventMock;
+        let meta;
         let params;
+        let eventConfig;
 
         beforeEach(() => {
+            meta = {
+                foo: 'bar',
+                one: 1
+            };
             options = {
                 method: 'POST',
                 url: '/builds',
                 payload: {
-                    jobId
+                    jobId,
+                    meta
                 },
                 credentials: {
                     scope: ['user'],
@@ -1299,7 +1299,16 @@ describe('build plugin test', () => {
                 eventId: 12345,
                 apiUri: 'http://localhost:12345',
                 username,
-                scmContext
+                scmContext,
+                meta
+            };
+            eventConfig = {
+                type: 'pr',
+                pipelineId,
+                username,
+                scmContext,
+                sha: testBuild.sha,
+                meta
             };
 
             jobMock.pipeline = sinon.stub().resolves(pipelineMock)();
@@ -1362,6 +1371,7 @@ describe('build plugin test', () => {
             jobMock.isPR.returns(false);
             jobMock.prNum = null;
             eventConfig.type = 'pipeline';
+            params.meta = meta;
 
             return server.inject(options).then((reply) => {
                 expectedLocation = {

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -210,6 +210,7 @@ describe('event plugin test', () => {
         let expectedLocation;
         let scmConfig;
         let userMock;
+        let meta;
         const username = 'myself';
         const parentBuildId = 12345;
         const pipelineId = 123;
@@ -240,13 +241,18 @@ describe('event plugin test', () => {
                 scmUri,
                 token: 'iamtoken'
             };
+            meta = {
+                foo: 'bar',
+                one: 1
+            };
             options = {
                 method: 'POST',
                 url: '/events',
                 payload: {
                     parentBuildId,
                     pipelineId,
-                    startFrom: '~commit'
+                    startFrom: '~commit',
+                    meta
                 },
                 credentials: {
                     scope: ['user'],
@@ -261,7 +267,8 @@ describe('event plugin test', () => {
                 startFrom: '~commit',
                 sha: '58393af682d61de87789fb4961645c42180cec5a',
                 type: 'pipeline',
-                username
+                username,
+                meta
             };
 
             eventFactoryMock.get.withArgs(parentEventId).resolves(decorateEventMock(testEvent));
@@ -272,7 +279,8 @@ describe('event plugin test', () => {
 
         it('returns 201 when it successfully creates an event with buildId passed in', () => {
             options.payload = {
-                buildId: 1234
+                buildId: 1234,
+                meta
             };
             buildFactoryMock.get.resolves({
                 id: 1234,


### PR DESCRIPTION
## Context
Allow users to specify `meta` when creating an `event` or `build`

## Objective
`POST` endpoint for `builds` and `events` should pass in `meta` from `request.payload.meta` to their respective factories.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1113

Pending:
* https://github.com/screwdriver-cd/models/pull/265
* https://github.com/screwdriver-cd/data-schema/pull/259
