### PR TITLE
fix: switch k8s api endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -49,7 +49,7 @@ jobs:
             DOCKER_REPO: screwdrivercd/screwdriver
             K8S_CONTAINER: screwdriver-api
             K8S_IMAGE: screwdrivercd/screwdriver
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: sdapi-beta
             SD_API_HOST: beta.api.screwdriver.cd
             K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
@@ -76,7 +76,7 @@ jobs:
             DOCKER_REPO: screwdrivercd/screwdriver
             K8S_CONTAINER: screwdriver-api
             K8S_IMAGE: screwdrivercd/screwdriver
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: sdapi
             SD_API_HOST: api.screwdriver.cd
             K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX


### PR DESCRIPTION
## Context

Our K8S_DEPLOY step is currently failing.
Previously we point `api.k8s.screwdriver.cd`  to the ips for `api.ossd.k8s.screwdriver.cd` in AWS route53. That means whenever we update the cluster, manual change is needed. Switch to the correct endpoint.

## Objective

This PR updates to the correct host.

## References

Related to https://github.com/screwdriver-cd/guide/pull/256