### PR TITLE
feat(1010): enabling prChain 2nd step

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -275,7 +275,8 @@ exports.register = (server, options, next) => {
 
         return eventFactory.get({ id: build.eventId }).then((event) => {
             const workflowGraph = event.workflowGraph;
-            const nextJobs = workflowParser.getNextJobs(workflowGraph, { trigger: currentJobName });
+            const nextJobs = workflowParser.getNextJobs(workflowGraph,
+                { trigger: currentJobName, prChain: pipeline.prChain });
 
             // Create a join object like: {A:[B,C], D:[B,F]} where [B,C] join on A, [B,F] join on D, etc.
             const joinObj = nextJobs.reduce((obj, jobName) => {

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -80,7 +80,8 @@ function stopJob({ job, prNum, action }) {
  */
 function hasTriggeredJob(pipeline, startFrom) {
     const nextJobs = workflowParser.getNextJobs(pipeline.workflowGraph, {
-        trigger: startFrom
+        trigger: startFrom,
+        prChain: pipeline.prChain
     });
 
     return nextJobs.length > 0;


### PR DESCRIPTION
## Context
This PR is the second step of enabling prChain feature.
This time we fixed only a backend（api, models, workflow-graph）. UI will be fixed next time.

## Objective
- If `prChain` flag is true in screwdriver.yaml, run subsequent jobs following workflow graph.
- Create all jobs with `PR-${prNum}:` prefix.

## Other PRs
https://github.com/screwdriver-cd/workflow-parser/pull/16
https://github.com/screwdriver-cd/models/pull/315

## References
- New design of prChain feature
https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-448142968
