### PR TITLE
fix: Fix miscalculation of options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Three (3) options for executor:
  - Docker (`docker`)
  - Nomad (`nomad`)
 
-Three (3) options for SCM:
+Two (2) options for SCM:
  - Github (`github`)
  - Bitbucket (`bitbucket`)
 


### PR DESCRIPTION
## Context

There were two entries in the list but shows three in the description.

## Objective

Fix text.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
