### PR TITLE
fix: re-enable sd-step functest

### DIFF
--- a/features/sd-step.feature
+++ b/features/sd-step.feature
@@ -18,7 +18,6 @@ Feature: Shared Steps
     - Method to update global SDK state.
     - Method to refer to installed packages via semver.
 
-    @ignore
     Scenario Outline: Use package via sd-step
         Given an existing pipeline with <image> image and <package> package
         When the main job is started


### PR DESCRIPTION
## Context
sd-step feature is ignored in the [previous PR](https://github.com/screwdriver-cd/screwdriver/pull/1404)  since the options `pkg-version` doesn't works well.
And the problem is fixed by [this PR](https://github.com/screwdriver-cd/sd-step/pull/17) in launcher@v5.0.46.

## Objective
This PR re-enables sd-step feature.

## References
https://github.com/screwdriver-cd/sd-step/pull/17
https://github.com/screwdriver-cd/screwdriver/pull/1404