### PR TITLE
fix(880): Update, save, and search by pipeline name

### DIFF
--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -43,11 +43,10 @@ module.exports = () => ({
 
                 if (request.query.search) {
                     config.search = {
-                        field: 'scmRepo',
-                        // Do a fuzzy search for name: screwdriver-cd/ui,
-                        // Need the comma to avoid searching in the url
+                        field: 'name',
+                        // Do a fuzzy search for name: screwdriver-cd/ui
                         // See https://www.w3schools.com/sql/sql_like.asp for syntax
-                        keyword: `%name%${request.query.search}%,%`
+                        keyword: `%${request.query.search}%`
                     };
                 }
 

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -97,6 +97,7 @@ module.exports = () => ({
                                     [username]: true
                                 };
                                 oldPipeline.scmRepo = scmRepo;
+                                oldPipeline.name = scmRepo.name;
 
                                 // update pipeline with new scmRepo and branch
                                 return oldPipeline.update()

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -344,20 +344,20 @@ describe('pipeline plugin test', () => {
         });
 
         it('returns 200 and all pipelines when sortBy is set', () => {
-            options.url = '/pipelines?sort=ascending&sortBy=scmRepo.name';
+            options.url = '/pipelines?sort=ascending&sortBy=name';
             pipelineFactoryMock.list.withArgs({
                 params: {
                     scmContext: 'github:github.com'
                 },
                 sort: 'ascending',
-                sortBy: 'scmRepo.name'
+                sortBy: 'name'
             }).resolves(getPipelineMocks(testPipelines));
             pipelineFactoryMock.list.withArgs({
                 params: {
                     scmContext: 'gitlab:mygitlab'
                 },
                 sort: 'ascending',
-                sortBy: 'scmRepo.name'
+                sortBy: 'name'
             }).resolves(getPipelineMocks(gitlabTestPipelines));
 
             return server.inject(options).then((reply) => {
@@ -374,8 +374,8 @@ describe('pipeline plugin test', () => {
                 },
                 sort: 'descending',
                 search: {
-                    field: 'scmRepo',
-                    keyword: '%name%screwdriver-cd/screwdriver%,%'
+                    field: 'name',
+                    keyword: '%screwdriver-cd/screwdriver%'
                 }
             }).resolves(getPipelineMocks(testPipelines));
             pipelineFactoryMock.list.withArgs({
@@ -384,8 +384,8 @@ describe('pipeline plugin test', () => {
                 },
                 sort: 'descending',
                 search: {
-                    field: 'scmRepo',
-                    keyword: '%name%screwdriver-cd/screwdriver%,%'
+                    field: 'name',
+                    keyword: '%screwdriver-cd/screwdriver%'
                 }
             }).resolves(getPipelineMocks(gitlabTestPipelines));
 


### PR DESCRIPTION
## Context
It's hard to do operations in the UI based on the pipeline name when it is stored in a JSON string in the DB under `scmRepo`.

## Objective
This PR saves and updates the pipeline `name` field at the root level of a pipeline when `scmRepo` is saved/updated. Also searches pipelines by pipeline `name`.

_Note: After this PR is merged, we will need to migrate `scmRepo.name` information to the new `name` field in the DB so that search will work for all pipelines._

## Related links
Blocked by https://github.com/screwdriver-cd/data-schema/pull/283, https://github.com/screwdriver-cd/models/pull/292
Related to https://github.com/screwdriver-cd/screwdriver/issues/880