### PR TITLE
fix: allow hashing password in auth config

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -25,6 +25,7 @@ const ALGORITHM = 'RS256';
  * @param  {Object}   options                        Configuration object
  * @param  {String}   options.cookiePassword         Password used for temporary encryption of cookie secrets
  * @param  {String}   options.encryptionPassword     Password used for iron encrypting
+ * @param  {String}   options.hashingPassword        Password used for hashing access token
  * @param  {Boolean}  options.https                  For setting the isSecure flag. Needs to be false for non-https
  * @param  {Boolean}  options.allowGuestAccess       Letting users browse your system
  * @param  {String}   options.jwtPrivateKey          Secret for signing JWTs
@@ -38,6 +39,7 @@ exports.register = (server, options, next) => {
         https: joi.boolean().truthy('true').falsy('false').required(),
         cookiePassword: joi.string().min(32).required(),
         encryptionPassword: joi.string().min(32).required(),
+        hashingPassword: joi.string().min(32).required(),
         allowGuestAccess: joi.boolean().truthy('true').falsy('false').default(false),
         jwtPrivateKey: joi.string().required(),
         jwtPublicKey: joi.string().required(),

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -51,6 +51,7 @@ describe('auth plugin test', () => {
     });
     const cookiePassword = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
     const encryptionPassword = 'this_is_another_password_that_needs_to_be_atleast_32_characters';
+    const hashingPassword = 'this_is_another_password_that_needs_to_be_atleast_32_characters';
 
     beforeEach((done) => {
         scm = {
@@ -106,6 +107,7 @@ describe('auth plugin test', () => {
             options: {
                 cookiePassword,
                 encryptionPassword,
+                hashingPassword,
                 scm,
                 jwtPrivateKey,
                 jwtPublicKey,

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -145,6 +145,7 @@ describe('auth plugin test', () => {
                 options: {
                     cookiePassword,
                     encryptionPassword,
+                    hashingPassword,
                     scm,
                     jwtPrivateKey,
                     jwtPublicKey,
@@ -194,6 +195,7 @@ describe('auth plugin test', () => {
                 register: plugin,
                 options: {
                     encryptionPassword,
+                    hashingPassword,
                     cookiePassword,
                     scm,
                     jwtPrivateKey,
@@ -217,6 +219,7 @@ describe('auth plugin test', () => {
                 options: {
                     cookiePassword,
                     encryptionPassword,
+                    hashingPassword,
                     scm,
                     jwtPrivateKey,
                     jwtPublicKey,
@@ -357,6 +360,7 @@ describe('auth plugin test', () => {
                     options: {
                         cookiePassword,
                         encryptionPassword,
+                        hashingPassword,
                         scm,
                         jwtPrivateKey,
                         jwtPublicKey,
@@ -519,6 +523,7 @@ describe('auth plugin test', () => {
                         options: {
                             cookiePassword,
                             encryptionPassword,
+                            hashingPassword,
                             scm,
                             jwtPrivateKey,
                             jwtPublicKey,
@@ -771,6 +776,7 @@ describe('auth plugin test', () => {
                     options: {
                         cookiePassword,
                         encryptionPassword,
+                        hashingPassword,
                         scm,
                         jwtPrivateKey,
                         jwtPublicKey,
@@ -998,6 +1004,7 @@ describe('auth plugin test', () => {
                 options: {
                     cookiePassword,
                     encryptionPassword,
+                    hashingPassword,
                     scm,
                     jwtPrivateKey,
                     jwtPublicKey,


### PR DESCRIPTION
Need to allow hashingPassword to be part of the auth config