### PR TITLE
fix(614): fix pipeline token refresh to return value

### DIFF
--- a/plugins/pipelines/tokens/refresh.js
+++ b/plugins/pipelines/tokens/refresh.js
@@ -60,7 +60,9 @@ module.exports = () => ({
                         }
 
                         return token.refresh()
-                            .then(reply(token.toJson()).code(200));
+                            .then((refreshed) => {
+                                reply(refreshed.toJson()).code(200);
+                            });
                     });
                 })
                 .catch(err => reply(boom.wrap(err)));

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1760,11 +1760,18 @@ describe('pipeline plugin test', () => {
             tokenFactoryMock.get.resolves(tokenMock);
         });
 
-        it('returns 200 and refreshed token', () =>
+        it('returns 200 and refreshed token', () => {
+            const refreshedToken = hoek.applyToDefaults(testTokens, {
+                value: 'refreshed'
+            });
+
+            tokenMock.refresh.resolves(getTokenMocks(refreshedToken));
+
             server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 200);
-            })
-        );
+                assert.equal(reply.result, refreshedToken);
+            });
+        });
 
         it('returns 401 when user does not have admin permission', () => {
             const error = {


### PR DESCRIPTION
In pipeline token, it doesn't return the updated value  when the token is refreshed as below. 
![image](https://user-images.githubusercontent.com/5774825/41888702-ca181e14-7941-11e8-8967-da632084c342.png)

This PR fix it.