### PR TITLE
feat(1412): event & build metrics

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -9,6 +9,7 @@ const stepUpdateRoute = require('./steps/update');
 const stepLogsRoute = require('./steps/logs');
 const listSecretsRoute = require('./listSecrets');
 const tokenRoute = require('./token');
+const metricsRoute = require('./metrics');
 const workflowParser = require('screwdriver-workflow-parser');
 
 /**
@@ -344,6 +345,7 @@ exports.register = (server, options, next) => {
         // Secrets
         listSecretsRoute(),
         tokenRoute(),
+        metricsRoute(),
         artifactGetRoute(options)
     ]);
 

--- a/plugins/builds/metrics.js
+++ b/plugins/builds/metrics.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/builds/{id}/metrics',
+    config: {
+        description: 'Get metrics for this build',
+        notes: 'Returns list of metrics for the given build',
+        tags: ['api', 'builds', 'metrics'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest', 'build']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const factory = request.server.app.buildFactory;
+            const { id } = request.params;
+            const { startTime, endTime } = request.query;
+
+            return factory.get(id)
+                .then((build) => {
+                    if (!build) {
+                        throw boom.notFound('Build does not exist');
+                    }
+
+                    return build.getMetrics({
+                        startTime,
+                        endTime
+                    });
+                })
+                .then(metrics => reply(metrics))
+                .catch(err => reply(boom.boomify(err)));
+        },
+        validate: {
+            query: joi.object({
+                startTime: joi.string().isoDate(),
+                endTime: joi.string().isoDate()
+            })
+        }
+    }
+});

--- a/plugins/events/index.js
+++ b/plugins/events/index.js
@@ -3,6 +3,7 @@
 const createRoute = require('./create');
 const getRoute = require('./get');
 const listBuildsRoute = require('./listBuilds');
+const metricsRoute = require('./metrics');
 
 /**
  * Event API Plugin
@@ -15,7 +16,8 @@ exports.register = (server, options, next) => {
     server.route([
         createRoute(),
         getRoute(),
-        listBuildsRoute()
+        listBuildsRoute(),
+        metricsRoute()
     ]);
 
     next();

--- a/plugins/events/metrics.js
+++ b/plugins/events/metrics.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/events/{id}/metrics',
+    config: {
+        description: 'Get metrics for this event',
+        notes: 'Returns list of metrics for the given event',
+        tags: ['api', 'events', 'metrics'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest', 'event']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const factory = request.server.app.eventFactory;
+            const { id } = request.params;
+            const { startTime, endTime } = request.query;
+
+            return factory.get(id)
+                .then((event) => {
+                    if (!event) {
+                        throw boom.notFound('Event does not exist');
+                    }
+
+                    return event.getMetrics({
+                        startTime,
+                        endTime
+                    });
+                })
+                .then(metrics => reply(metrics))
+                .catch(err => reply(boom.boomify(err)));
+        },
+        validate: {
+            query: joi.object({
+                startTime: joi.string().isoDate(),
+                endTime: joi.string().isoDate()
+            })
+        }
+    }
+});


### PR DESCRIPTION
Add endpoints for metrics
Change some mock names in tests to be consistent with the `pipelines.test.js`

Related: https://github.com/screwdriver-cd/screwdriver/issues/1412
Blocked by: 
- https://github.com/screwdriver-cd/datastore-sequelize/pull/45
- https://github.com/screwdriver-cd/models/pull/324