### PR TITLE
fix: make redirect_uri for oauth configurable

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -34,6 +34,8 @@ auth:
     __format: json
   # Default session timeout (in minutes)
   sessionTimeout: SESSION_TIMEOUT
+  # Oauth redirect uri, configure this if your app is not running at root under the host
+  oauthRedirectUri: OAUTH_REDIRECT_URI
 
 httpd:
   # Port to listen on

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -46,7 +46,8 @@ exports.register = (server, options, next) => {
         whitelist: joi.array().default([]),
         admins: joi.array().default([]),
         scm: joi.object().required(),
-        sessionTimeout: joi.number().integer().positive().default(120)
+        sessionTimeout: joi.number().integer().positive().default(120),
+        oauthRedirectUri: joi.string().optional()
     }), 'Invalid config for plugin-auth');
 
     /**
@@ -117,6 +118,10 @@ exports.register = (server, options, next) => {
                 bellConfig.password = pluginOptions.cookiePassword;
                 bellConfig.isSecure = pluginOptions.https;
                 bellConfig.forceHttps = pluginOptions.https;
+
+                if (pluginOptions.oauthRedirectUri) {
+                    bellConfig.location = pluginOptions.oauthRedirectUri;
+                }
 
                 // The oauth strategy differs between the scm modules
                 server.auth.strategy(`oauth_${scmContext}`, 'bell', bellConfig);

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -52,6 +52,7 @@ describe('auth plugin test', () => {
     const cookiePassword = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
     const encryptionPassword = 'this_is_another_password_that_needs_to_be_atleast_32_characters';
     const hashingPassword = 'this_is_another_password_that_needs_to_be_atleast_32_characters';
+    const oauthRedirectUri = 'https://myhost.com/api';
 
     beforeEach((done) => {
         scm = {
@@ -112,7 +113,8 @@ describe('auth plugin test', () => {
                 jwtPrivateKey,
                 jwtPublicKey,
                 allowGuestAccess: true,
-                https: false
+                https: false,
+                oauthRedirectUri
             }
         }, done);
     });


### PR DESCRIPTION
When `api` runs under a sub directory, e.g.http://myhost.com/api, the `redirect_uri` field constructed by `bell` will be wrong, it will miss the `/api` part. 

This PR will make`redirect_uri`  configurable so that user can actually pass in the actual value.
https://github.com/hapijs/bell/blob/master/API.md