### PR TITLE
fix(450): Allow pipeline to be removed if repository does not exist

### DIFF
--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -42,6 +42,39 @@ exports.register = (server, options, next) => {
                 parseInt(id, 10) === parseInt(credentials.pipelineId, 10)
     );
 
+    /**
+     * Identifies userDisplayName and Screwdriver admin status of user
+     * @method screwdriverAdminDetails
+     * @param  {String}        username   Username of the person
+     * @param  {String}        scmContext Scm to which the person logged in belongs
+     * @return {Object}                   Details including the display name and admin status of user
+     */
+    server.expose('screwdriverAdminDetails', (username, scmContext) => {
+        // construct object with defaults to store details
+        const adminDetails = {
+            isAdmin: false
+        };
+
+        if (scmContext) {
+            const scm = server.root.app.pipelineFactory.scm;
+            const scmDisplayName = scm.getDisplayName({ scmContext });
+            const adminsList = options.admins;
+
+            // construct displayable username string
+            adminDetails.userDisplayName = `${scmDisplayName}:${username}`;
+
+            // Check system configuration for list of system admins
+            // set admin status true if current user is identified to be a system admin
+            if (adminsList.length > 0
+                && adminsList.includes(adminDetails.userDisplayName)) {
+                adminDetails.isAdmin = true;
+            }
+        }
+
+        // return details
+        return adminDetails;
+    });
+
     server.route([
         createRoute(),
         removeRoute(),

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -42,39 +42,6 @@ exports.register = (server, options, next) => {
                 parseInt(id, 10) === parseInt(credentials.pipelineId, 10)
     );
 
-    /**
-     * Identifies userDisplayName and Screwdriver admin status of user
-     * @method screwdriverAdminDetails
-     * @param  {String}        username   Username of the person
-     * @param  {String}        scmContext Scm to which the person logged in belongs
-     * @return {Object}                   Details including the display name and admin status of user
-     */
-    server.expose('screwdriverAdminDetails', (username, scmContext) => {
-        // construct object with defaults to store details
-        const adminDetails = {
-            isAdmin: false
-        };
-
-        if (scmContext) {
-            const scm = server.root.app.pipelineFactory.scm;
-            const scmDisplayName = scm.getDisplayName({ scmContext });
-            const adminsList = options.admins;
-
-            // construct displayable username string
-            adminDetails.userDisplayName = `${scmDisplayName}:${username}`;
-
-            // Check system configuration for list of system admins
-            // set admin status true if current user is identified to be a system admin
-            if (adminsList.length > 0
-                && adminsList.includes(adminDetails.userDisplayName)) {
-                adminDetails.isAdmin = true;
-            }
-        }
-
-        // return details
-        return adminDetails;
-    });
-
     server.route([
         createRoute(),
         removeRoute(),

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -52,6 +52,12 @@ module.exports = () => ({
                                 + 'does not have admin permission for this repo');
                         }
                     })
+                    .catch((error) => {
+                        // Allow pipeline to be removed if the repository does not exist
+                        if (error.code !== 404) {
+                            throw error;
+                        }
+                    })
                     // user has good permissions, remove the pipeline
                     .then(() => pipeline.remove())
                     .then(() => reply().code(204));

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -56,8 +56,12 @@ module.exports = () => ({
                         }
                     })
                     .catch((error) => {
-                        // Allow pipeline to be removed if the repository does not exist
-                        if (error.code === 404 && !isPrivateRepo) {
+                        // Lookup whether user is admin
+                        const adminDetails = request.server.plugins.pipelines
+                            .screwdriverAdminDetails(username, scmContext);
+
+                        // Allow cluster admins to remove pipeline if the repository does not exist
+                        if (error.code === 404 && !isPrivateRepo && adminDetails.isAdmin) {
                             return Promise.resolve(null);
                         }
 

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -57,7 +57,7 @@ module.exports = () => ({
                     })
                     .catch((error) => {
                         // Lookup whether user is admin
-                        const adminDetails = request.server.plugins.pipelines
+                        const adminDetails = request.server.plugins.banners
                             .screwdriverAdminDetails(username, scmContext);
 
                         // Allow cluster admins to remove pipeline if the repository does not exist

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -471,6 +471,23 @@ describe('pipeline plugin test', () => {
                 assert.equal(reply.statusCode, 500);
             });
         });
+
+        it('returns 500 when repository does not exist and private repo is enabled', () => {
+            const scms = {
+                'github:github.com': {
+                    config: {
+                        privateRepo: true
+                    }
+                }
+            };
+
+            pipelineFactoryMock.scm.scms = scms;
+            userMock.getPermissions.withArgs(scmUri).rejects({ code: 404 });
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
     });
 
     describe('GET /pipelines/{id}/jobs', () => {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -402,6 +402,15 @@ describe('pipeline plugin test', () => {
             })
         );
 
+        it('returns 204 when repository does not exist', () => {
+            userMock.getPermissions.withArgs(scmUri).rejects({ code: 404 });
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 204);
+                assert.calledOnce(pipeline.remove);
+            });
+        });
+
         it('returns 401 when user does not have admin permission', () => {
             const error = {
                 statusCode: 401,

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -169,6 +169,7 @@ describe('pipeline plugin test', () => {
             list: sinon.stub(),
             scm: {
                 getScmContexts: sinon.stub(),
+                getDisplayName: sinon.stub().returns('github'),
                 parseUrl: sinon.stub(),
                 decorateUrl: sinon.stub(),
                 getCommitSha: sinon.stub().resolves('sha')
@@ -215,7 +216,8 @@ describe('pipeline plugin test', () => {
             register: plugin,
             options: {
                 password,
-                scm: scmMock
+                scm: scmMock,
+                admins: ['github:myself']
             }
         }, {
             // eslint-disable-next-line global-require
@@ -395,6 +397,10 @@ describe('pipeline plugin test', () => {
             pipelineFactoryMock.get.withArgs(id).resolves(pipeline);
         });
 
+        afterEach(() => {
+            pipelineFactoryMock.get.withArgs(id).reset();
+        });
+
         it('returns 204 when delete successfully', () =>
             server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 204);
@@ -402,7 +408,7 @@ describe('pipeline plugin test', () => {
             })
         );
 
-        it('returns 204 when repository does not exist', () => {
+        it('returns 204 when repository does not exist and user is admin', () => {
             userMock.getPermissions.withArgs(scmUri).rejects({ code: 404 });
 
             return server.inject(options).then((reply) => {


### PR DESCRIPTION
## Context
Currently, pipelines cannot be removed if its underlying repository does not exist.

## Objective
Allow pipeline to be removed if `getPermissions` returns a 404 and only if `privateRepo` is disabled.

## References
Pending:
  - https://github.com/screwdriver-cd/scm-bitbucket/pull/52
https://github.com/screwdriver-cd/screwdriver/issues/450