### PR TITLE
fix: Use toolbox script for deploying

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -41,7 +41,7 @@ jobs:
     beta:
         requires: [publish]
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
             - test: npm install && npm run functional
@@ -64,12 +64,11 @@ jobs:
             # Talking to Kubernetes
             - K8S_TOKEN
 
-
     # Deploy to our prod environment and run tests
     prod:
         requires: [beta]
         steps:
-            - setup-ci: git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
             - test: npm install && npm run functional


### PR DESCRIPTION
## Context

The beta deploy job keeps failing even though the deployment is successful. This is because the script we are using is grepping for `200 OK` in the response, which is compatible when using HTTP/1.1. However, HTTP/2 only returns `HTTP/2 200`, which fails the script.

## Objective

This PR switches to using the toolbox script for deploying, which solves this issue already.


## References
- Toolbox: https://github.com/screwdriver-cd/toolbox/blob/master/k8s-deploy.sh#L30
- Original script: https://gist.github.com/stjohnjohnson/3d2388b2a7ba658cdcdaffa8cd874e50#file-k8s-deploy-sh-L30
