### PR TITLE
fix: display disabled state for job badge

### DIFF
--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -32,6 +32,7 @@ const metricsRoute = require('./metrics');
 exports.register = (server, options, next) => {
     const statusColor = {
         unknown: 'lightgrey',
+        disabled: 'lightgrey',
         created: 'lightgrey',
         success: 'green',
         queued: 'blue',

--- a/plugins/pipelines/jobBadge.js
+++ b/plugins/pipelines/jobBadge.js
@@ -62,6 +62,17 @@ module.exports = config => ({
                     return reply.redirect(getUrl(badgeConfig));
                 }
 
+                if (job.state === 'DISABLED') {
+                    return reply.redirect(getUrl(Object.assign(
+                        badgeConfig,
+                        {
+                            builds: [{
+                                status: 'DISABLED'
+                            }],
+                            subject: `${pipeline.name}:${jobName}`
+                        })));
+                }
+
                 const listConfig = {
                     paginate: {
                         page: 1,

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -793,6 +793,16 @@ describe('pipeline plugin test', () => {
             })
         );
 
+        it('returns 302 to for a job that is disabled', () => {
+            jobMock.state = 'DISABLED';
+
+            return server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
+                assert.equal(reply.statusCode, 302);
+                assert.deepEqual(reply.headers.location,
+                    'foo/bar--test:deploy-disabled-lightgrey');
+            });
+        });
+
         it('returns 302 to unknown for a job that does not exist', () => {
             jobFactoryMock.get.resolves(null);
 


### PR DESCRIPTION
Currently, the job badge shows build status of the last build. This PR will show the state of the job if it is `DISABLED`.