### PR TITLE
fix(1319): register buildCluster factory

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -110,6 +110,10 @@ const buildFactory = Models.BuildFactory.getInstance({
     bookend,
     uiUri: ecosystem.ui
 });
+const buildClusterFactory = Models.BuildClusterFactory.getInstance({
+    datastore,
+    scm
+});
 const stepFactory = Models.StepFactory.getInstance({
     datastore
 });

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -44,6 +44,7 @@ function registerResourcePlugins(server, config, callback) {
         'auth',
         'banners',
         'builds',
+        'buildClusters',
         'collections',
         'commands',
         'events',

--- a/lib/server.js
+++ b/lib/server.js
@@ -58,6 +58,7 @@ function prettyPrintErrors(request, reply) {
  * @param  {Factory}     config.tokenFactory        Token Factory instance
  * @param  {Factory}     config.eventFactory        Event Factory instance
  * @param  {Factory}     config.collectionFactory   Collection Factory instance
+ * @param  {Factory}     config.buildClusterFactory Build Cluster Factory instance
  * @param  {Factory}     config.triggerFactory      Trigger Factory instance
  * @param  {Function}    callback                   Callback to invoke when server has started.
  * @return {http.Server}                            A listener: NodeJS http.Server object
@@ -104,6 +105,7 @@ module.exports = (config) => {
         jobFactory: config.jobFactory,
         userFactory: config.userFactory,
         buildFactory: config.buildFactory,
+        buildClusterFactory: config.buildClusterFactory,
         stepFactory: config.stepFactory,
         bannerFactory: config.bannerFactory,
         secretFactory: config.secretFactory,

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -22,6 +22,7 @@ describe('Register Unit Test Case', () => {
         '../plugins/auth',
         '../plugins/banners',
         '../plugins/builds',
+        '../plugins/buildClusters',
         '../plugins/collections',
         '../plugins/commands',
         '../plugins/events',


### PR DESCRIPTION
Beta is broken at creating new builds because it pulls in the latest model which checks build cluster table when creating builds. But that is not registered in the api 