### PR TITLE
fix(1010): [3] Fix the error from forked repository

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -30,11 +30,11 @@ const workflowParser = require('screwdriver-workflow-parser');
  */
 async function createBuild({ jobFactory, buildFactory, eventFactory, pipelineId,
     jobName, username, scmContext, build, start }) {
-    const event = await eventFactory.get(build.eventId).catch(err => reply(boom.boomify(err)));
+    const event = await eventFactory.get(build.eventId);
     const job = await jobFactory.get({
         name: jobName,
         pipelineId
-    }).catch(err => reply(boom.boomify(err)));
+    });
     const prRef = event.pr.ref ? event.pr.ref : '';
 
     if (job.state === 'ENABLED') {

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const boom = require('boom');
 const getRoute = require('./get');
 const updateRoute = require('./update');
 const createRoute = require('./create');

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -311,6 +311,7 @@ describe('build plugin test', () => {
                         { src: '~commit', dest: 'main' }
                     ]
                 },
+                pr: {},
                 getBuilds: sinon.stub(),
                 update: sinon.stub(),
                 toJson: sinon.stub().returns({ id: 123 })
@@ -1032,8 +1033,6 @@ describe('build plugin test', () => {
                     state: 'ENABLED'
                 };
                 const src = `~sd@${pipelineId}:main`;
-                const token = 'token';
-                let prRef = '';
 
                 beforeEach(() => {
                     eventMock.workflowGraph = {
@@ -1083,7 +1082,7 @@ describe('build plugin test', () => {
                             scmContext,
                             eventId: 'bbf22a3808c19dc50777258a253805b14fb3ad8b',
                             configPipelineSha,
-                            prRef,
+                            prRef: '',
                             start: true
                         });
                         assert.calledWith(triggerFactoryMock.list, {
@@ -1131,11 +1130,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    prRef = 'prref';
-
-                    // Event type should be `pr` in chainPR events
-                    eventMock.type = 'pr';
-                    eventMock.prNum = 15;
+                    eventMock.pr = { ref: 'pull/15/merge' };
 
                     jobMock.name = 'PR-15:main';
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'PR-15:publish' })
@@ -1143,11 +1138,6 @@ describe('build plugin test', () => {
 
                     // flag should be true in chainPR events
                     pipelineMock.prChain = true;
-                    pipelineMock.token = sinon.stub().resolves(token);
-                    buildFactoryMock.scm.getPrInfo.resolves({
-                        sha: testBuild.sha,
-                        ref: prRef
-                    });
 
                     // Set no external pipeline
                     triggerMocks = [
@@ -1157,13 +1147,6 @@ describe('build plugin test', () => {
                     return server.inject(options).then((reply) => {
                         assert.equal(reply.statusCode, 200);
                         assert.isTrue(buildMock.update.calledBefore(buildFactoryMock.create));
-                        assert.calledOnce(buildFactoryMock.scm.getPrInfo);
-                        assert.calledWith(buildFactoryMock.scm.getPrInfo, {
-                            scmContext,
-                            scmUri,
-                            token: pipelineMock.token,
-                            prNum: eventMock.prNum
-                        });
                         assert.calledWith(buildFactoryMock.create, {
                             jobId: publishJobId,
                             sha: testBuild.sha,
@@ -1172,7 +1155,7 @@ describe('build plugin test', () => {
                             scmContext,
                             eventId: 'bbf22a3808c19dc50777258a253805b14fb3ad8b',
                             configPipelineSha,
-                            prRef,
+                            prRef: eventMock.pr.ref,
                             start: true
                         });
                         // Events should not be created if there is no external pipeline
@@ -1287,7 +1270,6 @@ describe('build plugin test', () => {
                     state: 'ENABLED'
                 };
                 const jobC = Object.assign({}, jobB, { id: 3 });
-                const prRef = '';
                 let jobBconfig;
                 let jobCconfig;
                 let parentEventMock;
@@ -1338,7 +1320,7 @@ describe('build plugin test', () => {
                         username: 12345,
                         scmContext: 'github:github.com',
                         configPipelineSha: 'abc123',
-                        prRef
+                        prRef: ''
                     };
                     jobCconfig = Object.assign({}, jobBconfig, { jobId: 3 });
                 });


### PR DESCRIPTION
## Context
Now, job error happens in PRs from forked repository, because `sd-scm-github` step tries to `git reset` with the commit SHA of forked repository which dose not exist in original one.
This is because there is no `config.prRef` value in argument below.
https://github.com/screwdriver-cd/scm-github/blob/master/index.js#L316

## Objective
In chainPR workflow, we should pass the `prRef` value to the buildFactory.create() method.
To achieve this, 
1. We need to set `prRef` into the events model  when event is created.
2. Then, we can get `prRef` from events model like `event.pr.ref`;

## References
Issue:
https://github.com/screwdriver-cd/screwdriver/issues/1010#issuecomment-478911280

Other PRs:
[1]: data-schema: https://github.com/screwdriver-cd/data-schema/pull/327
[2]: models: https://github.com/screwdriver-cd/models/pull/359