### PR TITLE
[small] add event to emit data

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -129,9 +129,9 @@ module.exports = () => ({
                         settings: job.permutations[0].settings,
                         status: build.status,
                         event,
-                        pipelineName: pipeline.scmRepo.name,
+                        pipeline,
                         jobName: job.name,
-                        buildId: build.id,
+                        build,
                         buildLink:
                             `${buildFactory.uiUri}/pipelines/${pipeline.id}/builds/${id}`
                     });

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -124,10 +124,11 @@ module.exports = () => ({
 
                     // Only trigger next build on success
                     return Promise.all([build.update(), event.update()]);
-                }).then(([build]) => build.job.then(job => job.pipeline.then((pipeline) => {
+                }).then(([build, event]) => build.job.then(job => job.pipeline.then((pipeline) => {
                     request.server.emit('build_status', {
                         settings: job.permutations[0].settings,
                         status: build.status,
+                        event,
                         pipelineName: pipeline.scmRepo.name,
                         jobName: job.name,
                         buildId: build.id,

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -381,6 +381,7 @@ describe('build plugin test', () => {
                     buildId: 12345,
                     buildLink: 'http://foo.bar/pipelines/123/builds/12345',
                     jobName: 'main',
+                    event: eventMock,
                     pipelineName: 'screwdriver-cd/screwdriver',
                     settings: {
                         email: 'foo@bar.com'

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -378,11 +378,11 @@ describe('build plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.calledWith(server.emit, 'build_status', {
-                    buildId: 12345,
+                    build: buildMock,
                     buildLink: 'http://foo.bar/pipelines/123/builds/12345',
                     jobName: 'main',
                     event: eventMock,
-                    pipelineName: 'screwdriver-cd/screwdriver',
+                    pipeline: pipelineMock,
                     settings: {
                         email: 'foo@bar.com'
                     },


### PR DESCRIPTION
## Context
We want to enrich infomations of notifications.

## Objective
Pass event, build, pipeline data to notification plugins.

relates:
https://github.com/screwdriver-cd/notifications-email/pull/16
https://github.com/screwdriver-cd/notifications-slack/pull/13