### PR TITLE
feat: allow update number of lines for build step

### DIFF
--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -46,6 +46,8 @@ module.exports = () => ({
                     if (request.payload.code !== undefined) {
                         steps[stepIndex].code = request.payload.code;
                         steps[stepIndex].endTime = request.payload.endTime || now;
+                    } else if (request.payload.lines !== undefined) {
+                        steps[stepIndex].lines = request.payload.lines;
                     } else {
                         steps[stepIndex].startTime = request.payload.startTime || now;
                     }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1744,6 +1744,19 @@ describe('build plugin test', () => {
             });
         });
 
+        it('returns 200 when updating the lines', () => {
+            buildFactoryMock.get.withArgs(id).resolves(buildMock);
+            delete options.payload.startTime;
+            delete options.payload.endTime;
+            delete options.payload.code;
+            options.payload.lines = 100;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepProperty(reply.result, 'lines', options.payload.lines);
+            });
+        });
+
         it('returns 403 for a the wrong build permission', () => {
             buildFactoryMock.get.withArgs(id).resolves(buildMock);
             options.credentials.username = 'b7c747ead67d34bb465c0225a2d78ff99f0457fd';


### PR DESCRIPTION
We add a new field `lines` for step in data-schema.
https://github.com/screwdriver-cd/data-schema/blob/master/models/build.js#L32

This PR is to allow that field to be updated.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1114