### PR TITLE
fix: [1] able to promote tag by tag

### DIFF
--- a/plugins/commands/createTag.js
+++ b/plugins/commands/createTag.js
@@ -5,6 +5,9 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const baseSchema = schema.models.commandTag.base;
 const urlLib = require('url');
+const VERSION_REGEX = schema.config.regex.VERSION;
+const exactVersionSchema = joi.reach(schema.models.commandTag.base, 'version');
+const tagSchema = joi.reach(schema.models.commandTag.base, 'tag');
 
 /* Currently, only build scope is allowed to tag command due to security reasons.
  * The same pipeline that publishes the command has the permission to tag it.
@@ -31,13 +34,28 @@ module.exports = () => ({
             const namespace = request.params.namespace;
             const name = request.params.name;
             const tag = request.params.tagName;
-            const version = request.payload.version;
+            let version = request.payload.version;
+            const isVersion = VERSION_REGEX.exec(version);
 
-            return Promise.all([
-                pipelineFactory.get(pipelineId),
-                commandFactory.get({ namespace, name, version }),
-                commandTagFactory.get({ namespace, name, tag })
-            ]).then(([pipeline, command, commandTag]) => {
+            return Promise.resolve().then(() => {
+                if (version && isVersion) {
+                    return Promise.all([
+                        pipelineFactory.get(pipelineId),
+                        commandFactory.get({ namespace, name, version }),
+                        commandTagFactory.get({ namespace, name, tag })
+                    ]);
+                }
+
+                return commandTagFactory.get({ namespace, name, tag: version }).then( targetCommandTag => {
+                    version = targetCommandTag.version;
+                    return Promise.all([
+                        pipelineFactory.get(pipelineId),
+                        commandFactory.get({ namespace, name, version }),
+                        commandTagFactory.get({ namespace, name, tag })
+                    ]);
+                });
+
+            }).then(([pipeline, command, commandTag]) => {
                 // If command doesn't exist, throw error
                 if (!command) {
                     throw boom.notFound(`Command ${namespace}/${name}@${version} not found`);
@@ -77,7 +95,10 @@ module.exports = () => ({
                 tagName: joi.reach(baseSchema, 'tag')
             },
             payload: {
-                version: joi.reach(baseSchema, 'version')
+                version: joi.alternatives().try(
+                    exactVersionSchema,
+                    tagSchema
+                )
             }
         }
     }

--- a/plugins/commands/createTag.js
+++ b/plugins/commands/createTag.js
@@ -46,15 +46,16 @@ module.exports = () => ({
                     ]);
                 }
 
-                return commandTagFactory.get({ namespace, name, tag: version }).then( targetCommandTag => {
-                    version = targetCommandTag.version;
-                    return Promise.all([
-                        pipelineFactory.get(pipelineId),
-                        commandFactory.get({ namespace, name, version }),
-                        commandTagFactory.get({ namespace, name, tag })
-                    ]);
-                });
+                return commandTagFactory.get({ namespace, name, tag: version })
+                    .then((targetCommandTag) => {
+                        version = targetCommandTag.version;
 
+                        return Promise.all([
+                            pipelineFactory.get(pipelineId),
+                            commandFactory.get({ namespace, name, version }),
+                            commandTagFactory.get({ namespace, name, tag })
+                        ]);
+                    });
             }).then(([pipeline, command, commandTag]) => {
                 // If command doesn't exist, throw error
                 if (!command) {

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -993,7 +993,6 @@ describe('command plugin test', () => {
             version: 'latest'
         };
         const testCommandTag = decorateObj(hoek.merge({ id: 1 }, payload));
-        const testCommandTagWithTag = decorateObj(hoek.merge({ id: 1 }, payloadTag));
 
         beforeEach(() => {
             options = {
@@ -1038,7 +1037,7 @@ describe('command plugin test', () => {
             });
         });
 
-        it('creates commands tag if has good permission and tag does not exist', () => {
+        it('creates a command tag if it has permission and tag does not exist', () => {
             commandTagFactoryMock.create.resolves(testCommandTag);
 
             return server.inject(options).then((reply) => {
@@ -1071,7 +1070,7 @@ describe('command plugin test', () => {
             });
         });
 
-        it('update command tag if has good permission and tag exists', () => {
+        it('updates a command tag if it has permission and tag exists', () => {
             const command = hoek.merge({
                 update: sinon.stub().resolves(testCommandTag)
             }, testCommandTag);
@@ -1095,8 +1094,8 @@ describe('command plugin test', () => {
             });
         });
 
-        it('creates commands tag if has good permission and tag does not exist with tag', () => {
-            commandTagFactoryMock.create.resolves(testCommandTagWithTag);
+        it('creates a command tag with tag if it has permission and tag does not exists', () => {
+            commandTagFactoryMock.create.resolves(testCommandTag);
             commandTagFactoryMock.get.onFirstCall().resolves(testCommandTag);
             commandTagFactoryMock.get.onSecondCall().resolves(null);
 
@@ -1110,7 +1109,7 @@ describe('command plugin test', () => {
                     pathname: `${options.url}/1`
                 };
 
-                assert.deepEqual(reply.result, hoek.merge({ id: 1 }, payloadTag));
+                assert.deepEqual(reply.result, hoek.merge({ id: 1 }, payload));
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(commandFactoryMock.get, {
                     namespace: 'screwdriver',
@@ -1133,7 +1132,7 @@ describe('command plugin test', () => {
             });
         });
 
-        it('update command tag if has good permission and tag exists with tag', () => {
+        it('updates a command tag with tag if it has permission and tag exists', () => {
             const command = hoek.merge({
                 update: sinon.stub().resolves(testCommandTag)
             }, testCommandTag);

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -989,7 +989,11 @@ describe('command plugin test', () => {
         const payload = {
             version: '1.2.0'
         };
+        const payloadTag = {
+            version: 'latest'
+        };
         const testCommandTag = decorateObj(hoek.merge({ id: 1 }, payload));
+        const testCommandTagWithTag = decorateObj(hoek.merge({ id: 1 }, payloadTag));
 
         beforeEach(() => {
             options = {
@@ -1085,6 +1089,70 @@ describe('command plugin test', () => {
                     name: 'test',
                     tag: 'stable'
                 });
+                assert.calledOnce(command.update);
+                assert.notCalled(commandTagFactoryMock.create);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('creates commands tag if has good permission and tag does not exist with tag', () => {
+            commandTagFactoryMock.create.resolves(testCommandTagWithTag);
+            commandTagFactoryMock.get.onFirstCall().resolves(testCommandTag);
+            commandTagFactoryMock.get.onSecondCall().resolves(null);
+
+            options.payload = payloadTag;
+
+            return server.inject(options).then((reply) => {
+                const expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/1`
+                };
+
+                assert.deepEqual(reply.result, hoek.merge({ id: 1 }, payloadTag));
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledWith(commandFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    version: '1.2.0'
+                });
+                assert.calledWith(commandTagFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    tag: 'stable'
+                });
+                assert.calledWith(commandTagFactoryMock.create, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    tag: 'stable',
+                    version: '1.2.0'
+                });
+                assert.calledTwice(commandTagFactoryMock.get);
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('update command tag if has good permission and tag exists with tag', () => {
+            const command = hoek.merge({
+                update: sinon.stub().resolves(testCommandTag)
+            }, testCommandTag);
+
+            commandTagFactoryMock.get.resolves(command);
+            options.payload = payloadTag;
+
+            return server.inject(options).then((reply) => {
+                assert.calledWith(commandFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    version: '1.2.0'
+                });
+                assert.calledWith(commandTagFactoryMock.get, {
+                    namespace: 'screwdriver',
+                    name: 'test',
+                    tag: 'stable'
+                });
+                assert.calledTwice(commandTagFactoryMock.get);
                 assert.calledOnce(command.update);
                 assert.notCalled(commandTagFactoryMock.create);
                 assert.equal(reply.statusCode, 200);


### PR DESCRIPTION
## Context

Now sd-cmd cannot promote tag by tag. 

## Objective

Be able to promote tag with tag.
(e.g. 
```
sd-cmd promote hoge/huga latest stable
```

todo:
- [x]  add test