### PR TITLE
fix(1010): [small] add chainPR value to getNextJobs function

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -276,7 +276,8 @@ exports.register = (server, options, next) => {
 
         return eventFactory.get({ id: build.eventId }).then((event) => {
             const workflowGraph = event.workflowGraph;
-            const nextJobs = workflowParser.getNextJobs(workflowGraph, { trigger: currentJobName });
+            const nextJobs = workflowParser.getNextJobs(workflowGraph,
+                { trigger: currentJobName, prChain: pipeline.prChain });
 
             // Create a join object like: {A:[B,C], D:[B,F]} where [B,C] join on A, [B,F] join on D, etc.
             const joinObj = nextJobs.reduce((obj, jobName) => {

--- a/test/plugins/data/validator.output.json
+++ b/test/plugins/data/validator.output.json
@@ -78,7 +78,6 @@
             }
         ]
     },
-    "prChain": false,
     "workflowGraph": {
         "nodes": [
             { "name": "~pr" },


### PR DESCRIPTION
## Context
Now, Jobs does not chain even if chainPR is true.
We need to pass `pipeline.prChain` flag to getNextJobs function, when checking `triggerNextJobs`.

`getNextJobs` function has fixed before.
https://github.com/screwdriver-cd/workflow-parser/blob/master/lib/getNextJobs.js


## References
screwdriver-cd/screwdriver#1010 (comment)