### PR TITLE
fix: add new endpoint for job badge

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -267,7 +267,7 @@ ecosystem:
   # Externally routable URL for the Artifact Store
   store: https://store.screwdriver.cd
   # Badge service (needs to add a status and color)
-  badges: https://img.shields.io/badge/build-{{status}}-{{color}}.svg
+  badges: https://img.shields.io/badge/{{subject}}-{{status}}-{{color}}.svg
   # Default registry to pull build containers from. Uses Docker Hub if nothing/empty string is provided
   dockerRegistry: ""
   # Extra origins allowed to do CORS to API

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -13,7 +13,7 @@ const idSchema = joi.reach(schema.models.pipeline.base, 'id');
  * @param  {Array}  [buildsStatus]   Current status of all builds in the same event
  * @return {string}                  URL to redirect to
  */
-function getUrl(badgeService, buildsStatus = []) {
+function getUrl(badgeService, buildsStatus = [], subject = 'pipeline') {
     const counts = {};
     const parts = [];
     let worst = 'lightgrey';
@@ -48,7 +48,9 @@ function getUrl(badgeService, buildsStatus = []) {
     });
 
     return tinytim.tim(badgeService, {
-        status: parts.join(', '), color: worst
+        subject,
+        status: parts.join(', '),
+        color: worst
     });
 }
 

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -9,6 +9,7 @@ const syncPRsRoute = require('./syncPRs');
 const getRoute = require('./get');
 const listRoute = require('./list');
 const badgeRoute = require('./badge');
+const jobBadgeRoute = require('./jobBadge');
 const listJobsRoute = require('./listJobs');
 const listSecretsRoute = require('./listSecrets');
 const listEventsRoute = require('./listEvents');
@@ -53,6 +54,7 @@ exports.register = (server, options, next) => {
         getRoute(),
         listRoute(),
         badgeRoute(),
+        jobBadgeRoute(),
         listJobsRoute(),
         listSecretsRoute(),
         listEventsRoute(),

--- a/plugins/pipelines/jobBadge.js
+++ b/plugins/pipelines/jobBadge.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const tinytim = require('tinytim');
+const idSchema = joi.reach(schema.models.pipeline.base, 'id');
+
+/**
+ * Generate Badge URL
+ * @method getUrl
+ * @param  {string}  badgeService    Template URL for badges - needs {{status}} and {{color}}
+ * @param  {Array}  [builds]         An array of builds
+ * @return {string}                  URL to redirect to
+ */
+function getUrl(badgeService, builds = [], subject = 'job') {
+    let color = 'lightgrey';
+    let status = '';
+
+    const statusColor = {
+        success: 'green',
+        queued: 'blue',
+        running: 'blue',
+        unknown: 'lightgrey',
+        failure: 'red',
+        aborted: 'red'
+    };
+
+    if (builds.length > 0) {
+        status = builds[0].status.toLowerCase();
+        color = statusColor[status];
+    }
+
+    return tinytim.tim(badgeService, {
+        subject,
+        status,
+        color
+    });
+}
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipelines/{id}/{jobName}/badge',
+    config: {
+        description: 'Get a badge for a job',
+        notes: 'Redirects to the badge service',
+        tags: ['api', 'job', 'badge'],
+        handler: (request, reply) => {
+            const jobFactory = request.server.app.jobFactory;
+            const { id, jobName } = request.params;
+            const badgeService = request.server.app.ecosystem.badges;
+
+            return jobFactory.get({
+                pipelineId: id,
+                name: jobName
+            }).then((job) => {
+                if (!job) {
+                    return reply.redirect(getUrl(badgeService));
+                }
+
+                const config = {
+                    paginate: {
+                        page: 1,
+                        count: 1
+                    }
+                };
+
+                return job.getBuilds(config)
+                    .then(builds => reply.redirect(getUrl(badgeService, builds, jobName)));
+            }).catch(() => reply.redirect(getUrl(badgeService)));
+        },
+        validate: {
+            params: {
+                id: idSchema,
+                jobName: joi.reach(schema.models.job.base, 'name')
+            }
+        }
+    }
+});


### PR DESCRIPTION
- add new endpoint for job badge and modify the pipeline badge keyword from `build` to `pipeline`
- the new endpoint will be `v4/pipelines/id/jobName/badge`

pipeline badge:
<img width="114" alt="Screen Shot 2019-03-22 at 3 18 31 PM" src="https://user-images.githubusercontent.com/20427140/54856048-eb2e9180-4cb5-11e9-9cf8-4626bcccf645.png">

`deploy` job badge
<img width="109" alt="Screen Shot 2019-03-22 at 3 19 01 PM" src="https://user-images.githubusercontent.com/20427140/54856065-fda8cb00-4cb5-11e9-992b-e13a739de771.png">

Related to: 
https://github.com/screwdriver-cd/screwdriver/issues/1451

