### PR TITLE
fix: increase retry

### DIFF
--- a/features/support/world.js
+++ b/features/support/world.js
@@ -124,8 +124,8 @@ function CustomWorld({ attach, parameters }) {
         requestretry({
             uri: `${this.instance}/${this.namespace}/builds/${buildID}`,
             method: 'GET',
-            maxAttempts: 15,
-            retryDelay: 5000,
+            maxAttempts: 20,
+            retryDelay: 8000,
             retryStrategy: buildRetryStrategy,
             json: true,
             auth: {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -124,8 +124,8 @@ function CustomWorld({ attach, parameters }) {
         requestretry({
             uri: `${this.instance}/${this.namespace}/builds/${buildID}`,
             method: 'GET',
-            maxAttempts: 20,
-            retryDelay: 8000,
+            maxAttempts: 25,
+            retryDelay: 5000,
             retryStrategy: buildRetryStrategy,
             json: true,
             auth: {


### PR DESCRIPTION
Functional tests are failing. Some builds might take quite long. Increasing these values to make it retry more times. 