### PR TITLE
fix: includes prParentJobId in token

### DIFF
--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -40,19 +40,24 @@ module.exports = () => ({
                 if (build.status !== 'QUEUED' && build.status !== 'BLOCKED') {
                     throw boom.forbidden('Build is already running or finished.');
                 }
+                const jwtInfo = {
+                    isPR: profile.isPR,
+                    jobId: profile.jobId,
+                    eventId: profile.eventId,
+                    pipelineId: profile.pipelineId,
+                    configPipelineId: profile.configPipelineId
+                };
+
+                if (profile.prParentJobId) {
+                    jwtInfo.prParentJobId = profile.prParentJobId;
+                }
 
                 const token = request.server.plugins.auth.generateToken(
                     request.server.plugins.auth.generateProfile(
                         profile.username,
                         profile.scmContext,
                         ['build'],
-                        {
-                            isPR: profile.isPR,
-                            jobId: profile.jobId,
-                            eventId: profile.eventId,
-                            pipelineId: profile.pipelineId,
-                            configPipelineId: profile.configPipelineId
-                        }
+                        jwtInfo
                     ), parseInt(buildTimeout, 10)
                 );
 

--- a/test/plugins/banner.test.js
+++ b/test/plugins/banner.test.js
@@ -141,21 +141,47 @@ describe('banner plugin test', () => {
             bannerFactoryMock.get.resolves(null);
         });
 
-        it('returns 201 and creates a banner', () => {
+        it('returns 201 and creates a banner', () =>
             server.inject(options).then((reply) => {
-                const expected = Object.assign({}, testBanner);
+                const expected = Object.assign({}, options.payload);
 
-                delete expected.id;
-                delete expected.createTime;
+                expected.createdBy = options.credentials.username;
                 assert.calledWith(bannerFactoryMock.create, expected);
                 assert.equal(reply.statusCode, 201);
-                assert.equal(reply.result, testBanner);
+                assert.deepEqual(reply.result, testBanner);
+            })
+        );
+
+        it('returns 201 and creates a banner using default type', () => {
+            delete options.payload.type;
+
+            return server.inject(options).then((reply) => {
+                const expected = Object.assign({}, options.payload);
+
+                expected.createdBy = options.credentials.username;
+                assert.calledWith(bannerFactoryMock.create, expected);
+                assert.equal(reply.statusCode, 201);
+                assert.deepEqual(reply.result, testBanner);
+            });
+        });
+
+        it('returns 201 and creates a banner using default isActive', () => {
+            delete options.payload.isActive;
+
+            return server.inject(options).then((reply) => {
+                const expected = Object.assign({}, options.payload);
+
+                expected.createdBy = options.credentials.username;
+                assert.calledWith(bannerFactoryMock.create, expected);
+                assert.equal(reply.statusCode, 201);
+                assert.deepEqual(reply.result, testBanner);
             });
         });
 
         it('returns 403 for non-admin user', () => {
             options.credentials.username = 'batman123';
-            server.inject(options).then((reply) => {
+
+            return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 403);
             });
         });
@@ -165,7 +191,7 @@ describe('banner plugin test', () => {
 
             bannerFactoryMock.create.rejects(testError);
 
-            server.inject(options).then((reply) => {
+            return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 500);
             });
         });
@@ -289,7 +315,7 @@ describe('banner plugin test', () => {
         it('returns 403 updating banner by non-admin user', () => {
             options.credentials.username = 'batman123';
 
-            server.inject(options).then((reply) => {
+            return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 403);
             });
         });
@@ -324,7 +350,7 @@ describe('banner plugin test', () => {
         it('returns 403 deleting banner by non-admin user', () => {
             options.credentials.username = 'batman123';
 
-            server.inject(options).then((reply) => {
+            return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 403);
             });
         });


### PR DESCRIPTION
Need to include `prParentJobId` in the jwt so we can do permission check inside store. 

Blocked by: https://github.com/screwdriver-cd/models/pull/304
Related: https://github.com/screwdriver-cd/screwdriver/issues/1382