### PR TITLE
fix(1257): config format for build cache

### DIFF
--- a/design/build-cache.md
+++ b/design/build-cache.md
@@ -27,31 +27,29 @@ The build cache and cache usage is configurable via Yaml and backed by an intern
 ### Yaml specification
 
 ```yml
+# Caches defined in the shared section can be pipeline or exection scoped.
+cache:
+  # A pipeline scoped cache.
+  pipeline: ["node_modules/", "~/.sbt"]
+  # An event scoped cache
+  event: ["target/generated-intermediate-resouce/*"]
+  # A job scoped cache 
+  job:
+    build: ["target/some-artifact.zip"]
+    publish-preview: ["target/some-artifact.zip"]
 shared:
-  # Caches defined in the shared section can be pipeline or exection scoped.
-  cache:
-    # A pipeline scoped cache.
-    pipeline: ["node_modules/", "~/.sbt"]
-    # An event scoped cache
-    event: ["target/generated-intermediate-resouce/*"]
-    # A job scoped cache 
-    job:
-        - build: ["target/some-artifact.zip"]
-        - publish-preview: ["target/some-artifact.zip"]
+  image: rust:latest
 jobs:
   test:
     requires: [~pr]
-    image: rust:latest
     steps:
       - test: cargo test
   build: 
     requires: [~pr]
-    image: rust:latest
     steps:
       - test: cargo build
   publish-preview:
     requires: [~commit]
-    image: rust:latest
     steps:
       - add_musl: rustup target install x86_64-unknown-linux-musl
       - build: cargo build --release --target=x86_64-unknown-linux-musl

--- a/design/build-cache.md
+++ b/design/build-cache.md
@@ -27,7 +27,6 @@ The build cache and cache usage is configurable via Yaml and backed by an intern
 ### Yaml specification
 
 ```yml
-# Caches defined in the shared section can be pipeline or exection scoped.
 cache:
   # A pipeline scoped cache.
   pipeline: ["node_modules/", "~/.sbt"]


### PR DESCRIPTION
Decided to put the cache settings in top-level because of these reasons:
- Cannot put in `shared` because it currently has the same format as `jobs` and we don't want to change that. 
- Cannot put in `jobs` because the cache config itself contains multiple scopes, and it also contains multiple job names in there. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1257, https://github.com/screwdriver-cd/screwdriver/issues/1280