### PR TITLE
fix: get user by access token

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -154,7 +154,7 @@ exports.register = (server, options, next) => {
                                 return Promise.reject();
                             } else if (token.userId) {
                                 // if token has userId then the token is for user
-                                return userFactory.get(token.userId)
+                                return userFactory.get({ accessToken: tokenValue })
                                     .then((user) => {
                                         if (!user) {
                                             return Promise.reject();

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -725,7 +725,7 @@ describe('auth plugin test', () => {
             return server.inject({
                 url: `/auth/token?api_token=${apiKey}`
             }).then((reply) => {
-                assert.calledWith(userFactoryMock.get, id);
+                assert.calledWith(userFactoryMock.get, { accessToken: apiKey });
                 assert.equal(reply.statusCode, 401, 'Login route should be unavailable');
                 assert.notOk(reply.result.token, 'Token should not be issued');
             });


### PR DESCRIPTION
Functional tests is broken with the last PR merged saying that `lastUsed` of accessToken is not updated: 
https://cd.screwdriver.cd/pipelines/1/builds/44534
PR: https://github.com/screwdriver-cd/screwdriver/pull/1123

Because in that PR, it switch from `userFactory.get({ accessToken: xxx })` to `userFactory.get(token.userId)`. But inside the model, we only update t`oken.lastUsed` field when you're getting the user with accessToken.
