### PR TITLE
fix: Try pinning scm-github package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "screwdriver-models": "^27.15.8",
     "screwdriver-notifications-email": "^1.1.9",
     "screwdriver-notifications-slack": "^2.1.8",
-    "screwdriver-scm-github": "^8.1.3",
+    "screwdriver-scm-github": "8.1.5",
     "screwdriver-scm-gitlab": "^1.1.0",
     "screwdriver-scm-router": "^3.2.0",
     "screwdriver-template-validator": "^3.0.5",


### PR DESCRIPTION
In case the issue is this bug: https://github.com/screwdriver-cd/scm-github/pull/112/files

