### PR TITLE
fix: add buffer to jwt expires time

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -16,6 +16,7 @@ const tokenRoute = require('./token');
 const uuid = require('uuid/v4');
 
 const DEFAULT_TIMEOUT = 2 * 60; // 2h in minutes
+const EXPIRES_IN_BUFFER = 5; // in minutes
 const ALGORITHM = 'RS256';
 
 /**
@@ -89,7 +90,7 @@ exports.register = (server, options, next) => {
     server.expose('generateToken', (profile, buildTimeout = DEFAULT_TIMEOUT) =>
         jwt.sign(profile, pluginOptions.jwtPrivateKey, {
             algorithm: ALGORITHM,
-            expiresIn: buildTimeout * 60, // must be in second
+            expiresIn: (buildTimeout + EXPIRES_IN_BUFFER) * 60, // must be in second
             jwtid: uuid()
         })
     );


### PR DESCRIPTION
## Context
When build has timed out and failed, teardown step tries to finish the  build and change the build status. 
But teardown step fails because build time out and jwt expires time are the same now. 
When the build timed out, at the same time jwt expires too.

## Objective
Add buffer time (5 minutes) to the jwt expires time.

## Related
https://github.com/screwdriver-cd/screwdriver/issues/1075
