### PR TITLE
fix(1150): Check if config pipeline can access build secret

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,9 +105,9 @@
     "screwdriver-scm-router": "^3.1.0",
     "screwdriver-template-validator": "^3.0.5",
     "screwdriver-workflow-parser": "^1.5.0",
-    "sqlite3": "^4.0.0",
+    "sqlite3": "^4.0.1",
     "tinytim": "^0.1.1",
-    "uuid": "^3.1.0",
+    "uuid": "^3.3.0",
     "verror": "^1.6.1",
     "vision": "^4.1.0",
     "winston": "^2.4.3"

--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -49,7 +49,8 @@ module.exports = () => ({
                         {
                             isPR: profile.isPR,
                             jobId: profile.jobId,
-                            pipelineId: profile.pipelineId
+                            pipelineId: profile.pipelineId,
+                            configPipelineId: profile.configPipelineId
                         }
                     ), parseInt(buildTimeout, 10)
                 );

--- a/plugins/secrets/index.js
+++ b/plugins/secrets/index.js
@@ -58,7 +58,8 @@ exports.register = (server, options, next) => {
                 });
             }
 
-            if (secret.pipelineId !== credentials.pipelineId) {
+            if (secret.pipelineId !== credentials.pipelineId &&
+                secret.pipelineId !== credentials.configPipelineId) {
                 throw boom.forbidden(`${username} is not allowed to access this secret`);
             }
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2200,7 +2200,8 @@ describe('build plugin test', () => {
                 scope: ['build'],
                 isPR: false,
                 jobId: 1234,
-                pipelineId: 1
+                pipelineId: 1,
+                configPipelineId: 123
             });
 
             generateTokenMock.withArgs(
@@ -2220,7 +2221,8 @@ describe('build plugin test', () => {
                     scmContext: 'github:github.com',
                     isPR: false,
                     jobId: 1234,
-                    pipelineId: 1
+                    pipelineId: 1,
+                    configPipelineId: 123
                 }
             };
         });
@@ -2232,7 +2234,7 @@ describe('build plugin test', () => {
                     '12345',
                     'github:github.com',
                     ['build'],
-                    { isPR: false, jobId: 1234, pipelineId: 1 }
+                    { isPR: false, jobId: 1234, pipelineId: 1, configPipelineId: 123 }
                 );
                 assert.calledWith(generateTokenMock, {
                     username: '12345',
@@ -2240,7 +2242,8 @@ describe('build plugin test', () => {
                     scope: ['build'],
                     isPR: false,
                     jobId: 1234,
-                    pipelineId: 1
+                    pipelineId: 1,
+                    configPipelineId: 123
                 }, 50);
                 assert.equal(reply.result.token, 'sometoken');
             })


### PR DESCRIPTION
## Context
Currently, when checking access to build secrets, only the `pipelineId` is checked.
https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/secrets/index.js#L61-L63

This will not work in the case of child pipelines since they inherit their parent pipeline secrets. Therefore, we include the `configPipelineId` as part of the JWT in order to check for it.

## Objective
Pass in the `configPipelineId` as part of the `generateProfile` function in the `/builds/{id}/token` endpoint.

Also check if `configPipelineId` matches `secret.pipeline.Id`.

## References
https://github.com/screwdriver-cd/models/pull/269
https://github.com/screwdriver-cd/screwdriver/issues/1150
