### PR TITLE
fix: increase wait time in feature tests

### DIFF
--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -103,7 +103,7 @@ function findEventBuilds(config) {
             return result;
         }
 
-        return promiseToWait(3).then(() => findEventBuilds(config));
+        return promiseToWait(5).then(() => findEventBuilds(config));
     });
 }
 
@@ -154,7 +154,7 @@ function searchForBuild(config) {
             return result[0];
         }
 
-        return promiseToWait(3).then(() => searchForBuild(config));
+        return promiseToWait(5).then(() => searchForBuild(config));
     });
 }
 
@@ -189,7 +189,7 @@ function waitForBuildStatus(config) {
             return buildData;
         }
 
-        return promiseToWait(3).then(() => waitForBuildStatus(config));
+        return promiseToWait(5).then(() => waitForBuildStatus(config));
     });
 }
 

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const request = require('./request');
+const WAIT_TIME = 6;
 
 /**
  * Promise to wait a certain number of seconds
@@ -103,7 +104,7 @@ function findEventBuilds(config) {
             return result;
         }
 
-        return promiseToWait(5).then(() => findEventBuilds(config));
+        return promiseToWait(WAIT_TIME).then(() => findEventBuilds(config));
     });
 }
 
@@ -154,7 +155,7 @@ function searchForBuild(config) {
             return result[0];
         }
 
-        return promiseToWait(5).then(() => searchForBuild(config));
+        return promiseToWait(WAIT_TIME).then(() => searchForBuild(config));
     });
 }
 
@@ -189,7 +190,7 @@ function waitForBuildStatus(config) {
             return buildData;
         }
 
-        return promiseToWait(5).then(() => waitForBuildStatus(config));
+        return promiseToWait(WAIT_TIME).then(() => waitForBuildStatus(config));
     });
 }
 

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -129,8 +129,8 @@ function CustomWorld({ attach, parameters }) {
         requestretry({
             uri: `${this.instance}/${this.namespace}/builds/${buildID}`,
             method: 'GET',
-            maxAttempts: 25,
-            retryDelay: 5000,
+            maxAttempts: 20,
+            retryDelay: 10000,
             retryStrategy: buildRetryStrategy,
             json: true,
             auth: {


### PR DESCRIPTION
Functional tests are failing because some builds were "RUNNING" instead of "SUCCESS", and also some checks where it tries to find the builds, they are not created yet. 

However, when looked into the functional test pipelines, it looks like the builds passed. Increasing the wait time to see if it fixes. 