### PR TITLE
fix(1521): badge use last effective event status

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -276,7 +276,8 @@ exports.register = (server, options, next) => {
 
         return eventFactory.get({ id: build.eventId }).then((event) => {
             const workflowGraph = event.workflowGraph;
-            const nextJobs = workflowParser.getNextJobs(workflowGraph, { trigger: currentJobName });
+            const nextJobs = workflowParser.getNextJobs(workflowGraph,
+                { trigger: currentJobName, prChain: pipeline.prChain });
 
             // Create a join object like: {A:[B,C], D:[B,F]} where [B,C] join on A, [B,F] join on D, etc.
             const joinObj = nextJobs.reduce((obj, jobName) => {

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -104,8 +104,8 @@ module.exports = () => ({
                         return reply.redirect(getUrl(badgeService));
                     }
 
-                    return pipeline.getEvents({ sort: 'ascending' }).then((events) => {
-                        const getLastEffectiveEvent = async (events) => { 
+                    return pipeline.getEvents({ sort: 'ascending' }).then((allEvents) => {
+                        const getLastEffectiveEvent = async (events) => {
                             const lastEvent = events.pop();
 
                             if (!lastEvent) {
@@ -139,7 +139,7 @@ module.exports = () => ({
                             });
                         };
 
-                        return getLastEffectiveEvent(events);
+                        return getLastEffectiveEvent(allEvents);
                     });
                 })
                 .catch(() => reply.redirect(getUrl(badgeService)));

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -105,7 +105,7 @@ module.exports = () => ({
                     }
 
                     return pipeline.getEvents({ sort: 'ascending' }).then((allEvents) => {
-                        const getLastEffectiveEvent = async (events) => {
+                        const getLastEffectiveEvent = (events) => {
                             const lastEvent = events.pop();
 
                             if (!lastEvent) {


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/screwdriver/issues/1521#issuecomment-472771605

## Objective
When `[skip ci]` created an empty event, the badge was displayed as unknown. Fixed to create badges as far back as effective build.
<img width="968" alt="ui" src="https://user-images.githubusercontent.com/24538326/54349205-1994e700-468e-11e9-9b9f-770e6bae9c27.png">

■Before
<img width="48" alt="before" src="https://user-images.githubusercontent.com/24538326/54349244-303b3e00-468e-11e9-98c0-e9c2e09dbeb2.png">

■After
<img width="106" alt="after" src="https://user-images.githubusercontent.com/24538326/54349252-34fff200-468e-11e9-9585-18b59898433b.png">
