### PR TITLE
fix: allow build to get meta

### DIFF
--- a/plugins/jobs/lastSuccessfulMeta.js
+++ b/plugins/jobs/lastSuccessfulMeta.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'jobs', 'builds'],
         auth: {
             strategies: ['token'],
-            scope: ['user', 'pipeline']
+            scope: ['user', 'build', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
Allow build scope to call this endpoint. No reason to restrict it since `build` can also call GET jobs or GET builds. 
@chestery 