### PR TITLE
feat(1522): allow easy way to get job with jobName

### DIFF
--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'pipelines', 'events'],
         auth: {
             strategies: ['token'],
-            scope: ['user', 'pipeline']
+            scope: ['user', 'build', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/pipelines/listJobs.js
+++ b/plugins/pipelines/listJobs.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'pipelines', 'jobs'],
         auth: {
             strategies: ['token'],
-            scope: ['user', 'pipeline']
+            scope: ['user', 'build', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {
@@ -22,9 +22,10 @@ module.exports = () => ({
             }
         },
         handler: (request, reply) => {
-            const factory = request.server.app.pipelineFactory;
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const { page, count, jobName } = request.query;
 
-            return factory.get(request.params.id)
+            return pipelineFactory.get(request.params.id)
                 .then((pipeline) => {
                     if (!pipeline) {
                         throw boom.notFound('Pipeline does not exist');
@@ -36,11 +37,11 @@ module.exports = () => ({
                         }
                     };
 
-                    if (request.query.page || request.query.count) {
-                        config.paginate = {
-                            page: request.query.page,
-                            count: request.query.count
-                        };
+                    if (jobName) {
+                        config.params.name = jobName;
+                    }
+                    if (page || count) {
+                        config.paginate = { page, count };
                     }
 
                     return pipeline.getJobs(config);
@@ -53,7 +54,8 @@ module.exports = () => ({
         },
         validate: {
             query: schema.api.pagination.concat(joi.object({
-                archived: joi.boolean().truthy('true').falsy('false').default(false)
+                archived: joi.boolean().truthy('true').falsy('false').default(false),
+                name: joi.reach(schema.models.job.base, 'name')
             }))
         }
     }

--- a/plugins/pipelines/listJobs.js
+++ b/plugins/pipelines/listJobs.js
@@ -55,7 +55,7 @@ module.exports = () => ({
         validate: {
             query: schema.api.pagination.concat(joi.object({
                 archived: joi.boolean().truthy('true').falsy('false').default(false),
-                name: joi.reach(schema.models.job.base, 'name')
+                jobName: joi.reach(schema.models.job.base, 'name')
             }))
         }
     }

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -144,7 +144,7 @@ const getUserMock = (user) => {
     return mock;
 };
 
-describe.only('pipeline plugin test', () => {
+describe('pipeline plugin test', () => {
     let pipelineFactoryMock;
     let userFactoryMock;
     let eventFactoryMock;

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -144,7 +144,7 @@ const getUserMock = (user) => {
     return mock;
 };
 
-describe('pipeline plugin test', () => {
+describe.only('pipeline plugin test', () => {
     let pipelineFactoryMock;
     let userFactoryMock;
     let eventFactoryMock;
@@ -633,6 +633,21 @@ describe('pipeline plugin test', () => {
                 assert.deepEqual(reply.result, testJobs);
             })
         );
+
+        it('returns 200 for getting jobs with jobNames', () => {
+            options.url = `/pipelines/${id}/jobs?jobName=deploy`;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.calledWith(pipelineMock.getJobs, {
+                    params: {
+                        archived: false,
+                        name: 'deploy'
+                    }
+                });
+                assert.deepEqual(reply.result, testJobs);
+            });
+        });
 
         it('returns 400 for wrong query format', () => {
             pipelineFactoryMock.get.resolves(null);


### PR DESCRIPTION
Allow query by `jobName` and `pipelineId`

Related: https://github.com/screwdriver-cd/screwdriver/issues/1522