### PR TITLE
fix: fix unit tests without default pagination query param

### DIFF
--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -164,8 +164,8 @@ describe('command plugin test', () => {
                 assert.calledWith(commandFactoryMock.list, {
                     params: {},
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -184,8 +184,8 @@ describe('command plugin test', () => {
                         namespace: 'foo'
                     },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -274,8 +274,8 @@ describe('command plugin test', () => {
                         name: 'build'
                     },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -934,8 +934,8 @@ describe('command plugin test', () => {
                         name: 'bar'
                     },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -973,8 +973,8 @@ describe('command plugin test', () => {
                         name: 'with-no-tags'
                     },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -319,8 +319,8 @@ describe('job plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.calledWith(job.getBuilds, {
                     paginate: {
-                        count: 50,
-                        page: 1
+                        count: undefined,
+                        page: undefined
                     },
                     sort: 'descending'
                 });
@@ -352,7 +352,7 @@ describe('job plugin test', () => {
                 assert.calledWith(job.getBuilds, {
                     paginate: {
                         count: 30,
-                        page: 1
+                        page: undefined
                     },
                     sort: 'descending'
                 });

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -535,8 +535,8 @@ describe('pipeline plugin test', () => {
                         archived: false
                     },
                     paginate: {
-                        count: 50,
-                        page: 1
+                        count: undefined,
+                        page: undefined
                     }
                 });
                 assert.deepEqual(reply.result, testJobs);

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -152,8 +152,8 @@ describe('template plugin test', () => {
                 assert.calledWith(templateFactoryMock.list, {
                     params: {},
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -172,8 +172,8 @@ describe('template plugin test', () => {
                         namespace: 'chef'
                     },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -259,8 +259,8 @@ describe('template plugin test', () => {
                 assert.calledWith(templateFactoryMock.list, {
                     params: { name: 'screwdriver/build' },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -473,8 +473,8 @@ describe('template plugin test', () => {
                 assert.calledWith(templateTagFactoryMock.list, {
                     params: { name: 'screwdriver/build' },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });
@@ -509,8 +509,8 @@ describe('template plugin test', () => {
                 assert.calledWith(templateTagFactoryMock.list, {
                     params: { name: 'template-with-no-tags' },
                     paginate: {
-                        page: 1,
-                        count: 50
+                        page: undefined,
+                        count: undefined
                     },
                     sort: 'descending'
                 });


### PR DESCRIPTION
We remove the default pagination query param from data-schema which breaks unit tests.
