### PR TITLE
fix: Fix badge statuses

### DIFF
--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -52,6 +52,41 @@ function getUrl(badgeService, buildsStatus = []) {
     });
 }
 
+/**
+ * DFS the workflowGraph from the start point
+ * @method dfs
+ * @param  {Object} workflowGraph   workflowGraph
+ * @param  {String} start           Start job name
+ * @param  {String} prNum           PR number in case of PR trigger
+ * @return {Set}                    A set of build ids that are visited
+ */
+function dfs(workflowGraph, start, prNum) {
+    let nextJobsConfig;
+
+    if (start === '~pr') {
+        nextJobsConfig = {
+            trigger: start,
+            prNum
+        };
+    } else {
+        nextJobsConfig = {
+            trigger: start
+        };
+    }
+
+    const nextJobs = workflowParser.getNextJobs(workflowGraph, nextJobsConfig);
+
+    let visited = new Set(nextJobs);
+
+    nextJobs.forEach((job) => {
+        const subJobs = dfs(workflowGraph, job);
+
+        visited = new Set([...visited, ...subJobs]);
+    });
+
+    return visited;
+}
+
 module.exports = () => ({
     method: 'GET',
     path: '/pipelines/{id}/badge',
@@ -87,13 +122,12 @@ module.exports = () => ({
                             let workflowLength = 0;
 
                             if (lastEvent.workflowGraph) {
-                                const nextJobs = workflowParser.getNextJobs(
-                                    lastEvent.workflowGraph, {
-                                        trigger: lastEvent.startFrom
-                                    }
-                                );
+                                const nextJobs = dfs(lastEvent.workflowGraph,
+                                    lastEvent.startFrom,
+                                    lastEvent.prNum,
+                                    builds);
 
-                                workflowLength = nextJobs.length;
+                                workflowLength = nextJobs.size;
                             }
 
                             for (let i = builds.length; i < workflowLength; i += 1) {

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -2,6 +2,7 @@
 
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const workflowParser = require('screwdriver-workflow-parser');
 const tinytim = require('tinytim');
 const idSchema = joi.reach(schema.models.pipeline.base, 'id');
 
@@ -86,8 +87,13 @@ module.exports = () => ({
                             let workflowLength = 0;
 
                             if (lastEvent.workflowGraph) {
-                                workflowLength = lastEvent.workflowGraph.nodes.filter(n =>
-                                    n.name !== '~commit' && n.name !== '~pr').length;
+                                const nextJobs = workflowParser.getNextJobs(
+                                    lastEvent.workflowGraph, {
+                                        trigger: lastEvent.startFrom
+                                    }
+                                );
+
+                                workflowLength = nextJobs.length;
                             }
 
                             for (let i = builds.length; i < workflowLength; i += 1) {

--- a/test/plugins/data/events.json
+++ b/test/plugins/data/events.json
@@ -2,6 +2,7 @@
     "id": 12345,
     "type": "pipeline",
     "pipelineId": 1234,
+    "startFrom": "~commit",
     "sha": "ccc49349d3cffbd12ea9e3d41521480b4aa5de5f",
     "createTime": "2038-01-19T03:14:08.131Z",
     "commit": {

--- a/test/plugins/data/eventsPr.json
+++ b/test/plugins/data/eventsPr.json
@@ -1,0 +1,41 @@
+[{
+    "id": 12345,
+    "type": "pipeline",
+    "pipelineId": 1234,
+    "startFrom": "~pr",
+    "prNum": 1,
+    "sha": "ccc49349d3cffbd12ea9e3d41521480b4aa5de5f",
+    "createTime": "2038-01-19T03:14:08.131Z",
+    "commit": {
+        "url": "https://link.to/commitDiff",
+        "message": "some commit message that is here",
+        "author": {
+            "avatar": "https://avatars.githubusercontent.com/u/1234567?v=3",
+            "name": "Batman",
+            "url": "https://internal-ghe.mycompany.com/imbatman",
+            "username": "imbatman"
+        }
+    },
+    "workflowGraph": {
+        "nodes": [
+            { "name": "~pr" },
+            { "name": "pullrequest" },
+            { "name": "pullrequest2" },
+            { "name": "~commit" },
+            { "name": "main" },
+            { "name": "publish" },
+            { "name": "beta" }
+        ],
+        "edges": [
+            { "src": "~pr", "dest": "pullrequest" },
+            { "src": "~pr", "dest": "pullrequest2" }
+        ]
+    },
+    "causeMessage": "Merge pull request #26 from screwdriver-cd/models",
+    "creator": {
+        "avatar": "https://avatars.githubusercontent.com/u/2042?v=3",
+        "name": "St John",
+        "url": "https://github.com/stjohn",
+        "username": "stjohn"
+    }
+}]

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -693,7 +693,7 @@ describe('pipeline plugin test', () => {
         it('returns 302 to for a valid build', () =>
             server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, '1 success, 1 unknown, 1 failure/red');
+                assert.deepEqual(reply.headers.location, '1 success, 1 failure/red');
             })
         );
 


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/screwdriver/issues/1429

Badge generation is borked because it shows statuses for all workflow edges in the graph instead of just the one that was triggered.

## Objective

PR computes statuses for workflow edges only in the current workflow, not for all nodes in the graph. For instance, if the current workflow is triggered by a commit, instead of computing statuses for all workflows (pr, commit etc), compute only for commit edges.

## References

Issue: https://github.com/screwdriver-cd/screwdriver/issues/1429
