### PR TITLE
feat: expose SameSite Cookie option

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -36,6 +36,8 @@ auth:
   sessionTimeout: SESSION_TIMEOUT
   # Oauth redirect uri, configure this if your app is not running at root under the host
   oauthRedirectUri: OAUTH_REDIRECT_URI
+  # SameSite Cookie Option
+  sameSite: COOKIE_SAME_SITE
 
 httpd:
   # Port to listen on

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -34,6 +34,8 @@ auth:
   admins: []
   # Default session timeout (in minutes)
   sessionTimeout: 120
+  # SameSite Cookie Option
+  sameSite: false
 
 httpd:
   # Port to listen on

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -35,7 +35,7 @@ auth:
   # Default session timeout (in minutes)
   sessionTimeout: 120
   # SameSite Cookie Option
-  sameSite: false
+  sameSite: Strict
 
 httpd:
   # Port to listen on

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "good-squeeze": "^5.1.0",
     "hapi": "^16.6.3",
     "hapi-auth-bearer-token": "^4.3.0",
-    "hapi-auth-cookie": "^6.1.1",
+    "hapi-auth-cookie": "^7.0.0",
     "hapi-auth-jwt2": "^7.3.0",
     "hapi-swagger": "^7.0.0",
     "hoek": "^5.0.4",

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -17,6 +17,7 @@ const uuid = require('uuid/v4');
 
 const DEFAULT_TIMEOUT = 2 * 60; // 2h in minutes
 const ALGORITHM = 'RS256';
+const JOI_BOOLEAN = joi.boolean().truthy('true').falsy('false');
 
 /**
  * Auth API Plugin
@@ -31,23 +32,25 @@ const ALGORITHM = 'RS256';
  * @param  {String}   options.jwtPrivateKey          Secret for signing JWTs
  * @param  {String}  [options.jwtEnvironment]        Environment for the JWTs. Example: 'prod' or 'beta'
  * @param  {Object}   options.scm                    SCM class to setup Authentication
+ * @param  {Object}   options.sameSite               Cookie option for SameSite setting
  * @param  {Function} next                           Function to call when done
  */
 exports.register = (server, options, next) => {
     const pluginOptions = joi.attempt(options, joi.object().keys({
         jwtEnvironment: joi.string().default(''),
-        https: joi.boolean().truthy('true').falsy('false').required(),
+        https: JOI_BOOLEAN.required(),
         cookiePassword: joi.string().min(32).required(),
         encryptionPassword: joi.string().min(32).required(),
         hashingPassword: joi.string().min(32).required(),
-        allowGuestAccess: joi.boolean().truthy('true').falsy('false').default(false),
+        allowGuestAccess: JOI_BOOLEAN.default(false),
         jwtPrivateKey: joi.string().required(),
         jwtPublicKey: joi.string().required(),
         whitelist: joi.array().default([]),
         admins: joi.array().default([]),
         scm: joi.object().required(),
         sessionTimeout: joi.number().integer().positive().default(120),
-        oauthRedirectUri: joi.string().optional()
+        oauthRedirectUri: joi.string().optional(),
+        sameSite: joi.alternatives().try(JOI_BOOLEAN, joi.string()).required()
     }), 'Invalid config for plugin-auth');
 
     /**
@@ -131,8 +134,10 @@ exports.register = (server, options, next) => {
                 cookie: 'sid',
                 ttl: pluginOptions.sessionTimeout * 60 * 1000,
                 password: pluginOptions.cookiePassword,
-                isSecure: pluginOptions.https
+                isSecure: pluginOptions.https,
+                isSameSite: pluginOptions.sameSite
             });
+
             server.auth.strategy('token', 'jwt', {
                 key: pluginOptions.jwtPublicKey,
                 verifyOptions: {
@@ -144,6 +149,7 @@ exports.register = (server, options, next) => {
                     cb(null, true);
                 }
             });
+
             server.auth.strategy('auth_token', 'bearer-access-token', {
                 accessTokenName: 'api_token',
                 allowCookieToken: false,

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -70,6 +70,8 @@ describe('server case', () => {
         });
 
         it('populates access-control-allow-origin correctly', (done) => {
+            Assert.notOk(error);
+
             server.route({
                 method: 'GET',
                 path: '/v1/status',

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -114,7 +114,8 @@ describe('auth plugin test', () => {
                 jwtPublicKey,
                 allowGuestAccess: true,
                 https: false,
-                oauthRedirectUri
+                oauthRedirectUri,
+                sameSite: false
             }
         }, done);
     });
@@ -151,7 +152,8 @@ describe('auth plugin test', () => {
                     scm,
                     jwtPrivateKey,
                     jwtPublicKey,
-                    https: false
+                    https: false,
+                    sameSite: false
                 }
             })
                 .then(() => Promise.reject(new Error('should not be here')))
@@ -203,7 +205,9 @@ describe('auth plugin test', () => {
                     jwtPrivateKey,
                     jwtPublicKey,
                     https: false,
-                    admins: ['github:batman', 'batman']
+                    admins: ['github:batman', 'batman'],
+                    sameSite: false
+
                 }
             }, next);
         });
@@ -226,7 +230,8 @@ describe('auth plugin test', () => {
                     jwtPrivateKey,
                     jwtPublicKey,
                     jwtEnvironment: 'beta',
-                    https: false
+                    https: false,
+                    sameSite: false
                 }
             }).then(() => {
                 const profile = newServer.plugins.auth
@@ -367,7 +372,8 @@ describe('auth plugin test', () => {
                         jwtPrivateKey,
                         jwtPublicKey,
                         https: false,
-                        allowGuestAccess: false
+                        allowGuestAccess: false,
+                        sameSite: false
                     }
                 });
             });
@@ -530,7 +536,8 @@ describe('auth plugin test', () => {
                             jwtPrivateKey,
                             jwtPublicKey,
                             https: false,
-                            whitelist: ['github:batman']
+                            whitelist: ['github:batman'],
+                            sameSite: false
                         }
                     });
                 });
@@ -783,7 +790,8 @@ describe('auth plugin test', () => {
                         jwtPrivateKey,
                         jwtPublicKey,
                         https: false,
-                        admins: ['batman']
+                        admins: ['batman'],
+                        sameSite: false
                     }
                 }, next);
             });
@@ -1010,7 +1018,8 @@ describe('auth plugin test', () => {
                     scm,
                     jwtPrivateKey,
                     jwtPublicKey,
-                    https: false
+                    https: false,
+                    sameSite: false
                 }
             }).then(() => (
                 server.inject({


### PR DESCRIPTION
## Context

`SameSite` cookie config provides strict CSRF protection, but it breaks CORS interaction for our internal usecases. Hence providing an option for cluster admins to set this value.

## Objective
1. Upgrade `hapi-auth-cookie` to v7  which supports `isSameSite` setting.
2. Provide a config to set this value.


## References

1. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives See `SameSite` section
