### PR TITLE
fix(979): pull in new executor-docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "screwdriver-coverage-sonar": "^1.0.8",
     "screwdriver-data-schema": "^18.32.0",
     "screwdriver-datastore-sequelize": "^5.0.0",
-    "screwdriver-executor-docker": "^3.0.0",
+    "screwdriver-executor-docker": "^4.0.0",
     "screwdriver-executor-k8s": "^13.0.0",
     "screwdriver-executor-k8s-vm": "^2.4.3",
     "screwdriver-executor-nomad": "^1.0.4",


### PR DESCRIPTION
This fixes a bug of missing files with Docker 18.03.0-ce.

Change in executor-docker
- https://github.com/screwdriver-cd/executor-docker/blob/b511eedee2e01c22d7d401f186c00fbdae3aca15/index.js#L175


Related issue: https://github.com/screwdriver-cd/screwdriver/issues/979