### PR TITLE
fix: add new statuses mapping for badge

### DIFF
--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -30,6 +30,20 @@ const metricsRoute = require('./metrics');
  * @param  {Function} next              Function to call when done
  */
 exports.register = (server, options, next) => {
+    const statusColor = {
+        unknown: 'lightgrey',
+        created: 'lightgrey',
+        success: 'green',
+        queued: 'blue',
+        blocked: 'blue',
+        running: 'blue',
+        collapsed: 'lightgrey',
+        frozen: 'lightgrey',
+        unstable: 'yellow',
+        failure: 'red',
+        aborted: 'red'
+    };
+
     /**
      * Returns true if the scope does not include pipeline or includes pipeline
      * and it's pipelineId matches the pipeline, otherwise returns false
@@ -53,8 +67,8 @@ exports.register = (server, options, next) => {
         syncPRsRoute(),
         getRoute(),
         listRoute(),
-        badgeRoute(),
-        jobBadgeRoute(),
+        badgeRoute({ statusColor }),
+        jobBadgeRoute({ statusColor }),
         listJobsRoute(),
         listSecretsRoute(),
         listEventsRoute(),

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -707,6 +707,7 @@ describe('pipeline plugin test', () => {
 
         beforeEach(() => {
             pipelineMock = getPipelineMocks(testPipeline);
+            pipelineMock.name = 'foo/bar';
             pipelineFactoryMock.get.resolves(pipelineMock);
             eventsMock = getEventsMocks(testEvents);
             eventsPrMock = getEventsMocks(testEventsPr);
@@ -719,7 +720,7 @@ describe('pipeline plugin test', () => {
             server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
                 assert.deepEqual(reply.headers.location,
-                    'pipeline/1 success, 1 unknown, 1 failure/red');
+                    'foo/bar/1 unknown, 1 success, 1 failure/red');
             })
         );
 
@@ -728,7 +729,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'pipeline/1 success, 1 failure/red');
+                assert.deepEqual(reply.headers.location, 'foo/bar/1 success, 1 failure/red');
             });
         });
 
@@ -773,17 +774,21 @@ describe('pipeline plugin test', () => {
         const id = '123';
         const jobName = 'deploy';
         let jobMock;
+        let pipelineMock;
 
         beforeEach(() => {
             jobMock = getJobsMocks(testJob);
+            pipelineMock = getPipelineMocks(testPipeline);
+            pipelineMock.name = 'foo/bar';
             jobFactoryMock.get.resolves(jobMock);
+            pipelineFactoryMock.get.resolves(pipelineMock);
         });
 
         it('returns 302 to for a valid build', () =>
             server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
                 assert.deepEqual(reply.headers.location,
-                    'deploy/success/green');
+                    'foo/bar:deploy/success/green');
             })
         );
 


### PR DESCRIPTION
- Add new statuses mapping for badge
- modify the format a little bit, now it will have the pipeline name as prefix for both pipeline and job badge
<img width="133" alt="Screen Shot 2019-03-25 at 5 42 28 PM" src="https://user-images.githubusercontent.com/20427140/54963286-7497cb00-4f25-11e9-8206-a0158480bd14.png">
<img width="156" alt="Screen Shot 2019-03-25 at 5 42 59 PM" src="https://user-images.githubusercontent.com/20427140/54963287-75c8f800-4f25-11e9-81cb-4d610e8517a0.png">


Related to: https://github.com/screwdriver-cd/screwdriver/issues/1451