### PR TITLE
fix(757): allow update build status msg only

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -85,6 +85,13 @@ module.exports = () => ({
 
                     return eventFactory.get(build.eventId).then(event => ({ build, event }));
                 }).then(({ build, event }) => {
+                    // If payload only has statusMessage
+                    if (!desiredStatus && statusMessage) {
+                        build.statusMessage = statusMessage;
+
+                        return Promise.all([build.update(), event.update()]);
+                    }
+
                     switch (desiredStatus) {
                     case 'SUCCESS':
                     case 'FAILURE':

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -566,6 +566,30 @@ describe('build plugin test', () => {
                 });
             });
 
+            it('allows updating statusMessage only', () => {
+                const statusMessage = 'hello';
+                const options = {
+                    method: 'PUT',
+                    url: `/builds/${id}`,
+                    credentials: {
+                        username: id,
+                        scope: ['temporal']
+                    },
+                    payload: {
+                        statusMessage
+                    }
+                };
+
+                return server.inject(options).then((reply) => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.calledWith(buildFactoryMock.get, id);
+                    assert.calledOnce(buildMock.update);
+                    assert.strictEqual(buildMock.statusMessage, statusMessage);
+                    assert.isUndefined(buildMock.meta);
+                    assert.isUndefined(buildMock.endTime);
+                });
+            });
+
             it('saves status, statusMessage, meta updates, and merge event meta', () => {
                 const meta = {
                     foo: 'bar',


### PR DESCRIPTION
If payload contains only statusMsg, only updates that.

Blocked by: https://github.com/screwdriver-cd/data-schema/pull/281/files