### PR TITLE
fix(1211): Display build aborted reason when a PR is closed

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -29,17 +29,22 @@ function isRestrictedPR(restriction, prSource) {
  * If the build is running, set state to ABORTED
  * @method stopJob
  * @param  {Object} config
+ * @param  {String} config.action  Event action ('Closed' or 'Synchronized')
  * @param  {Job}    config.job     Job to stop
  * @param  {String} config.prNum   Pull request number
  * @return {Promise}
  */
-function stopJob({ job, prNum }) {
+function stopJob({ job, prNum, action }) {
     const stopRunningBuild = (build) => {
         if (build.isDone()) {
             return Promise.resolve();
         }
+
+        const statusMessage = action === 'Closed' ? `Aborted because PR#${prNum} was closed` :
+            `Aborted because new commit was pushed to PR#${prNum}`;
+
         build.status = 'ABORTED';
-        build.statusMessage = `Aborted because PR#${prNum} is closed`;
+        build.statusMessage = statusMessage;
 
         return build.update();
     };
@@ -139,8 +144,8 @@ function pullRequestOpened(options, request, reply) {
  * @param  {Hapi.reply}   reply   Reply to user
  */
 function pullRequestClosed(options, request, reply) {
-    const { pipeline, hookId, name, prNum } = options;
-    const updatePRJobs = (job => stopJob({ job, prNum })
+    const { pipeline, hookId, name, prNum, action } = options;
+    const updatePRJobs = (job => stopJob({ job, prNum, action })
         .then(() => request.log(['webhook', hookId, job.id], `${job.name} stopped`))
         .then(() => {
             job.archived = true;
@@ -178,7 +183,7 @@ function pullRequestClosed(options, request, reply) {
  * @param  {Hapi.reply}   reply                 Reply to user
  */
 function pullRequestSync(options, request, reply) {
-    const { pipeline, hookId, restriction, prSource, name, prNum } = options;
+    const { pipeline, hookId, restriction, prSource, name, prNum, action } = options;
     let prJobs;
 
     // Check for restriction upfront
@@ -194,7 +199,7 @@ function pullRequestSync(options, request, reply) {
         .then((jobs) => {
             prJobs = jobs.filter(j => j.name.includes(name));
 
-            return Promise.all(prJobs.map(j => stopJob({ job: j, prNum })));
+            return Promise.all(prJobs.map(j => stopJob({ job: j, prNum, action })));
         })
         .then(() => request.log(['webhook', hookId], `Job(s) for ${name} stopped`))
         .then(() => startPRJob(options, request))

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -791,8 +791,10 @@ describe('github plugin test', () => {
                     })
                 );
 
-                it('has the workflow for stopping builds before starting a new one', () =>
-                    server.inject(options).then((reply) => {
+                it('has the workflow for stopping builds before starting a new one', () => {
+                    const abortMsg = 'Aborted because new commit was pushed to PR#1';
+
+                    return server.inject(options).then((reply) => {
                         assert.calledOnce(model1.update);
                         assert.calledOnce(model2.update);
                         assert.calledWith(eventFactoryMock.create, {
@@ -811,9 +813,13 @@ describe('github plugin test', () => {
                         });
                         assert.isOk(model1.update.calledBefore(eventFactoryMock.create));
                         assert.isOk(model2.update.calledBefore(eventFactoryMock.create));
+                        assert.strictEqual(model1.status, 'ABORTED');
+                        assert.strictEqual(model1.statusMessage, abortMsg);
+                        assert.strictEqual(model2.status, 'ABORTED');
+                        assert.strictEqual(model2.statusMessage, abortMsg);
                         assert.equal(reply.statusCode, 201);
-                    })
-                );
+                    });
+                });
 
                 it('does not update if build finished running', () => {
                     model2.isDone.returns(true);
@@ -959,9 +965,9 @@ describe('github plugin test', () => {
                         assert.calledOnce(model1.update);
                         assert.calledOnce(model2.update);
                         assert.strictEqual(model1.status, 'ABORTED');
-                        assert.strictEqual(model1.statusMessage, 'Aborted because PR#1 is closed');
+                        assert.strictEqual(model1.statusMessage, 'Aborted because PR#1 was closed');
                         assert.strictEqual(model2.status, 'ABORTED');
-                        assert.strictEqual(model2.statusMessage, 'Aborted because PR#1 is closed');
+                        assert.strictEqual(model2.statusMessage, 'Aborted because PR#1 was closed');
                     })
                 );
 

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -958,6 +958,10 @@ describe('github plugin test', () => {
                     server.inject(options).then(() => {
                         assert.calledOnce(model1.update);
                         assert.calledOnce(model2.update);
+                        assert.strictEqual(model1.status, 'ABORTED');
+                        assert.strictEqual(model1.statusMessage, 'Aborted because PR#1 is closed');
+                        assert.strictEqual(model2.status, 'ABORTED');
+                        assert.strictEqual(model2.statusMessage, 'Aborted because PR#1 is closed');
                     })
                 );
 


### PR DESCRIPTION
## Context

We set the build status message when a user aborts a build in the UI. It would be nice if we had an equivalent status message when the build is aborted because a PR is closed.

## Objective

This PR adds a status message for aborted PR builds.

## References

Issue: https://github.com/screwdriver-cd/screwdriver/issues/1211