### PR TITLE
fix: allow current admin to update pipeline with deprecated scmContext

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -6,6 +6,29 @@ const schema = require('screwdriver-data-schema');
 const idSchema = joi.reach(schema.models.pipeline.base, 'id');
 const helper = require('./helper');
 
+/**
+ * Get user permissions on old pipeline
+ * @method getPermissionsForOldPipeline
+ * @param  {Array}                     scmContexts  An array of scmContext
+ * @param  {Object}                    pipeline     Pipeline to check against
+ * @param  {Object}                    user         User to check for
+ * @return {Promise}
+ */
+function getPermissionsForOldPipeline({ scmContexts, pipeline, user }) {
+    // this pipeline's scmContext has been removed, allow current admin to change it
+    if (!scmContexts.includes(pipeline.scmContext)) {
+        const permission = { admin: false };
+
+        if (pipeline.admins.includes(user.username)) {
+            permission.admin = true;
+        }
+
+        return Promise.resolve(permission);
+    }
+
+    return user.getPermissions(pipeline.scmUri);
+}
+
 module.exports = () => ({
     method: 'PUT',
     path: '/pipelines/{id}',
@@ -29,6 +52,7 @@ module.exports = () => ({
             const userFactory = request.server.app.userFactory;
             const username = request.auth.credentials.username;
             const scmContext = request.auth.credentials.scmContext;
+            const scmContexts = pipelineFactory.scm.getScmContexts();
             const isValidToken = request.server.plugins.pipelines.isValidToken;
             let gitToken;
 
@@ -67,7 +91,11 @@ module.exports = () => ({
                         })
                         // get the user permissions for the repo
                         .then(scmUri => Promise.all([
-                            user.getPermissions(oldPipeline.scmUri),
+                            getPermissionsForOldPipeline({
+                                scmContexts,
+                                pipeline: oldPipeline,
+                                user
+                            }),
                             user.getPermissions(scmUri)
                         ])
                             // if the user isn't an admin for both repos, reject


### PR DESCRIPTION
We may have some pipelines with deprecated scmContext in the DB, we won't be able to hit github api to check user permission against those repos since the API doesn't config that deprecated scmContext.

This PR will allow current admin to update pipeline's `checkoutUrl` with deprecated scmContext.