### PR TITLE
fix: pass download flag to artifact endpoint

### DIFF
--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -7,6 +7,7 @@ const uuid = require('uuid/v4');
 
 const idSchema = joi.reach(schema.models.build.base, 'id');
 const artifactSchema = joi.string().label('Artifact Name');
+const downloadSchema = joi.string().valid(['', 'false', 'true']).label('Flag to trigger download');
 
 module.exports = config => ({
     method: 'GET',
@@ -38,8 +39,12 @@ module.exports = config => ({
                 jwtid: uuid()
             });
 
-            const baseUrl = `${config.ecosystem.store}/v1/builds/`
+            let baseUrl = `${config.ecosystem.store}/v1/builds/`
                 + `${buildId}/ARTIFACTS/${encodedArtifact}?token=${token}`;
+
+            if (request.query.download) {
+                baseUrl += `&download=${request.query.download}`;
+            }
 
             return reply().redirect().location(baseUrl);
         },
@@ -47,6 +52,9 @@ module.exports = config => ({
             params: {
                 id: idSchema,
                 name: artifactSchema
+            },
+            query: {
+                download: downloadSchema
             }
         }
     }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2657,6 +2657,20 @@ describe('build plugin test', () => {
                 assert.deepEqual(reply.headers.location, url);
             });
         });
+
+        it('redirects to store for an artifact download request', () => {
+            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/manifest?token=sign&download=true`;
+
+            return server.inject({
+                url: `/builds/${id}/artifacts/${artifact}?download=true`,
+                credentials: {
+                    scope: ['user']
+                }
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 302);
+                assert.deepEqual(reply.headers.location, url);
+            });
+        });
     });
 
     describe('POST /builds/{id}/token', () => {


### PR DESCRIPTION
## Context

want artifact to be downloadable by the browser with mime type dictated by the extension of coz

## Objective

pass along the download option to the store endpoint

## References

related to: https://github.com/screwdriver-cd/screwdriver/issues/1476

related PRs:
- https://github.com/screwdriver-cd/store/pull/75
- https://github.com/screwdriver-cd/ui/pull/408