### PR TITLE
fix: support get step metrics for all steps for a job

### DIFF
--- a/plugins/jobs/stepMetrics.js
+++ b/plugins/jobs/stepMetrics.js
@@ -5,7 +5,7 @@ const joi = require('joi');
 
 module.exports = () => ({
     method: 'GET',
-    path: '/jobs/{id}/metrics/steps/{stepName}',
+    path: '/jobs/{id}/metrics/steps',
     config: {
         description: 'Get step metrics for this job',
         notes: 'Returns list of step metrics for the given job',
@@ -21,8 +21,8 @@ module.exports = () => ({
         },
         handler: (request, reply) => {
             const factory = request.server.app.jobFactory;
-            const { id, stepName } = request.params;
-            const { startTime, endTime } = request.query;
+            const { id } = request.params;
+            const { startTime, endTime, stepName } = request.query;
 
             return factory.get(id)
                 .then((job) => {
@@ -42,7 +42,8 @@ module.exports = () => ({
         validate: {
             query: joi.object({
                 startTime: joi.string().isoDate(),
-                endTime: joi.string().isoDate()
+                endTime: joi.string().isoDate(),
+                stepName: joi.string() // optional, if not passed in will fetch all steps
             })
         }
     }

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -466,7 +466,7 @@ describe('job plugin test', () => {
         beforeEach(() => {
             options = {
                 method: 'GET',
-                url: `/jobs/${id}/metrics/steps/sd-setup-scm` +
+                url: `/jobs/${id}/metrics/steps` +
                 `?startTime=${startTime}&endTime=${endTime}`,
                 credentials: {
                     username,
@@ -478,16 +478,29 @@ describe('job plugin test', () => {
             jobFactoryMock.get.resolves(jobMock);
         });
 
-        it('returns 200 and metrics for job', () =>
+        it('returns 200 and step metrics of all steps for job', () =>
             server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.calledWith(jobMock.getStepMetrics, {
+                    stepName: undefined,
+                    startTime,
+                    endTime
+                });
+            })
+        );
+
+        it('returns 200 and step metrics of sd-setup-scm for job', () => {
+            options.url = `${options.url}&stepName=sd-setup-scm`;
+
+            return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 200);
                 assert.calledWith(jobMock.getStepMetrics, {
                     stepName: 'sd-setup-scm',
                     startTime,
                     endTime
                 });
-            })
-        );
+            });
+        });
 
         it('returns 404 when job does not exist', () => {
             const error = {


### PR DESCRIPTION
- support get step metrics for all steps for a job
- make `stepName` an optional query param

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1412