### PR TITLE
fix(1010): [1][medium] add chainPR annotation.

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -308,6 +308,8 @@ webhooks:
     __format: json
   # Restrict PR: all, none, branch, or fork
   restrictPR: RESTRICT_PR
+  # Chain PR: true or false
+  chainPR: CHAIN_PR
 
 bookends:
   # List of module names, or objects { name, config } for instantiation to use in sd-setup

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -224,6 +224,8 @@ webhooks:
   ignoreCommitsBy: []
   # Restrict PR: all, none, branch, or fork
   restrictPR: none
+  # Chain PR: true or false
+  chainPR: false
 
 coverage: {}
   # plugin: sonar

--- a/lib/server.js
+++ b/lib/server.js
@@ -48,6 +48,7 @@ function prettyPrintErrors(request, reply) {
  * @param  {Object}      config.httpd.tls           TLS Configuration
  * @param  {Object}      config.webhooks            Webhooks settings
  * @param  {String}      config.webhooks.restrictPR Restrict PR setting
+ * @param  {Boolean}     config.webhooks.chainPR    Chain PR flag
  * @param  {Object}      config.ecosystem           List of hosts in the ecosystem
  * @param  {Object}      config.ecosystem.ui        URL for the User Interface
  * @param  {Factory}     config.pipelineFactory     Pipeline Factory instance

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "nock": "^9.6.1",
     "node-plantuml": "^0.5.0",
     "npm-auto-version": "^1.0.0",
+    "rewire": "^4.0.1",
     "sinon": "^2.3.1",
     "stream-to-promise": "^2.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "screwdriver-scm-gitlab": "^1.3.1",
     "screwdriver-scm-router": "^4.0.1",
     "screwdriver-template-validator": "^3.0.6",
-    "screwdriver-workflow-parser": "^1.8.1",
+    "screwdriver-workflow-parser": "^1.8.3",
     "sqlite3": "^4.0.6",
     "tinytim": "^0.1.1",
     "uuid": "^3.3.2",

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -5,6 +5,9 @@ const joi = require('joi');
 const winston = require('winston');
 const workflowParser = require('screwdriver-workflow-parser');
 
+const ANNOT_NS = 'screwdriver.cd';
+const ANNOT_CHAIN_PR = `${ANNOT_NS}/chainPR`;
+const ANNOT_RESTRICT_PR = `${ANNOT_NS}/restrictPR`;
 const WAIT_FOR_CHANGEDFILES = 1.8;
 
 /**
@@ -163,22 +166,23 @@ async function triggeredPipelines(pipelineFactory, scmConfig, branch, type) {
  * Create events for each pipeline
  * @async  createPREvents
  * @param  {Object}       options
- * @param  {String}       options.username      User who created the PR
- * @param  {String}       options.scmConfig     Has the token and scmUri to get branches
- * @param  {String}       options.sha           Specific SHA1 commit to start the build with
- * @param  {String}       options.prRef         Reference to pull request
- * @param  {String}       options.prNum         Pull request number
- * @param  {String}       options.prTitle       Pull request title
- * @param  {Array}        options.changedFiles  List of changed files
- * @param  {String}       options.branch        The branch against which pr is opened
- * @param  {String}       options.action        Event action
- * @param  {String}       options.skipMessage   Message to skip starting builds
- * @param  {Hapi.request} request               Request from user
+ * @param  {String}       options.username        User who created the PR
+ * @param  {String}       options.scmConfig       Has the token and scmUri to get branches
+ * @param  {String}       options.sha             Specific SHA1 commit to start the build with
+ * @param  {String}       options.prRef           Reference to pull request
+ * @param  {String}       options.prNum           Pull request number
+ * @param  {String}       options.prTitle         Pull request title
+ * @param  {Array}        options.changedFiles    List of changed files
+ * @param  {String}       options.branch          The branch against which pr is opened
+ * @param  {String}       options.action          Event action
+ * @param  {String}       options.skipMessage     Message to skip starting builds
+ * @param  {Boolean}      options.resolvedChainPR Resolved Chain PR flag
+ * @param  {Hapi.request} request                 Request from user
  * @return {Promise}
  */
 async function createPREvents(options, request) {
     const { username, scmConfig, sha, prRef, prNum,
-        prTitle, changedFiles, branch, action, skipMessage } = options;
+        prTitle, changedFiles, branch, action, skipMessage, resolvedChainPR } = options;
     const scm = request.server.app.pipelineFactory.scm;
     const eventFactory = request.server.app.eventFactory;
     const pipelineFactory = request.server.app.pipelineFactory;
@@ -207,7 +211,8 @@ async function createPREvents(options, request) {
             configPipelineSha,
             startFrom: `~pr:${branch}`,
             changedFiles,
-            causeMessage: `${action} by ${userDisplayName}`
+            causeMessage: `${action} by ${userDisplayName}`,
+            chainPR: resolvedChainPR
         };
 
         if (skipMessage) {
@@ -233,6 +238,21 @@ async function createPREvents(options, request) {
 }
 
 /**
+ * Resolve ChainPR flag
+ * @method resolveChainPR
+ * @param  {Boolean}  chainPR              Plugin Chain PR flag
+ * @param  {Pipeline} pipeline             Pipeline
+ * @param  {Object}   pipeline.annotations Pipeline-level annotations
+ * @return {Boolean}
+ */
+function resolveChainPR(chainPR, pipeline) {
+    const defaultChainPR = typeof chainPR === 'undefined' ? false : chainPR;
+    const annotChainPR = pipeline.annotations[ANNOT_CHAIN_PR];
+
+    return typeof annotChainPR === 'undefined' ? defaultChainPR : annotChainPR;
+}
+
+/**
  * Create a new job and start the build for an opened pull-request
  * @async  pullRequestOpened
  * @param  {Object}       options
@@ -240,22 +260,25 @@ async function createPREvents(options, request) {
  * @param  {String}       options.prSource      The origin of this PR
  * @param  {Pipeline}     options.pipeline      Pipeline model for the pr
  * @param  {String}       options.restrictPR    Restrict PR setting
+ * @param  {Boolean}      options.chainPR       Chain PR flag
  * @param  {Hapi.request} request               Request from user
  * @param  {Hapi.reply}   reply                 Reply to user
  */
 async function pullRequestOpened(options, request, reply) {
-    const { hookId, prSource, pipeline, restrictPR } = options;
+    const { hookId, prSource, pipeline, restrictPR, chainPR } = options;
 
     if (pipeline) {
         const p = await pipeline.sync();
         const defaultRestrictPR = restrictPR || 'none';
-        const restriction = p.annotations['screwdriver.cd/restrictPR'] || defaultRestrictPR;
+        const restriction = p.annotations[ANNOT_RESTRICT_PR] || defaultRestrictPR;
 
         // Check for restriction upfront
         if (isRestrictedPR(restriction, prSource)) {
             options.skipMessage = 'Skipping build since pipeline is configured to restrict ' +
             `${restriction} and PR is ${prSource}`;
         }
+
+        options.resolvedChainPR = resolveChainPR(chainPR, p);
     }
 
     return createPREvents(options, request)
@@ -321,6 +344,7 @@ async function pullRequestClosed(options, request, reply) {
  * @param  {String}       options.name          Name of the new job (PR-1)
  * @param  {String}       options.prSource      The origin of this PR
  * @param  {String}       options.restrictPR    Restrict PR setting
+ * @param  {Boolean}      options.chainPR       Chain PR flag
  * @param  {Pipeline}     options.pipeline      Pipeline model for the pr
  * @param  {Array}        options.changedFiles  List of files that were changed
  * @param  {String}       options.prNum         Pull request number
@@ -329,18 +353,20 @@ async function pullRequestClosed(options, request, reply) {
  * @param  {Hapi.reply}   reply                 Reply to user
  */
 async function pullRequestSync(options, request, reply) {
-    const { pipeline, hookId, prSource, name, prNum, action, restrictPR } = options;
+    const { pipeline, hookId, prSource, name, prNum, action, restrictPR, chainPR } = options;
 
     if (pipeline) {
         const p = await pipeline.sync();
         const defaultRestrictPR = restrictPR || 'none';
-        const restriction = p.annotations['screwdriver.cd/restrictPR'] || defaultRestrictPR;
+        const restriction = p.annotations[ANNOT_RESTRICT_PR] || defaultRestrictPR;
 
         // Check for restriction upfront
         if (isRestrictedPR(restriction, prSource)) {
             options.skipMessage = 'Skipping build since pipeline is configured to restrict ' +
                 `${restriction} and PR is ${prSource}`;
         }
+
+        options.resolvedChainPR = resolveChainPR(chainPR, p);
 
         await p.jobs.then(jobs => jobs.filter(j => j.name.includes(name)))
             .then(prJobs => Promise.all(prJobs.map(j => stopJob({ job: j, prNum, action }))));
@@ -394,6 +420,7 @@ async function obtainScmToken(pluginOptions, userFactory, username, scmContext) 
  * @param  {Object}             pluginOptions
  * @param  {String}             pluginOptions.username    Generic scm username
  * @param  {String}             pluginOptions.restrictPR  Restrict PR setting
+ * @param  {Boolean}            pluginOptions.chainPR     Chain PR flag
  * @param  {Hapi.request}       request                   Request from user
  * @param  {Hapi.reply}         reply                     Reply to user
  * @param  {Object}             parsed
@@ -409,7 +436,7 @@ function pullRequestEvent(pluginOptions, request, reply, parsed) {
         token: '',
         scmContext
     };
-    const { restrictPR } = pluginOptions;
+    const { restrictPR, chainPR } = pluginOptions;
 
     request.log(['webhook', hookId], `PR #${prNum} ${action} for ${fullCheckoutUrl}`);
 
@@ -456,7 +483,8 @@ function pullRequestEvent(pluginOptions, request, reply, parsed) {
                         action: action.charAt(0).toUpperCase() + action.slice(1),
                         branch,
                         fullCheckoutUrl,
-                        restrictPR
+                        restrictPR,
+                        chainPR
                     };
 
                     await updateAdmins(userFactory, username, scmContext, pipeline);
@@ -617,7 +645,8 @@ exports.register = (server, options, next) => {
     const pluginOptions = joi.attempt(options, joi.object().keys({
         username: joi.string().required(),
         ignoreCommitsBy: joi.array().items(joi.string()).optional(),
-        restrictPR: joi.string().valid('all', 'none', 'branch', 'fork').optional()
+        restrictPR: joi.string().valid('all', 'none', 'branch', 'fork').optional(),
+        chainPR: joi.boolean().optional()
     }), 'Invalid config for plugin-webhooks');
 
     server.route({

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -638,6 +638,7 @@ async function pushEvent(pluginOptions, request, reply, parsed, skipMessage) {
  * @param  {String}     options.username        Generic scm username
  * @param  {Array}      options.ignoreCommitsBy Ignore commits made by these usernames
  * @param  {Array}      options.restrictPR      Restrict PR setting
+ * @param  {Boolean}    options.chainPR         Chain PR flag
  * @param  {Function}   next                    Function to call when done
  */
 exports.register = (server, options, next) => {


### PR DESCRIPTION
## Context

prChain flag is moved from top-level setting to pipeline-level annotation.
- Current
```
prChain: true
jobs:
   main:
       ....
```
- After
```
annotations:
  screwdriver.cd/chainPR: true 
jobs:
   main:
       ....
```

## Objective

This PR adds value resolution of the `screwdriver.cd/chainPR` annotation and the plugin-level setting, which is added for maintenance of similarity with `restrictPR`.

## References

- https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-466188824
