### PR TITLE
fix: Increase retry delay and max number for feature test when waiting for build

### DIFF
--- a/features/support/world.js
+++ b/features/support/world.js
@@ -129,8 +129,8 @@ function CustomWorld({ attach, parameters }) {
         requestretry({
             uri: `${this.instance}/${this.namespace}/builds/${buildID}`,
             method: 'GET',
-            maxAttempts: 20,
-            retryDelay: 10000,
+            maxAttempts: 25,
+            retryDelay: 15000,
             retryStrategy: buildRetryStrategy,
             json: true,
             auth: {


### PR DESCRIPTION
## Context

sd-step test is failing since status is seen as `RUNNING` when should be `SUCCESS`.
The actual total test takes 4 mins total but the `waitForBuild` method only waits for 3 mins.

## Objective

This PR increases the timeout to 6 mins.

## References

Actual sd-step build: https://beta.cd.screwdriver.cd/pipelines/2571/builds/36966
Functional test failure: https://cd.screwdriver.cd/pipelines/1/builds/88817