### PR TITLE
fix: register auth before isadmin

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -20,8 +20,7 @@ function registerDefaultPlugins(server, callback) {
         '../plugins/swagger',
         '../plugins/validator',
         '../plugins/template-validator',
-        '../plugins/command-validator',
-        '../plugins/isAdmin'
+        '../plugins/command-validator'
     ].map(plugin => require(plugin));
 
     async.eachSeries(plugins, (plugin, next) => {
@@ -55,7 +54,8 @@ function registerResourcePlugins(server, config, callback) {
         'tokens',
         'secrets',
         'webhooks',
-        'stats'
+        'stats',
+        'isAdmin'
     ];
 
     if (hoek.reach(config, 'coverage.coveragePlugin')) {

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -16,8 +16,7 @@ describe('Register Unit Test Case', () => {
         '../plugins/swagger',
         '../plugins/validator',
         '../plugins/template-validator',
-        '../plugins/command-validator',
-        '../plugins/isAdmin'
+        '../plugins/command-validator'
     ];
     const resourcePlugins = [
         '../plugins/auth',
@@ -33,7 +32,8 @@ describe('Register Unit Test Case', () => {
         '../plugins/templates',
         '../plugins/tokens',
         '../plugins/webhooks',
-        '../plugins/stats'
+        '../plugins/stats',
+        '../plugins/isAdmin'
     ];
     const pluginLength = expectedPlugins.length + resourcePlugins.length;
     const mocks = {};


### PR DESCRIPTION
Getting `Unknown authentication strategy token in /v4/isAdmin`
Let's try to register this after `auth`