### PR TITLE
fix: set default restrict PRs to none

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -223,7 +223,7 @@ webhooks:
   # Ignore commits made by these users
   ignoreCommitsBy: []
   # Restrict PR: all, none, branch, or fork
-  restrictPR: fork
+  restrictPR: none
 
 coverage: {}
   # plugin: sonar


### PR DESCRIPTION
Related: https://github.com/screwdriver-cd/screwdriver/issues/579