### PR TITLE
feat(880): Pass in sortBy for GET /pipelines endpoint [4]

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -28,7 +28,7 @@ server.register({
 ### Routes
 
 #### Get all pipelines
-`page`, `count` and `configPipelineId` optional
+`page`, `count`, `sort`, `sortBy`, and `configPipelineId` optional
 
 `GET /pipelines?page={pageNumber}&count={countNumber}&configPipelineId={configPipelineId}`
 

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -37,6 +37,10 @@ module.exports = () => ({
                     config.params.configPipelineId = request.query.configPipelineId;
                 }
 
+                if (request.query.sortBy) {
+                    config.sortBy = request.query.sortBy;
+                }
+
                 if (request.query.page || request.query.count) {
                     config.paginate = {
                         page: request.query.page,

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -322,6 +322,50 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 and all pipelines when sort is set', () => {
+            options.url = '/pipelines?sort=ascending';
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'github:github.com'
+                },
+                sort: 'ascending'
+            }).resolves(getPipelineMocks(testPipelines));
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'gitlab:mygitlab'
+                },
+                sort: 'ascending'
+            }).resolves(getPipelineMocks(gitlabTestPipelines));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testPipelines.concat(gitlabTestPipelines));
+            });
+        });
+
+        it('returns 200 and all pipelines when sortBy is set', () => {
+            options.url = '/pipelines?sort=ascending&sortBy=scmRepo.name';
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'github:github.com'
+                },
+                sort: 'ascending',
+                sortBy: 'scmRepo.name'
+            }).resolves(getPipelineMocks(testPipelines));
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'gitlab:mygitlab'
+                },
+                sort: 'ascending',
+                sortBy: 'scmRepo.name'
+            }).resolves(getPipelineMocks(gitlabTestPipelines));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testPipelines.concat(gitlabTestPipelines));
+            });
+        });
+
         it('returns 200 and all pipelines with matched configPipelineId', () => {
             options.url = '/pipelines?page=1&count=3&configPipelineId=123';
             pipelineFactoryMock.list.withArgs({


### PR DESCRIPTION
## Context

Would be nice to paginate GET /pipelines result, but the UI expects pipelines to be sorted alphabetically by `scmRepo.name`.

## Objective

This PR passes in the `sort` and `sortBy` fields to `GET /pipelines` endpoint to allow for required sorting.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/880
Blocked by https://github.com/screwdriver-cd/data-schema/pull/274, https://github.com/screwdriver-cd/datastore-sequelize/pull/31, https://github.com/screwdriver-cd/models/pull/287