### PR TITLE
[small] Fix workflow tests

### DIFF
--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -94,10 +94,8 @@ defineSupportCode(({ Before, Given, When, Then }) => {
             eventId: this.eventId,
             jwt: this.jwt
         })
-            .then((response) => {
-                this.builds = response.body;
-            })
-            .then(() => {
+            .then((builds) => {
+                this.builds = builds;
                 const job = this.jobs.find(j => j.name === jobName);
                 const build = this.builds.find(b => b.jobId === job.id);
 
@@ -115,10 +113,8 @@ defineSupportCode(({ Before, Given, When, Then }) => {
             eventId: this.eventId,
             jwt: this.jwt
         })
-            .then((response) => {
-                this.builds = response.body;
-            })
-            .then(() => {
+            .then((builds) => {
+                this.builds = builds;
                 const parentJob = this.jobs.find(j => j.name === parentJobName);
                 const parentBuild = this.builds.find(b => b.jobId === parentJob.id);
                 const triggeredJob = this.jobs.find(j => j.name === triggeredJobName);
@@ -138,8 +134,8 @@ defineSupportCode(({ Before, Given, When, Then }) => {
             eventId: this.eventId,
             jwt: this.jwt
         })
-            .then((response) => {
-                this.builds = response.body;
+            .then((builds) => {
+                this.builds = builds;
                 const joinJob = this.jobs.find(j => j.name === joinJobName);
                 const joinBuild = this.builds.find(b => b.jobId === joinJob.id);
 
@@ -160,10 +156,8 @@ defineSupportCode(({ Before, Given, When, Then }) => {
             eventId: this.eventId,
             jwt: this.jwt
         })
-            .then((response) => {
-                this.builds = response.body;
-            })
-            .then(() => {
+            .then((builds) => {
+                this.builds = builds;
                 const job = this.jobs.find(j => j.name === jobName);
                 const build = this.builds.find(b => b.jobId === job.id);
 

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -103,9 +103,7 @@ function findEventBuilds(config) {
             return result;
         }
 
-        return promiseToWait(3).then(() => {
-            return findEventBuilds(config)
-        });
+        return promiseToWait(3).then(() => findEventBuilds(config));
     });
 }
 

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -96,6 +96,16 @@ function findEventBuilds(config) {
         auth: {
             bearer: config.jwt
         }
+    }).then((buildData) => {
+        const result = buildData.body || [];
+
+        if (result.length > 0) {
+            return result;
+        }
+
+        return promiseToWait(3).then(() => {
+            return findEventBuilds(config)
+        });
     });
 }
 


### PR DESCRIPTION
## Context
Functional tests of workflow frequently fails.
We have to wait for builds to start after triggering steps finished.

## Objective
Add retry process in `findEventBuilds` function.

## References
relates: https://github.com/screwdriver-cd/screwdriver/pull/1328