### PR TITLE
fix: fix functional tests

### DIFF
--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -6,7 +6,7 @@ const sdapi = require('../support/sdapi');
 const github = require('../support/github');
 const { defineSupportCode } = require('cucumber');
 
-const TIMEOUT = 800 * 1000;
+const TIMEOUT = 500 * 1000;
 
 defineSupportCode(({ Before, Given, When, Then }) => {
     Before({
@@ -183,7 +183,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
     Then(/^any existing builds should be stopped$/, {
         timeout: TIMEOUT
     }, function step() {
-        const desiredStatus = ['ABORTED', 'SUCCESS'];
+        const desiredStatus = ['ABORTED', 'SUCCESS', 'FAILURE'];
 
         return sdapi.waitForBuildStatus({
             buildId: this.previousBuildId,

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -73,8 +73,7 @@ function closePullRequest(token, repoOwner, repoName, prNumber) {
         owner: repoOwner,
         repo: repoName,
         number: prNumber,
-        state: 'closed',
-        base: 'master'
+        state: 'closed'
     });
 }
 


### PR DESCRIPTION
- to close a PR, we only need to change the `state`, `base` means want to update it to a new value which is not needed for us
https://octokit.github.io/rest.js/#api-Pulls-update

- we get timeout very often for test case `any existing builds should be stopped`, that's because we keep waiting until we get status `SUCCESS` or `ABORTED`, but the status sometimes can be `FAILURE` when git is slow and api cannot get `screwdriver.yaml` .
https://cd.screwdriver.cd/pipelines/2080/builds/95446
