### PR TITLE
fix(614): get pipeline by access token

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -168,7 +168,7 @@ exports.register = (server, options, next) => {
                                     });
                             } else if (token.pipelineId) {
                                 // if token has pipelineId then the token is for pipeline
-                                return pipelineFactory.get(token.pipelineId)
+                                return pipelineFactory.get({ accessToken: tokenValue })
                                     .then((pipeline) => {
                                         if (!pipeline) {
                                             return Promise.reject();

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -663,7 +663,7 @@ describe('auth plugin test', () => {
                 assert.equal(reply.statusCode, 200, 'Login route should be available');
                 assert.ok(reply.result.token, 'Token not returned');
                 assert.calledWith(tokenFactoryMock.get, { value: apiKey });
-                assert.calledWith(userFactoryMock.get, id);
+                assert.calledWith(userFactoryMock.get, { accessToken: apiKey });
                 expect(reply.result.token).to.be.a.jwt
                     .and.have.property('username', username);
                 expect(reply.result.token).to.be.a.jwt
@@ -683,7 +683,7 @@ describe('auth plugin test', () => {
                 assert.equal(reply.statusCode, 200, 'Login route should be available');
                 assert.ok(reply.result.token, 'Token not returned');
                 assert.calledWith(tokenFactoryMock.get, { value: apiKey });
-                assert.calledWith(pipelineFactoryMock.get, pipelineId);
+                assert.calledWith(pipelineFactoryMock.get, { accessToken: apiKey });
                 expect(reply.result.token).to.be.a.jwt
                     .and.have.property('username', username);
                 expect(reply.result.token).to.be.a.jwt
@@ -738,7 +738,7 @@ describe('auth plugin test', () => {
             return server.inject({
                 url: `/auth/token?api_token=${apiKey}`
             }).then((reply) => {
-                assert.calledWith(pipelineFactoryMock.get, pipelineId);
+                assert.calledWith(pipelineFactoryMock.get, { accessToken: apiKey });
                 assert.equal(reply.statusCode, 401, 'Login route should be unavailable');
                 assert.notOk(reply.result.token, 'Token should not be issued');
             });


### PR DESCRIPTION
## Context
Currently, the `lastUsed` of pipeline token never be updated even if the token is used.
The [PR](https://github.com/screwdriver-cd/models/pull/267) of models  fix to update it when the pipeline is fetched by accessToken just like user token is doing.

## Objective
This PR fix to get the pipeline by `accessToken` to udpate `lastUsed`.

Please merge this PR after the PR https://github.com/screwdriver-cd/models/pull/267 is merged.

## References
https://github.com/screwdriver-cd/screwdriver/issues/614#issuecomment-399249412
