### PR TITLE
fix: split encryptionPassword

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -109,7 +109,7 @@ const secretFactory = Models.SecretFactory.getInstance({
 });
 const tokenFactory = Models.TokenFactory.getInstance({
     datastore,
-    password: authConfig.encryptionPassword
+    password: authConfig.hashingPassword
 });
 const eventFactory = Models.EventFactory.getInstance({
     datastore,

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -15,9 +15,12 @@ auth:
     # A password used for encrypting session data.
     # **Needs to be minimum 32 characters**
     cookiePassword: SECRET_COOKIE_PASSWORD
-    # A password used for encrypting stored secrets.
+    # A password used for encrypting stored pipeline secrets and user Oauth token.
     # **Needs to be minimum 32 characters**
     encryptionPassword: SECRET_PASSWORD
+    # A password used for hashing user/pipeline access tokens.
+    # **Needs to be minimum 32 characters**
+    hashingPassword: SECRET_HASHING_PASSWORD
     # A flag to set if the server is running over https.
     # Used as a flag for the OAuth flow
     https: IS_HTTPS

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -17,9 +17,12 @@ auth:
     # A password used for encrypting session data.
     # **Needs to be minimum 32 characters**
     cookiePassword: WOW-ANOTHER-INSECURE-PASSWORD!!!
-    # A password used for encrypting stored secrets.
+    # A password used for encrypting stored pipeline secrets and user Oauth token.
     # **Needs to be minimum 32 characters**
     encryptionPassword: WOW-ANOTHER-MORE-INSECURE-PASSWORD!!!
+    # A password used for hashing user/pipeline access tokens.
+    # **Needs to be minimum 32 characters**
+    hashingPassword: WOW-ANOTHER-MORE-INSECURE-PASSWORD!!!
     # A flag to set if the server is running over https.
     # Used as a flag for the OAuth flow
     https: false


### PR DESCRIPTION
Currently, we're using the `encryptionPassword` for two different purposes.
- encrypt/decrypt pipeline secrets/user Oauth token
- as a one way hashing key for aceess token 
https://github.com/screwdriver-cd/models/blob/master/lib/tokenFactory.js#L54

This PR will split it into two to serve its own purpose and for better key management.