### PR TITLE
[4] feat: Add pr title to the event

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -134,6 +134,7 @@ function triggeredPipelines(pipelineFactory, scmConfig, branch, type) {
  * @param  {String}       options.sha           Specific SHA1 commit to start the build with
  * @param  {String}       options.prRef         Reference to pull request
  * @param  {String}       options.prNum         Pull request number
+ * @param  {String}       options.prTitle       Pull request title
  * @param  {Array}        options.changedFiles  List of changed files
  * @param  {String}       options.branch        The branch against which pr is opened
  * @param  {String}       options.action        Event action
@@ -141,7 +142,8 @@ function triggeredPipelines(pipelineFactory, scmConfig, branch, type) {
  * @return {Promise}
  */
 async function createPREvents(options, request) {
-    const { username, scmConfig, sha, prRef, prNum, changedFiles, branch, action } = options;
+    const { username, scmConfig, sha, prRef, prNum,
+        prTitle, changedFiles, branch, action } = options;
     const scm = request.server.app.pipelineFactory.scm;
     const eventFactory = request.server.app.eventFactory;
     const pipelineFactory = request.server.app.pipelineFactory;
@@ -179,6 +181,7 @@ async function createPREvents(options, request) {
             eventConfig = Object.assign({
                 prRef,
                 prNum,
+                prTitle,
                 // eslint-disable-next-line no-await-in-loop
                 prInfo: await eventFactory.scm.getPrInfo(scmConfig)
             }, eventConfig);
@@ -362,7 +365,7 @@ function obtainScmToken(pluginOptions, userFactory, username, scmContext) {
 function pullRequestEvent(pluginOptions, request, reply, parsed) {
     const pipelineFactory = request.server.app.pipelineFactory;
     const userFactory = request.server.app.userFactory;
-    const { hookId, action, checkoutUrl, branch, sha, prNum, prRef,
+    const { hookId, action, checkoutUrl, branch, sha, prNum, prTitle, prRef,
         prSource, username, scmContext, changedFiles, type } = parsed;
     const fullCheckoutUrl = `${checkoutUrl}#${branch}`;
     const scmConfig = {
@@ -408,6 +411,7 @@ function pullRequestEvent(pluginOptions, request, reply, parsed) {
                         scmConfig,
                         prRef,
                         prNum,
+                        prTitle,
                         prSource,
                         pipeline,
                         changedFiles,

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -571,6 +571,7 @@ describe('github plugin test', () => {
                 beforeEach(() => {
                     name = 'PR-2';
                     parsed.prNum = 2;
+                    parsed.prTitle = 'Update the README with new information';
                     parsed.action = 'opened';
                     options.payload = testPayloadOpen;
                     scmConfig.prNum = 2;
@@ -602,6 +603,7 @@ describe('github plugin test', () => {
                             configPipelineSha: latestSha,
                             startFrom: '~pr',
                             prNum: 2,
+                            prTitle: 'Update the README with new information',
                             prRef,
                             changedFiles,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`
@@ -715,6 +717,7 @@ describe('github plugin test', () => {
                             startFrom: '~pr',
                             prNum: 2,
                             prRef,
+                            prTitle: 'Update the README with new information',
                             prInfo,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
                             changedFiles
@@ -752,6 +755,7 @@ describe('github plugin test', () => {
                             configPipelineSha: latestSha,
                             startFrom: '~pr',
                             prNum: 2,
+                            prTitle: 'Update the README with new information',
                             prRef,
                             changedFiles,
                             causeMessage: `Reopened by ${scmDisplayName}:${username}`
@@ -807,6 +811,7 @@ describe('github plugin test', () => {
                             configPipelineSha: latestSha,
                             startFrom: '~pr',
                             prNum: 2,
+                            prTitle: 'Update the README with new information',
                             prRef,
                             changedFiles,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`
@@ -843,6 +848,7 @@ describe('github plugin test', () => {
                             configPipelineSha: latestSha,
                             startFrom: '~pr',
                             prNum: 2,
+                            prTitle: 'Update the README with new information',
                             prRef,
                             changedFiles,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`
@@ -891,6 +897,7 @@ describe('github plugin test', () => {
                         'content-length': '21241'
                     };
                     scmConfig.prNum = 1;
+                    parsed.prTitle = 'Update the README with new information';
                     options.payload = testPayloadSync;
                     jobMock.getRunningBuilds.resolves([model1, model2]);
                     eventFactoryMock.scm.getPrInfo.withArgs(scmConfig)
@@ -915,6 +922,7 @@ describe('github plugin test', () => {
                             configPipelineSha: latestSha,
                             startFrom: '~pr',
                             prNum: 1,
+                            prTitle: 'Update the README with new information',
                             prRef,
                             changedFiles,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`
@@ -1028,6 +1036,7 @@ describe('github plugin test', () => {
                             startFrom: '~pr',
                             prNum: 1,
                             prRef,
+                            prTitle: 'Update the README with new information',
                             prInfo,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
                             changedFiles
@@ -1063,6 +1072,7 @@ describe('github plugin test', () => {
                             startFrom: '~pr',
                             prRef,
                             prNum: 1,
+                            prTitle: 'Update the README with new information',
                             type: 'pr',
                             webhooks: true,
                             changedFiles,
@@ -1125,6 +1135,7 @@ describe('github plugin test', () => {
                             startFrom: '~pr',
                             prInfo,
                             prNum: 1,
+                            prTitle: 'Update the README with new information',
                             prRef,
                             changedFiles,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`
@@ -1161,6 +1172,7 @@ describe('github plugin test', () => {
                             configPipelineSha: latestSha,
                             startFrom: '~pr',
                             prNum: 1,
+                            prTitle: 'Update the README with new information',
                             prRef,
                             changedFiles,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
We want to add pr title to the event for using it in notification.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add prTitle to the event when PREvent is created.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
data-schema https://github.com/screwdriver-cd/data-schema/pull/310
models https://github.com/screwdriver-cd/models/pull/321
scm-github https://github.com/screwdriver-cd/scm-github/pull/120