### PR TITLE
fix(1474): Only update blocked stats once

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const boom = require('boom');
+const hoek = require('hoek');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const { EXTERNAL_TRIGGER } = schema.config.regex;
@@ -116,9 +117,12 @@ module.exports = () => ({
                     case 'UNSTABLE':
                         break;
                     case 'BLOCKED':
-                        build.stats = Object.assign(build.stats, {
-                            blockedStartTime: (new Date()).toISOString()
-                        });
+                        if (!hoek.reach(build, 'stats.blockedStartTime')) {
+                            build.stats = Object.assign(build.stats, {
+                                blockedStartTime: (new Date()).toISOString()
+                            });
+                        }
+
                         break;
                     default:
                         throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -66,12 +66,15 @@ module.exports = () => ({
                             });
                         })
                         // get the user permissions for the repo
-                        .then(scmUri => user.getPermissions(scmUri)
-                            // if the user isn't an admin, reject
-                            .then((permissions) => {
-                                if (!permissions.admin) {
+                        .then(scmUri => Promise.all([
+                            user.getPermissions(oldPipeline.scmUri),
+                            user.getPermissions(scmUri)
+                        ])
+                            // if the user isn't an admin for both repos, reject
+                            .then(([oldPermissions, permissions]) => {
+                                if (!oldPermissions.admin || !permissions.admin) {
                                     throw boom.forbidden(
-                                        `User ${username} is not an admin of this repo`);
+                                        `User ${username} is not an admin of these repos`);
                                 }
                             })
                             // check if there is already a pipeline with the new checkoutUrl

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -571,6 +571,36 @@ describe('build plugin test', () => {
                 });
             });
 
+            it('skips updating BLOCKED stats if they are already set', () => {
+                const status = 'BLOCKED';
+                const options = {
+                    method: 'PUT',
+                    url: `/builds/${id}`,
+                    credentials: {
+                        username: id,
+                        scope: ['temporal']
+                    },
+                    payload: {
+                        status
+                    }
+                };
+
+                buildMock.stats = {
+                    blockedStartTime: '2017-01-06T01:49:50.384359267Z'
+                };
+
+                return server.inject(options).then((reply) => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.calledWith(buildFactoryMock.get, id);
+                    assert.calledOnce(buildMock.update);
+                    assert.strictEqual(buildMock.status, status);
+                    assert.strictEqual(buildMock.stats.blockedStartTime,
+                        '2017-01-06T01:49:50.384359267Z');
+                    assert.isUndefined(buildMock.meta);
+                    assert.isUndefined(buildMock.endTime);
+                });
+            });
+
             it('allows updating to UNSTABLE', () => {
                 const status = 'UNSTABLE';
                 const options = {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1293,6 +1293,7 @@ describe('pipeline plugin test', () => {
         const unformattedCheckoutUrl = 'git@github.com:screwdriver-cd/data-MODEL.git';
         let formattedCheckoutUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
         const scmUri = 'github.com:12345:master';
+        const oldScmUri = 'github.com:12345:branchName';
         const id = 123;
         const token = 'secrettoken';
         const username = 'd2lam';
@@ -1321,6 +1322,7 @@ describe('pipeline plugin test', () => {
 
             userMock = getUserMock({ username, scmContext });
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
+            userMock.getPermissions.withArgs(oldScmUri).resolves({ admin: true });
             userMock.unsealToken.resolves(token);
             userFactoryMock.get.withArgs({ username, scmContext }).resolves(userMock);
 
@@ -1393,7 +1395,7 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 403 when the pipeline is child piepline', () => {
+        it('returns 403 when the pipeline is child pipeline', () => {
             pipelineMock.configPipelineId = 123;
 
             return server.inject(options).then((reply) => {
@@ -1401,8 +1403,16 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 403 when the user does not have admin permissions', () => {
+        it('returns 403 when the user does not have admin permissions on the new repo', () => {
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 403);
+            });
+        });
+
+        it('returns 403 when the user does not have admin permissions on the old repo', () => {
+            userMock.getPermissions.withArgs(oldScmUri).resolves({ admin: false });
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 403);


### PR DESCRIPTION
## Context

Currently it looks like the build is stuck in the queue vs blocked since the blocked stat is updated each time the blocked status is set.

## Objective

This PR skips setting the blocked stat if it's already set.

Also fixes bug when updating checkoutUrl. Should also check if user has admin permissions on old repo as well as new one.

## References

Related to #1474 