### PR TITLE
fix(1194): add guest scope to collections API

### DIFF
--- a/plugins/collections/list.js
+++ b/plugins/collections/list.js
@@ -13,7 +13,7 @@ module.exports = () => ({
         tags: ['api', 'collections'],
         auth: {
             strategies: ['token'],
-            scope: ['user']
+            scope: ['user', '!guest']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
## Context

With out guest scope collections  API returns `404`

## Objective

Fixes broken pipeline page for guest access

## References

https://github.com/screwdriver-cd/screwdriver/issues/1194
