### PR TITLE
 feat(823): [6] release and tag trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "nock": "^9.6.1",
     "node-plantuml": "^0.5.0",
     "npm-auto-version": "^1.0.0",
+    "rewire": "^4.0.1",
     "sinon": "^7.2.7",
     "stream-to-promise": "^2.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "screwdriver-models": "^27.26.0",
     "screwdriver-notifications-email": "^1.1.9",
     "screwdriver-notifications-slack": "^2.1.9",
-    "screwdriver-scm-github": "^8.5.0",
+    "screwdriver-scm-github": "^9.0.0",
     "screwdriver-scm-gitlab": "^1.3.1",
     "screwdriver-scm-router": "^4.0.1",
     "screwdriver-template-validator": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -123,13 +123,13 @@
     "eslint-config-screwdriver": "^3.0.1",
     "form-data": "^2.3.3",
     "github": "^8.1.1",
-    "jenkins-mocha": "^6.0.0",
+    "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
     "mz": "^2.6.0",
     "nock": "^9.6.1",
     "node-plantuml": "^0.5.0",
     "npm-auto-version": "^1.0.0",
-    "sinon": "^2.3.1",
+    "sinon": "^7.2.7",
     "stream-to-promise": "^2.2.0"
   }
 }

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -162,6 +162,7 @@ function hasTriggeredJob(pipeline, startFrom) {
  * @param   {Object}            scmConfig       Has the token and scmUri to get branches
  * @param   {String}            branch          The branch which is committed
  * @param   {String}            type            Triggered GitHub event type ('pr' or 'repo')
+ * @param   {String}            action          Triggered GitHub event action
  * @returns {Promise}                           Promise that resolves into triggered pipelines
  */
 async function triggeredPipelines(pipelineFactory, scmConfig, branch, type, action) {

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -441,7 +441,7 @@ function pullRequestEvent(pluginOptions, request, reply, parsed, token) {
     const fullCheckoutUrl = `${checkoutUrl}#${branch}`;
     const scmConfig = {
         scmUri: '',
-        token: '',
+        token,
         scmContext
     };
     const { restrictPR } = pluginOptions;

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,8 +4,8 @@ shared:
 jobs:
     main:
         annotations:
-            screwdriver.cd/ram: HIGH
-            screwdriver.cd/cpu: HIGH
+            screwdriver.cd/ram: TURBO
+            screwdriver.cd/cpu: TURBO
         requires:
             - ~pr
             - ~commit

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,6 +3,8 @@ shared:
 
 jobs:
     main:
+        annotations:
+            screwdriver.cd/ram: HIGH
         requires:
             - ~pr
             - ~commit
@@ -13,6 +15,8 @@ jobs:
             - duplicate: NPM_FILTER=screwdriver- ./ci/npm-dups.sh
             - test: npm test
             - coverage: ./ci/coverage.sh
+        environment:
+            NODE_OPTIONS: "--max_old_space_size=4096"
         secrets:
             # Uploading coverage information to coveralls
             - COVERALLS_REPO_TOKEN

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,6 +5,7 @@ jobs:
     main:
         annotations:
             screwdriver.cd/ram: HIGH
+            screwdriver.cd/cpu: HIGH
         requires:
             - ~pr
             - ~commit
@@ -16,7 +17,7 @@ jobs:
             - test: npm test
             - coverage: ./ci/coverage.sh
         environment:
-            NODE_OPTIONS: "--max_old_space_size=4096"
+            NODE_OPTIONS: "--max_old_space_size=8192"
         secrets:
             # Uploading coverage information to coveralls
             - COVERALLS_REPO_TOKEN

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -245,6 +245,14 @@ describe('github plugin test', () => {
             eventMock = {
                 id: 'bbf22a3808c19dc50777258a253805b14fb3ad8b'
             };
+            reqHeaders = {
+                'x-github-event': 'notSupported',
+                'x-github-delivery': 'bar',
+                'user-agent': 'shot',
+                host: 'localhost:12345',
+                'content-type': 'application/json',
+                'content-length': '2'
+            };
 
             buildFactoryMock.create.resolves(buildMock);
             buildMock.update.resolves(null);
@@ -269,14 +277,6 @@ describe('github plugin test', () => {
         });
 
         it('returns 204 for unsupported event type', () => {
-            reqHeaders = {
-                'x-github-event': 'notSupported',
-                'x-github-delivery': 'bar',
-                'user-agent': 'shot',
-                host: 'localhost:12345',
-                'content-type': 'application/json',
-                'content-length': '2'
-            };
             pipelineFactoryMock.scm.parseHook.withArgs(reqHeaders, {}).resolves(null);
 
             options = {
@@ -299,14 +299,9 @@ describe('github plugin test', () => {
             beforeEach(() => {
                 parsed.type = 'repo';
                 parsed.action = 'push';
-                reqHeaders = {
-                    'x-github-event': 'push',
-                    'x-github-delivery': parsed.hookId,
-                    'user-agent': 'shot',
-                    host: 'localhost:12345',
-                    'content-type': 'application/json',
-                    'content-length': '6632'
-                };
+                reqHeaders['x-github-event'] = 'push';
+                reqHeaders['x-github-delivery'] = parsed.hookId;
+                reqHeaders['content-length'] = '6632';
                 payload = testPayloadPush;
                 options = {
                     method: 'POST',
@@ -603,14 +598,9 @@ describe('github plugin test', () => {
             beforeEach(() => {
                 parsed.type = 'pr';
                 parsed.action = 'opened';
-                reqHeaders = {
-                    'x-github-event': 'pull_request',
-                    'x-github-delivery': parsed.hookId,
-                    'user-agent': 'shot',
-                    host: 'localhost:12345',
-                    'content-type': 'application/json',
-                    'content-length': '21236'
-                };
+                reqHeaders['x-github-event'] = 'pull_request';
+                reqHeaders['x-github-delivery'] = parsed.hookId;
+                reqHeaders['content-length'] = '21236';
                 payload = testPayloadOpen;
                 options = {
                     method: 'POST',
@@ -1092,14 +1082,10 @@ describe('github plugin test', () => {
                     };
 
                     parsed.action = 'synchronized';
-                    reqHeaders = {
-                        'x-github-event': 'pull_request',
-                        'x-github-delivery': parsed.hookId,
-                        'user-agent': 'shot',
-                        host: 'localhost:12345',
-                        'content-type': 'application/json',
-                        'content-length': '21241'
-                    };
+                    reqHeaders['x-github-event'] = 'pull_request';
+                    reqHeaders['x-github-delivery'] = parsed.hookId;
+                    reqHeaders['content-length'] = '21241';
+
                     scmConfig.prNum = 1;
                     parsed.prTitle = 'Update the README with new information';
                     options.payload = testPayloadSync;
@@ -1476,14 +1462,9 @@ describe('github plugin test', () => {
                     };
 
                     parsed.action = 'closed';
-                    reqHeaders = {
-                        'x-github-event': 'pull_request',
-                        'x-github-delivery': parsed.hookId,
-                        'user-agent': 'shot',
-                        host: 'localhost:12345',
-                        'content-type': 'application/json',
-                        'content-length': '21236'
-                    };
+                    reqHeaders['x-github-event'] = 'pull_request';
+                    reqHeaders['x-github-delivery'] = parsed.hookId;
+                    reqHeaders['content-length'] = '21236';
                     options.payload = testPayloadClose;
                     jobMock.getRunningBuilds.resolves([model1, model2]);
                     pipelineFactoryMock.scm.parseHook.withArgs(reqHeaders, options.payload)

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -162,9 +162,9 @@ describe('webhooks plugin test', () => {
             create: sinon.stub()
         };
 
-        /* eslint-disable global-require */
-        plugin = require('../../plugins/webhooks');
-        /* eslint-enable global-require */
+        plugin = rewire('../../plugins/webhooks');
+        // eslint-disable-next-line no-underscore-dangle
+        plugin.__set__('WAIT_FOR_CHANGEDFILES', 0);
 
         server = new hapi.Server();
         server.root.app = {

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -20,10 +20,10 @@ const PARSED_CONFIG = require('./data/github.parsedyaml.json');
 sinon.assert.expose(assert, { prefix: '' });
 
 // separate from "webhooks plugin test" because there is unnecessary beforeEach hook for test test case
-describe('determineStartFrom', () => {
-    const webhook = rewire('../../plugins/webhooks/index.js');
+describe('webhooks.determineStartFrom', () => {
+    const webhooks = rewire('../../plugins/webhooks/index.js');
     // eslint-disable-next-line no-underscore-dangle
-    const determineStartFrom = webhook.__get__('determineStartFrom');
+    const determineStartFrom = webhooks.__get__('determineStartFrom');
     let action;
     let type;
     let targetBranch;
@@ -593,6 +593,15 @@ describe('webhooks plugin test', () => {
                         causeMessage: `Merged by ${username}`,
                         changedFiles: undefined
                     });
+                });
+            });
+
+            it('returns 204 when getCommitRefSha() is rejected', () => {
+                pipelineFactoryMock.scm.getCommitRefSha.rejects(new Error('some error'));
+
+                return server.inject(options).then((reply) => {
+                    assert.equal(reply.statusCode, 204);
+                    assert.notCalled(eventFactoryMock.create);
                 });
             });
         });


### PR DESCRIPTION
## Context
Our users want to start jobs triggered release event same like ~pr or ~commit.

## Objective
- https://github.com/screwdriver-cd/screwdriver/commit/c5fc1ff05d75346f534ba9dc024c359f77892bad : scm token is obtained twice. It's wasteful. And do a little refactor of the test.
- https://github.com/screwdriver-cd/screwdriver/commit/4baa8713e3ef73da6374c851e57346913f48e48d : 
    - enable to parse `~release` and `~tag` with `determineStartFrom()`
    - `sha` is empty when the event is `release` or `tag` so this PR provides to a function which gets `sha` after `parseHook()` with `scm.getCommitRefSha()`

It works locally like this:
![image](https://user-images.githubusercontent.com/3445553/54021458-86fad080-41d3-11e9-9ba2-f5cf2f537310.png)

## References
- Related Issue: https://github.com/screwdriver-cd/screwdriver/issues/823
- Blocked by:
    - https://github.com/screwdriver-cd/data-schema/pull/322
    - https://github.com/screwdriver-cd/scm-router/pull/17
    - https://github.com/screwdriver-cd/scm-github/pull/125/files
    - https://github.com/screwdriver-cd/models/pull/342