### PR TITLE
fix: add endpoint for last successful meta of a job

### DIFF
--- a/plugins/jobs/index.js
+++ b/plugins/jobs/index.js
@@ -3,6 +3,7 @@
 const getRoute = require('./get');
 const updateRoute = require('./update');
 const listBuildsRoute = require('./listBuilds');
+const lastSuccessfulMeta = require('./lastSuccessfulMeta');
 
 /**
  * Job API Plugin
@@ -15,7 +16,8 @@ exports.register = (server, options, next) => {
     server.route([
         getRoute(),
         updateRoute(),
-        listBuildsRoute()
+        listBuildsRoute(),
+        lastSuccessfulMeta()
     ]);
 
     next();

--- a/plugins/jobs/lastSuccessfulMeta.js
+++ b/plugins/jobs/lastSuccessfulMeta.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const idSchema = joi.reach(schema.models.job.base, 'id');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/jobs/{id}/lastSuccessfulMeta',
+    config: {
+        description: 'Get the last successful metadata for a given job',
+        notes: 'If no successful builds found in the past 50 builds, will return {}',
+        tags: ['api', 'jobs', 'builds'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'pipeline']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const factory = request.server.app.jobFactory;
+
+            return factory.get(request.params.id)
+                .then((job) => {
+                    if (!job) {
+                        throw boom.notFound('Job does not exist');
+                    }
+
+                    return job.getBuilds({
+                        status: 'SUCCESS'
+                    });
+                })
+                .then((builds) => {
+                    const meta = builds[0] ? builds[0].meta : {};
+
+                    return reply(meta);
+                })
+                .catch(err => reply(boom.boomify(err)));
+        },
+        response: {
+            schema: joi.object()
+        },
+        validate: {
+            params: {
+                id: idSchema
+            }
+        }
+    }
+});

--- a/test/plugins/data/builds.json
+++ b/test/plugins/data/builds.json
@@ -34,7 +34,12 @@
             "endTime": "2038-01-19T03:15:10.130Z"
         }
     ],
-    "status": "SUCCESS"
+    "status": "SUCCESS",
+    "meta": {
+      "coverage": {
+        "test": 100
+      }
+    }
 },{
     "id": 12346,
     "jobId": 1234,

--- a/test/plugins/data/collection.response.json
+++ b/test/plugins/data/collection.response.json
@@ -90,7 +90,12 @@
                         "endTime": "2038-01-19T03:15:10.130Z"
                     }
                 ],
-                "status": "SUCCESS"
+                "status": "SUCCESS",
+                "meta": {
+                  "coverage": {
+                    "test": 100
+                  }
+                }
             }]
         },
         {

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -356,4 +356,46 @@ describe('job plugin test', () => {
             });
         });
     });
+
+    describe('GET /jobs/{id}/lastSuccessfulMeta', () => {
+        const id = 1234;
+        let options;
+        let job;
+        let builds;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: `/jobs/${id}/lastSuccessfulMeta`
+            };
+
+            job = getJobMocks(testJob);
+            builds = getBuildMocks(testBuilds);
+
+            jobFactoryMock.get.withArgs(id).resolves(job);
+            job.getBuilds.resolves(builds);
+        });
+
+        it('returns 404 if job does not exist', () => {
+            jobFactoryMock.get.withArgs(id).resolves(null);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 200 for getting last successful meta', () =>
+            server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.calledWith(job.getBuilds, {
+                    status: 'SUCCESS'
+                });
+                assert.deepEqual(reply.result, {
+                    coverage: {
+                        test: 100
+                    }
+                });
+            })
+        );
+    });
 });


### PR DESCRIPTION
We need this endpoint to get last successful metadata for a given job