### PR TITLE
fix: set statusMessage to null if not set

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -87,7 +87,7 @@ module.exports = () => ({
                     // However, the status itself cannot be updated to SUCCESS
                     if (build.status !== 'UNSTABLE') {
                         build.status = desiredStatus;
-                        build.statusMessage = statusMessage || '';
+                        build.statusMessage = statusMessage || null;
                     }
 
                     // Only trigger next build on success

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -692,7 +692,7 @@ describe('build plugin test', () => {
                 return server.inject(options).then((reply) => {
                     assert.equal(reply.statusCode, 200);
                     assert.strictEqual(buildMock.status, 'RUNNING');
-                    assert.strictEqual(buildMock.statusMessage, '');
+                    assert.isNull(buildMock.statusMessage);
                     assert.notCalled(buildFactoryMock.create);
                 });
             });


### PR DESCRIPTION
status message is not allowed to be empty string: https://github.com/screwdriver-cd/data-schema/blob/9893b3b79838c0a67ed3455c4c64fd62052121cf/models/build.js#L124-L128