### PR TITLE
fix: encode subject based on badge service separator

### DIFF
--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -45,6 +45,28 @@ exports.register = (server, options, next) => {
     };
 
     /**
+     * Returns an encoded string of subject based on seperator of the badge service
+     * @method encodeBadgeSubject
+     * @param  {String} badgeService           badge service url
+     * @param  {String} subject                subject to put in the badge
+     * @return {String} encodedSubject
+     */
+    server.expose('encodeBadgeSubject', ({ badgeService, subject }) => {
+        const seperator = badgeService.match(/}}(.){{/)[1];
+
+        if (seperator === '/') {
+            return encodeURIComponent(subject);
+        }
+
+        // Reference: https://shields.io/
+        if (seperator === '-') {
+            return subject.replace(/-/g, '--').replace(/_/g, '__');
+        }
+
+        return subject;
+    });
+
+    /**
      * Returns true if the scope does not include pipeline or includes pipeline
      * and it's pipelineId matches the pipeline, otherwise returns false
      * @method isValidToken

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -45,21 +45,21 @@ exports.register = (server, options, next) => {
     };
 
     /**
-     * Returns an encoded string of subject based on seperator of the badge service
+     * Returns an encoded string of subject based on separator of the badge service
      * @method encodeBadgeSubject
      * @param  {String} badgeService           badge service url
      * @param  {String} subject                subject to put in the badge
      * @return {String} encodedSubject
      */
     server.expose('encodeBadgeSubject', ({ badgeService, subject }) => {
-        const seperator = badgeService.match(/}}(.){{/)[1];
+        const separator = badgeService.match(/}}(.){{/)[1];
 
-        if (seperator === '/') {
+        if (separator === '/') {
             return encodeURIComponent(subject);
         }
 
         // Reference: https://shields.io/
-        if (seperator === '-') {
+        if (separator === '-') {
             return subject.replace(/-/g, '--').replace(/_/g, '__');
         }
 

--- a/plugins/pipelines/jobBadge.js
+++ b/plugins/pipelines/jobBadge.js
@@ -8,11 +8,14 @@ const idSchema = joi.reach(schema.models.pipeline.base, 'id');
 /**
  * Generate Badge URL
  * @method getUrl
- * @param  {string}  badgeService    Template URL for badges - needs {{status}} and {{color}}
- * @param  {Array}  [builds]         An array of builds
- * @return {string}                  URL to redirect to
+ * @param  {String} badgeService            Badge service url
+ * @param  {Object} statusColor             Mapping for status and color
+ * @param  {Function} encodeBadgeSubject    Function to encode subject
+ * @param  {Array}  [builds=[]]             An array of builds
+ * @param  {String} [subject='job']         Subject of the badge
+ * @return {String}
  */
-function getUrl({ badgeService, statusColor, builds = [], subject = 'job' }) {
+function getUrl({ badgeService, statusColor, encodeBadgeSubject, builds = [], subject = 'job' }) {
     let color = 'lightgrey';
     let status = '';
 
@@ -22,7 +25,7 @@ function getUrl({ badgeService, statusColor, builds = [], subject = 'job' }) {
     }
 
     return tinytim.tim(badgeService, {
-        subject,
+        subject: encodeBadgeSubject({ badgeService, subject }),
         status,
         color
     });
@@ -40,10 +43,12 @@ module.exports = config => ({
             const pipelineFactory = request.server.app.pipelineFactory;
             const { id, jobName } = request.params;
             const badgeService = request.server.app.ecosystem.badges;
+            const encodeBadgeSubject = request.server.plugins.pipelines.encodeBadgeSubject;
             const { statusColor } = config;
             const badgeConfig = {
                 badgeService,
-                statusColor
+                statusColor,
+                encodeBadgeSubject
             };
 
             return Promise.all([

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -803,11 +803,12 @@ describe('pipeline plugin test', () => {
         });
 
         it('returns 302 to unknown when the datastore returns an error', () => {
+            server.app.ecosystem.badges = '{{subject}}*{{status}}*{{color}}';
             jobFactoryMock.get.rejects(new Error('icantdothatdave'));
 
             return server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'job--lightgrey');
+                assert.deepEqual(reply.headers.location, 'job**lightgrey');
             });
         });
     });

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -720,7 +720,7 @@ describe('pipeline plugin test', () => {
             server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
                 assert.deepEqual(reply.headers.location,
-                    'foo/bar/1 unknown, 1 success, 1 failure/red');
+                    'foo%2Fbar/1 unknown, 1 success, 1 failure/red');
             })
         );
 
@@ -729,7 +729,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'foo/bar/1 success, 1 failure/red');
+                assert.deepEqual(reply.headers.location, 'foo%2Fbar/1 success, 1 failure/red');
             });
         });
 
@@ -777,9 +777,10 @@ describe('pipeline plugin test', () => {
         let pipelineMock;
 
         beforeEach(() => {
+            server.app.ecosystem.badges = '{{subject}}-{{status}}-{{color}}';
             jobMock = getJobsMocks(testJob);
             pipelineMock = getPipelineMocks(testPipeline);
-            pipelineMock.name = 'foo/bar';
+            pipelineMock.name = 'foo/bar-test';
             jobFactoryMock.get.resolves(jobMock);
             pipelineFactoryMock.get.resolves(pipelineMock);
         });
@@ -788,7 +789,7 @@ describe('pipeline plugin test', () => {
             server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
                 assert.deepEqual(reply.headers.location,
-                    'foo/bar:deploy/success/green');
+                    'foo/bar--test:deploy-success-green');
             })
         );
 
@@ -797,7 +798,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'job//lightgrey');
+                assert.deepEqual(reply.headers.location, 'job--lightgrey');
             });
         });
 
@@ -806,7 +807,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'job//lightgrey');
+                assert.deepEqual(reply.headers.location, 'job--lightgrey');
             });
         });
     });


### PR DESCRIPTION
Different badge services may have different separators, e.g. https://shields.io/ uses `-` and internally we use `/`. This PR will properly encode the subject based on the specific separator.

current badge service:
https://github.com/screwdriver-cd/screwdriver/blob/master/config/default.yaml#L270

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1451