### PR TITLE
fix(1220): [2][small] Move waiting for changedFiles from pipeline model

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -4,6 +4,23 @@ const boom = require('boom');
 const joi = require('joi');
 const workflowParser = require('screwdriver-workflow-parser');
 
+const WAIT_FOR_CHANGEDFILES = 1.8;
+
+/**
+ * Promise to wait a certain number of seconds
+ *
+ * Might make this centralized for other tests to leverage
+ *
+ * @method promiseToWait
+ * @param  {Number}      timeToWait  Number of seconds to wait before continuing the chain
+ * @return {Promise}
+ */
+function promiseToWait(timeToWait) {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(), timeToWait * 1000);
+    });
+}
+
 /**
  * Check if the PR is being restricted or not
  * @method isRestrictedPR
@@ -579,7 +596,11 @@ exports.register = (server, options, next) => {
                         return reply().code(204);
                     }
 
-                    return obtainScmToken(pluginOptions, userFactory, username, scmContext)
+                    return promiseToWait(WAIT_FOR_CHANGEDFILES)
+                        .then(() => obtainScmToken(pluginOptions,
+                            userFactory,
+                            username,
+                            scmContext))
                         .then(token => scm.getChangedFiles({
                             payload: request.payload,
                             type,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We added the wait to ensure we will get latest config.
https://github.com/screwdriver-cd/models/pull/208
However, it is enough to wait before getChangedFiles is called. When PR webhook is occured, processing will through this point for sure.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I added promiseToWait before getChangedFiles is called.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
original issue https://github.com/screwdriver-cd/screwdriver/issues/1220#issuecomment-417989327
related PR
models: screwdriver-cd/models#289
