### PR TITLE
[2]fix(1117): Pass pipelineFactory to executor when setup executor

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -32,14 +32,6 @@ const DatastorePlugin = require(`screwdriver-datastore-${datastoreConfig.plugin}
 const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem },
     (datastoreConfig[datastoreConfig.plugin] || {})));
 
-// Setup Executor
-const executorConfig = config.get('executor');
-const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
-const executor = new ExecutorPlugin(Object.assign(
-    { ecosystem: hoek.clone(ecosystem) },
-    executorConfig[executorConfig.plugin].options
-));
-
 // Source Code Plugin
 const scmConfig = { scms: config.get('scms') };
 const ScmPlugin = require('screwdriver-scm-router');
@@ -67,8 +59,23 @@ bookends.setup || [], // plugins required for the setup- steps
 bookends.teardown || [] // plugins required for the teardown- steps
 );
 
-// Setup Model Factories
+// Setup Pipeline Factory for Executor
 const Models = require('screwdriver-models');
+const pipelineFactory = Models.PipelineFactory.getInstance({
+    datastore,
+    scm
+});
+
+// Setup Executor
+const executorConfig = config.get('executor');
+executorConfig[executorConfig.plugin].options.pipelineFactory = pipelineFactory;
+const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
+const executor = new ExecutorPlugin(Object.assign(
+    { ecosystem: hoek.clone(ecosystem) },
+    executorConfig[executorConfig.plugin].options
+));
+
+// Setup Model Factories
 const commandFactory = Models.CommandFactory.getInstance({
     datastore
 });
@@ -80,11 +87,6 @@ const templateFactory = Models.TemplateFactory.getInstance({
 });
 const templateTagFactory = Models.TemplateTagFactory.getInstance({
     datastore
-});
-
-const pipelineFactory = Models.PipelineFactory.getInstance({
-    datastore,
-    scm
 });
 const jobFactory = Models.JobFactory.getInstance({
     datastore,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The periodic build does not start in the case of the pipeline admin user was removed after periodic build made.
To fix this problem, executor-queue use pipelineFactory. Therefore, API fixed to pass pipelineFactory to executor when setup executor.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fixed to pass pipelineFactory to executor when setup executor.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: #1117 
executor-queue PR: https://github.com/screwdriver-cd/executor-queue/pull/33
