### PR TITLE
fix(1319): Fix build clusters endpoints

### DIFF
--- a/plugins/buildClusters/get.js
+++ b/plugins/buildClusters/get.js
@@ -23,20 +23,24 @@ module.exports = () => ({
             }
         },
         handler: (request, reply) => {
+            const name = request.params.name;
             const factory = request.server.app.buildClusterFactory;
             const config = {
                 params: {
-                    name: request.params.name
+                    name
                 }
             };
 
             return factory.list(config)
                 .then((model) => {
-                    if (!model) {
-                        return reply(boom.notFound('Build cluster does not exist'));
+                    if (!Array.isArray(model)) {
+                        return reply(boom.badData('Build cluster list returned non-array.'));
+                    }
+                    if (model.length === 0) {
+                        return reply(boom.notFound(`Build cluster ${name} does not exist`));
                     }
 
-                    return reply(model.toJson());
+                    return reply(model[0].toJson());
                 })
                 .catch(err => reply(boom.boomify(err)));
         },

--- a/plugins/buildClusters/get.js
+++ b/plugins/buildClusters/get.js
@@ -32,15 +32,12 @@ module.exports = () => ({
             };
 
             return factory.list(config)
-                .then((model) => {
-                    if (!Array.isArray(model)) {
-                        return reply(boom.badData('Build cluster list returned non-array.'));
-                    }
-                    if (model.length === 0) {
+                .then((buildClusters) => {
+                    if (buildClusters.length === 0) {
                         return reply(boom.notFound(`Build cluster ${name} does not exist`));
                     }
 
-                    return reply(model[0].toJson());
+                    return reply(buildClusters[0].toJson());
                 })
                 .catch(err => reply(boom.boomify(err)));
         },

--- a/plugins/buildClusters/remove.js
+++ b/plugins/buildClusters/remove.js
@@ -34,11 +34,8 @@ module.exports = () => ({
                     }
                 }),
                 userFactory.get({ username, scmContext })
-            ]).then(([buildCluster, user]) => {
-                if (!Array.isArray(buildCluster)) {
-                    return reply(boom.badData('Build cluster list returned non-array.'));
-                }
-                if (buildCluster.length === 0) {
+            ]).then(([buildClusters, user]) => {
+                if (buildClusters.length === 0) {
                     return reply(boom.notFound(`Build cluster ${name} does not exist`));
                 }
                 if (!user) {
@@ -55,7 +52,7 @@ module.exports = () => ({
                     ));
                 }
 
-                return buildCluster[0].remove()
+                return buildClusters[0].remove()
                     .then(() => reply().code(204));
             })
                 .catch(err => reply(boom.boomify(err)));

--- a/plugins/buildClusters/remove.js
+++ b/plugins/buildClusters/remove.js
@@ -35,7 +35,10 @@ module.exports = () => ({
                 }),
                 userFactory.get({ username, scmContext })
             ]).then(([buildCluster, user]) => {
-                if (!buildCluster) {
+                if (!Array.isArray(buildCluster)) {
+                    return reply(boom.badData('Build cluster list returned non-array.'));
+                }
+                if (buildCluster.length === 0) {
                     return reply(boom.notFound(`Build cluster ${name} does not exist`));
                 }
                 if (!user) {
@@ -52,7 +55,7 @@ module.exports = () => ({
                     ));
                 }
 
-                return buildCluster.remove()
+                return buildCluster[0].remove()
                     .then(() => reply().code(204));
             })
                 .catch(err => reply(boom.boomify(err)));

--- a/plugins/buildClusters/update.js
+++ b/plugins/buildClusters/update.js
@@ -48,17 +48,14 @@ module.exports = () => ({
                         name
                     }
                 })
