### PR TITLE
fix: fix no build event response

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -196,6 +196,9 @@ module.exports = () => ({
                         })
                         .then(() => eventFactory.create(payload));
                 }).then((event) => {
+                    if (event.builds === null) {
+                        return reply(boom.notFound('No jobs to start.'));
+                    }
                     // everything succeeded, inform the user
                     const location = urlLib.format({
                         host: request.headers.host,

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -529,13 +529,12 @@ function pushEvent(pluginOptions, request, reply, parsed) {
             return createEvents(eventFactory, pipelineFactory, pipelines, parsed);
         })
         .then((events) => {
-            const triggeredEvents = events.filter(e => e !== null);
+            const hasBuildEvents = events.filter(e => e.builds !== null);
 
-            if (triggeredEvents.length === 0) {
+            if (hasBuildEvents.length === 0) {
                 return reply().code(204);
             }
-
-            triggeredEvents.forEach((e) => {
+            hasBuildEvents.forEach((e) => {
                 request.log(['webhook', hookId, e.id],
                     `Event ${e.id} started`);
             });

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -529,11 +529,13 @@ function pushEvent(pluginOptions, request, reply, parsed) {
             return createEvents(eventFactory, pipelineFactory, pipelines, parsed);
         })
         .then((events) => {
-            if (events.length === 0) {
+            const triggeredEvents = events.filter(e => e !== null);
+
+            if (triggeredEvents.length === 0) {
                 return reply().code(204);
             }
 
-            events.forEach((e) => {
+            triggeredEvents.forEach((e) => {
                 request.log(['webhook', hookId, e.id],
                     `Event ${e.id} started`);
             });

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -581,5 +581,15 @@ describe('event plugin test', () => {
                 assert.notCalled(eventFactoryMock.create);
             });
         });
+
+        it('returns 201 when it creates an event with parent event for child pipeline', () => {
+            testEvent.builds = null;
+            eventFactoryMock.create.resolves(decorateEventMock(testEvent));
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+                delete testEvent.builds;
+            });
+        });
     });
 });


### PR DESCRIPTION
## Context
Events which doesn't trigger any jobs return error to github webhooks.
It would be better to return 204.

## Objective
* filter null response from createEvents.

## References
* https://github.com/screwdriver-cd/models/pull/316