### PR TITLE
fix(880): Pass search field and term to datastore for pipeline list [4]

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -29,7 +29,7 @@ server.register({
 
 #### Get all pipelines
 `page`, `count`, `sort`, `sortBy`, `search`, and `configPipelineId` optional
-`search` will search for a pipeline with a name containing the search term
+`search` will search for a pipeline with a name containing the search keyword in the `scmRepo` field
 
 `GET /pipelines?page={pageNumber}&count={countNumber}&configPipelineId={configPipelineId}&search={search}`
 

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -28,9 +28,10 @@ server.register({
 ### Routes
 
 #### Get all pipelines
-`page`, `count`, `sort`, `sortBy`, and `configPipelineId` optional
+`page`, `count`, `sort`, `sortBy`, `search`, and `configPipelineId` optional
+`search` will search for a pipeline with a name containing the search term
 
-`GET /pipelines?page={pageNumber}&count={countNumber}&configPipelineId={configPipelineId}`
+`GET /pipelines?page={pageNumber}&count={countNumber}&configPipelineId={configPipelineId}&search={search}`
 
 #### Get single pipeline
 

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -44,7 +44,9 @@ module.exports = () => ({
                 if (request.query.search) {
                     config.search = {
                         field: 'scmRepo',
-                        term: `%name%${request.query.search}%` // Do a fuzzy search for name: screwdriver-cd/ui
+                        // Do a fuzzy search for name: screwdriver-cd/ui
+                        // See https://www.w3schools.com/sql/sql_like.asp for syntax
+                        keyword: `%name%${request.query.search}%`
                     };
                 }
 
@@ -71,7 +73,7 @@ module.exports = () => ({
         validate: {
             query: schema.api.pagination.concat(joi.object({
                 configPipelineId: idSchema,
-                search: joi.string().label('Valid search terms')
+                search: joi.string().label('Valid search keyword')
 
             }))
         }

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -41,6 +41,13 @@ module.exports = () => ({
                     config.sortBy = request.query.sortBy;
                 }
 
+                if (request.query.search) {
+                    config.search = {
+                        field: 'scmRepo',
+                        term: `%name%${request.query.search}%` // Do a fuzzy search for name: screwdriver-cd/ui
+                    };
+                }
+
                 if (request.query.page || request.query.count) {
                     config.paginate = {
                         page: request.query.page,
@@ -63,7 +70,9 @@ module.exports = () => ({
         },
         validate: {
             query: schema.api.pagination.concat(joi.object({
-                configPipelineId: idSchema
+                configPipelineId: idSchema,
+                search: joi.string().label('Valid search terms')
+
             }))
         }
     }

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -375,7 +375,7 @@ describe('pipeline plugin test', () => {
                 sort: 'descending',
                 search: {
                     field: 'scmRepo',
-                    term: '%name%screwdriver-cd/screwdriver%'
+                    keyword: '%name%screwdriver-cd/screwdriver%'
                 }
             }).resolves(getPipelineMocks(testPipelines));
             pipelineFactoryMock.list.withArgs({
@@ -385,7 +385,7 @@ describe('pipeline plugin test', () => {
                 sort: 'descending',
                 search: {
                     field: 'scmRepo',
-                    term: '%name%screwdriver-cd/screwdriver%'
+                    keyword: '%name%screwdriver-cd/screwdriver%'
                 }
             }).resolves(getPipelineMocks(gitlabTestPipelines));
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -366,6 +366,35 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 and all pipelines with matched search', () => {
+            options.url = '/pipelines?search=screwdriver-cd/screwdriver';
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'github:github.com'
+                },
+                sort: 'descending',
+                search: {
+                    field: 'scmRepo',
+                    term: '%name%screwdriver-cd/screwdriver%'
+                }
+            }).resolves(getPipelineMocks(testPipelines));
+            pipelineFactoryMock.list.withArgs({
+                params: {
+                    scmContext: 'gitlab:mygitlab'
+                },
+                sort: 'descending',
+                search: {
+                    field: 'scmRepo',
+                    term: '%name%screwdriver-cd/screwdriver%'
+                }
+            }).resolves(getPipelineMocks(gitlabTestPipelines));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testPipelines.concat(gitlabTestPipelines));
+            });
+        });
+
         it('returns 200 and all pipelines with matched configPipelineId', () => {
             options.url = '/pipelines?page=1&count=3&configPipelineId=123';
             pipelineFactoryMock.list.withArgs({


### PR DESCRIPTION
## Context
Since we're adding pagination for pipelines, we can no longer have search functionality stored in the UI. 

## Objective
This PR passes search field and term to the datastore from the `GET /pipelines` endpoint. It will search the `scmRepo` text field for a term matching `%name%{pipeline_name}%`.

scmRepo field example:
```
{"branch":"tkyi-patch-1","name":"tkyi/mytest","url":"https://git.ouroath.com/tkyi/mytest/tree/tkyi-patch-1"}
```

To do a search, it expects a param like this:
```
params: {
  search: {
    field: "scmRepo",
    keyword: "%name%tkyi/mytest%"
  }
}
```

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880
Blocked by https://github.com/screwdriver-cd/models/pull/290, https://github.com/screwdriver-cd/datastore-sequelize/pull/32, https://github.com/screwdriver-cd/data-schema/pull/278