-                    .then((buildCluster) => {
-                        if (!Array.isArray(buildCluster)) {
-                            throw boom.badData('Build cluster list returned non-array.');
-                        }
-                        if (buildCluster.length === 0) {
+                    .then((buildClusters) => {
+                        if (buildClusters.length === 0) {
                             throw boom.notFound(`Build cluster ${name} does not exist`);
                         }
 
-                        Object.assign(buildCluster[0], request.payload);
+                        Object.assign(buildClusters[0], request.payload);
 
-                        return buildCluster[0].update()
+                        return buildClusters[0].update()
                             .then(updatedBuildCluster =>
                                 reply(updatedBuildCluster.toJson()).code(200)
                             );

--- a/plugins/buildClusters/update.js
+++ b/plugins/buildClusters/update.js
@@ -49,13 +49,16 @@ module.exports = () => ({
                     }
                 })
                     .then((buildCluster) => {
-                        if (!buildCluster) {
+                        if (!Array.isArray(buildCluster)) {
+                            throw boom.badData('Build cluster list returned non-array.');
+                        }
+                        if (buildCluster.length === 0) {
                             throw boom.notFound(`Build cluster ${name} does not exist`);
                         }
 
-                        Object.assign(buildCluster, request.payload);
+                        Object.assign(buildCluster[0], request.payload);
 
-                        return buildCluster.update()
+                        return buildCluster[0].update()
                             .then(updatedBuildCluster =>
                                 reply(updatedBuildCluster.toJson()).code(200)
                             );
@@ -78,12 +81,16 @@ module.exports = () => ({
                             name
                         }
                     })])
-                    .then(([token, buildCluster]) => {
-                        if (!buildCluster) {
+                    .then(([token, buildClusters]) => {
+                        if (!Array.isArray(buildClusters)) {
+                            throw boom.badData('Build cluster list returned non-array.');
+                        }
+                        if (buildClusters.length === 0) {
                             throw boom.notFound(`Build cluster ${name} does not exist`);
                         }
 
                         // To update scmOrganizations, user need to have admin permissions on both old and new organizations
+                        const buildCluster = buildClusters[0];
                         const orgs = buildCluster.scmOrganizations;
                         const newOrgs = scmOrganizations || [];
                         const combined = [...new Set([...orgs, ...newOrgs])];
@@ -109,8 +116,7 @@ module.exports = () => ({
 
                             return buildCluster.update()
                                 .then(updatedBuildCluster =>
-                                    reply(updatedBuildCluster.toJson()).code(200)
-                                );
+                                    reply(updatedBuildCluster.toJson()).code(200));
                         });
                     }))
                 .catch(err => reply(boom.boomify(err)));

--- a/test/plugins/buildClusters.test.js
+++ b/test/plugins/buildClusters.test.js
@@ -185,15 +185,6 @@ describe('buildCluster plugin test', () => {
             });
         });
 
-        it('returns 422 when build cluster returns something other than an array', () => {
-            buildClusterFactoryMock.list.withArgs({ params: { name } })
-                .resolves({});
-
-            return server.inject(`/buildclusters/${name}`).then((reply) => {
-                assert.equal(reply.statusCode, 422);
-            });
-        });
-
         it('returns 404 when build cluster does not exist', () => {
             buildClusterFactoryMock.list.withArgs({ params: { name } }).resolves([]);
 
@@ -479,15 +470,6 @@ describe('buildCluster plugin test', () => {
             });
         });
 
-        it('returns 422 when build cluster returns non-array for internal cluster', () => {
-            options.payload.managedByScrewdriver = true;
-            buildClusterFactoryMock.list.resolves({});
-
-            return server.inject(options).then((reply) => {
-                assert.equal(reply.statusCode, 422);
-            });
-        });
-
         it('returns 422 when build cluster returns non-array for external cluster', () => {
             buildClusterFactoryMock.scm.getOrgPermissions.resolves({
                 admin: false,
@@ -572,14 +554,6 @@ describe('buildCluster plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 404);
-            });
-        });
-
-        it('returns 422 when build cluster returns something other than an array', () => {
-            buildClusterFactoryMock.list.resolves({});
-
-            return server.inject(options).then((reply) => {
-                assert.equal(reply.statusCode, 422);
             });
         });
 

--- a/test/plugins/buildClusters.test.js
+++ b/test/plugins/buildClusters.test.js
@@ -15,7 +15,7 @@ sinon.assert.expose(assert, { prefix: '' });
 const decorateBuildClusterObject = (buildCluster) => {
     const decorated = hoek.clone(buildCluster);
 
-    decorated.update = sinon.stub().resolves(buildCluster);
+    decorated.update = sinon.stub().resolves(updatedBuildCluster);
     decorated.remove = sinon.stub().resolves({});
     decorated.toJson = sinon.stub().returns(buildCluster);
 
@@ -176,9 +176,8 @@ describe('buildCluster plugin test', () => {
 
     describe('GET /buildclusters/{name}', () => {
         it('returns 200 for a build cluster that exists', () => {
-            const buildClusterMock = getMockBuildClusters(testBuildCluster);
-
-            buildClusterFactoryMock.list.withArgs({ params: { name } }).resolves(buildClusterMock);
+            buildClusterFactoryMock.list.withArgs({ params: { name } })
+                .resolves(getMockBuildClusters(testBuildClusters));
 
             return server.inject(`/buildclusters/${name}`).then((reply) => {
                 assert.equal(reply.statusCode, 200);
@@ -186,8 +185,17 @@ describe('buildCluster plugin test', () => {
             });
         });
 
-        it('returns 404 when build does not exist', () => {
-            buildClusterFactoryMock.list.withArgs({ params: { name } }).resolves(null);
+        it('returns 422 when build cluster returns something other than an array', () => {
+            buildClusterFactoryMock.list.withArgs({ params: { name } })
+                .resolves({});
+
+            return server.inject(`/buildclusters/${name}`).then((reply) => {
+                assert.equal(reply.statusCode, 422);
+            });
+        });
+
+        it('returns 404 when build cluster does not exist', () => {
+            buildClusterFactoryMock.list.withArgs({ params: { name } }).resolves([]);
 
             return server.inject(`/buildclusters/${name}`).then((reply) => {
                 assert.equal(reply.statusCode, 404);
@@ -385,11 +393,11 @@ describe('buildCluster plugin test', () => {
     describe('PUT /buildclusters/{name}', () => {
         let options;
         let updatedBuildClusterMock;
-        let buildClusterMock;
+        let buildClustersMock;
         let userMock;
 
         beforeEach(() => {
-            buildClusterMock = getMockBuildClusters(testBuildCluster);
+            buildClustersMock = getMockBuildClusters(testBuildClusters);
             options = {
                 method: 'PUT',
                 url: `/buildclusters/${name}`,
@@ -405,8 +413,8 @@ describe('buildCluster plugin test', () => {
             };
 
             updatedBuildClusterMock = getMockBuildClusters(updatedBuildCluster);
-            buildClusterFactoryMock.list.resolves(buildClusterMock);
-            buildClusterMock.update.resolves(updatedBuildClusterMock);
+            buildClusterFactoryMock.list.resolves(buildClustersMock);
+            buildClustersMock[0].update.resolves(updatedBuildClusterMock);
             updatedBuildClusterMock.toJson.returns(updatedBuildCluster);
             buildClusterFactoryMock.scm.getOrgPermissions.resolves({
                 admin: true,
@@ -418,7 +426,7 @@ describe('buildCluster plugin test', () => {
         it('returns 200 and correct build cluster data', () =>
             server.inject(options).then((reply) => {
                 assert.deepEqual(reply.result, updatedBuildCluster);
-                assert.calledOnce(buildClusterMock.update);
+                assert.calledOnce(buildClustersMock[0].update);
                 assert.equal(reply.statusCode, 200);
             })
         );
@@ -428,14 +436,14 @@ describe('buildCluster plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.deepEqual(reply.result, updatedBuildCluster);
-                assert.calledOnce(buildClusterMock.update);
+                assert.calledOnce(buildClustersMock[0].update);
                 assert.equal(reply.statusCode, 200);
             });
         });
 
         it('returns 404 when the build cluster name is not found for internal cluster', () => {
             options.payload.managedByScrewdriver = true;
-            buildClusterFactoryMock.list.resolves(null);
+            buildClusterFactoryMock.list.resolves([]);
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 404);
@@ -443,7 +451,7 @@ describe('buildCluster plugin test', () => {
         });
 
         it('returns 404 when the build cluster name is not found', () => {
-            buildClusterFactoryMock.list.resolves(null);
+            buildClusterFactoryMock.list.resolves([]);
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 404);
@@ -471,6 +479,27 @@ describe('buildCluster plugin test', () => {
             });
         });
 
+        it('returns 422 when build cluster returns non-array for internal cluster', () => {
+            options.payload.managedByScrewdriver = true;
+            buildClusterFactoryMock.list.resolves({});
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 422);
+            });
+        });
+
+        it('returns 422 when build cluster returns non-array for external cluster', () => {
+            buildClusterFactoryMock.scm.getOrgPermissions.resolves({
+                admin: false,
+                member: true
+            });
+            buildClusterFactoryMock.list.resolves({});
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 422);
+            });
+        });
+
         it('returns 422 when the no scm orgs provided for an external cluster', () => {
             options.payload.scmOrganizations = [];
 
@@ -493,7 +522,7 @@ describe('buildCluster plugin test', () => {
         it('returns 500 when the build cluster model fails to update', () => {
             const testError = new Error('collectionModelUpdateError');
 
-            buildClusterMock.update.rejects(testError);
+            buildClustersMock[0].update.rejects(testError);
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 500);
@@ -503,11 +532,11 @@ describe('buildCluster plugin test', () => {
 
     describe('DELETE /buildclusters/{name}', () => {
         let options;
-        let buildClusterMock;
+        let buildClustersMock;
         let userMock;
 
         beforeEach(() => {
-            buildClusterMock = getMockBuildClusters(testBuildCluster);
+            buildClustersMock = getMockBuildClusters(testBuildClusters);
 
             options = {
                 method: 'DELETE',
@@ -519,14 +548,14 @@ describe('buildCluster plugin test', () => {
                 unsealToken: sinon.stub()
             };
             userFactoryMock.get.resolves(userMock);
-            buildClusterFactoryMock.list.resolves(buildClusterMock);
-            buildClusterMock.remove.resolves({});
+            buildClusterFactoryMock.list.resolves(buildClustersMock);
+            buildClustersMock[0].remove.resolves({});
         });
 
         it('returns 204 when delete is successful', () =>
             server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 204);
-                assert.calledOnce(buildClusterMock.remove);
+                assert.calledOnce(buildClustersMock[0].remove);
             })
         );
 
@@ -539,10 +568,18 @@ describe('buildCluster plugin test', () => {
         });
 
         it('returns 404 when build cluster does not exist', () => {
-            buildClusterFactoryMock.list.resolves(null);
+            buildClusterFactoryMock.list.resolves([]);
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 422 when build cluster returns something other than an array', () => {
+            buildClusterFactoryMock.list.resolves({});
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 422);
             });
         });
 
@@ -555,7 +592,7 @@ describe('buildCluster plugin test', () => {
         });
 
         it('returns 500 when call returns error', () => {
-            buildClusterMock.remove.rejects(new Error('collectionRemoveError'));
+            buildClustersMock[0].remove.rejects(new Error('collectionRemoveError'));
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 500);

--- a/test/plugins/data/updatedBuildCluster.json
+++ b/test/plugins/data/updatedBuildCluster.json
@@ -1,6 +1,11 @@
 {
-    "id": 12,
+    "id": 12345,
     "name": "iOS",
+    "scmOrganizations": ["screwdriver-cd"],
+    "scmContext": "github:github.com",
+    "managedByScrewdriver": false,
+    "maintainer": "foo@bar.com",
+    "isActive": false,
     "description": "updated description",
-    "isActive": false
+    "weightage": 100
 }


### PR DESCRIPTION
## Context

Since we're calling a list() instead of a get(), it returns and array instead of a since build cluster.

## Objective

This PR accounts for that array.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1319