### PR TITLE
fix: bug fix builds/update.js

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -128,10 +128,10 @@ module.exports = () => ({
                     request.server.emit('build_status', {
                         settings: job.permutations[0].settings,
                         status: build.status,
-                        event,
-                        pipeline,
+                        event: event.toJson(),
+                        pipeline: pipeline.toJson(),
                         jobName: job.name,
-                        build,
+                        build: build.toJson(),
                         buildLink:
                             `${buildFactory.uiUri}/pipelines/${pipeline.id}/builds/${id}`
                     });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -292,7 +292,8 @@ describe('build plugin test', () => {
                 admin: Promise.resolve({
                     username: 'foo',
                     unsealToken: sinon.stub().resolves('token')
-                })
+                }),
+                toJson: sinon.stub().returns({ id: pipelineId })
             };
 
             eventMock = {
@@ -311,7 +312,8 @@ describe('build plugin test', () => {
                     ]
                 },
                 getBuilds: sinon.stub(),
-                update: sinon.stub()
+                update: sinon.stub(),
+                toJson: sinon.stub().returns({ id: 123 })
             };
 
             eventFactoryMock.get.resolves(eventMock);
@@ -378,11 +380,11 @@ describe('build plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.calledWith(server.emit, 'build_status', {
-                    build: buildMock,
+                    build: buildMock.toJson(),
                     buildLink: 'http://foo.bar/pipelines/123/builds/12345',
                     jobName: 'main',
-                    event: eventMock,
-                    pipeline: pipelineMock,
+                    event: { id: 123 },
+                    pipeline: { id: 123 },
                     settings: {
                         email: 'foo@bar.com'
                     },


### PR DESCRIPTION
## Context
We found that the notification-plugins does not work.

## Objective
In this line of [notifications-email plugin](https://github.com/screwdriver-cd/notifications-email/blob/ff85796a9ecd42d21edddf6463df056140efbbdc/index.js#L82) it seems to catch the `e`. When I tried out debug out `e`, I got the following result.
```
TypeError: Cannot set property admin of [object Object] which has only a getter
    at internals.Object._base (/usr/src/app/node_modules/screwdriver-notifications-email/node_modules/joi/lib/types/object/index.js:85:38)
    at internals.Object._validate (/usr/src/app/node_modules/screwdriver-notifications-email/node_modules/joi/lib/types/any/index.js:590:37)
    at internals.Object._base (/usr/src/app/node_modules/screwdriver-notifications-email/node_modules/joi/lib/types/object/index.js:157:45)
    at internals.Object._validate (/usr/src/app/node_modules/screwdriver-notifications-email/node_modules/joi/lib/types/any/index.js:590:37)
    at internals.Object._validateWithOptions (/usr/src/app/node_modules/screwdriver-notifications-email/node_modules/joi/lib/types/any/index.js:650:29)
    at module.exports.internals.Any.root.validate (/usr/src/app/node_modules/screwdriver-notifications-email/node_modules/joi/lib/index.js:121:23)
    at module.exports.internals.Any.root.attempt (/usr/src/app/node_modules/screwdriver-notifications-email/node_modules/joi/lib/index.js:150:29)
    at EmailNotifier._notify (/usr/src/app/node_modules/screwdriver-notifications-email/index.js:82:17)
    at EmailNotifier.notify (/usr/src/app/node_modules/screwdriver-notifications-base/index.js:31:18)
    at server.on.buildData (/usr/src/app/node_modules/screwdriver-api/lib/registerPlugins.js:119:66)
    at Object.internals.handler (/usr/src/app/node_modules/podium/lib/index.js:283:33)
    at invoke (/usr/src/app/node_modules/podium/lib/index.js:255:23)
    at each (/usr/src/app/node_modules/podium/lib/index.js:259:13)
    at Object.exports.parallel (/usr/src/app/node_modules/items/lib/index.js:70:13)
    at Object.internals.emit (/usr/src/app/node_modules/podium/lib/index.js:276:18)
    at module.exports.internals.Server.internals.Podium._emit (/usr/src/app/node_modules/podium/lib/index.js:156:15)
    at each (/usr/src/app/node_modules/podium/lib/index.js:197:47)
    at Object.exports.parallel (/usr/src/app/node_modules/items/lib/index.js:70:13)
    at relay (/usr/src/app/node_modules/podium/lib/index.js:198:15)
    at Object.internals.emit (/usr/src/app/node_modules/podium/lib/index.js:202:16)
    at module.exports.internals.Podium.internals.Podium._emit (/usr/src/app/node_modules/podium/lib/index.js:156:15)
    at module.exports.internals.Podium.internals.Podium.emit (/usr/src/app/node_modules/podium/lib/index.js:129:17)
    at module.exports.internals.Server.internals.Plugin.emit (/usr/src/app/node_modules/hapi/lib/plugin.js:422:23)
    at job.pipeline.then (/usr/src/app/node_modules/screwdriver-api/plugins/builds/update.js:128:36)
    at <anonymous>
```

Try out debug out `buildData`, `admin` is `Promise`. As a simple solution, I think that `Promise` should not be processed by Joi.
```
  pipeline:
   PipelineModel {
     id: [Getter/Setter],
     name: [Getter/Setter],
(Omitted)
     childPipelines: [Getter/Setter],
     admin: Promise { [Object], domain: [Object] },
```

As a result of checking locally, by using `toJson()`, `Promise` was eliminated, so the problem was solved.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

Related: https://github.com/screwdriver-cd/screwdriver/pull/1361
