### PR TITLE
fix: [small] add timeout to delete collection test

### DIFF
--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -206,7 +206,7 @@ defineSupportCode(({ Before, Given, Then, When, After }) => {
         Assert.ok(collectionNames.includes('anotherCollection'));
     });
 
-    When(/^they delete that collection$/, function step() {
+    When(/^they delete that collection$/, { timeout: TIMEOUT }, function step() {
         return request({
             uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
             method: 'DELETE',


### PR DESCRIPTION
## Context
In our environment, the delete collection test exceeds default timeout (5000ms).

## Objective
This PR add timeout to delete collection test with configured value.
