### PR TITLE
 fix: set default unknow status for badge

### DIFF
--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -41,7 +41,7 @@ function getUrl({
 
     return tinytim.tim(badgeService, {
         subject: encodeBadgeSubject({ badgeService, subject }),
-        status: parts.join(', '),
+        status: parts.length > 0 ? parts.join(', ') : 'unknown',
         color: worst
     });
 }

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -32,6 +32,7 @@ const metricsRoute = require('./metrics');
 exports.register = (server, options, next) => {
     const statusColor = {
         unknown: 'lightgrey',
+        disabled: 'lightgrey',
         created: 'lightgrey',
         success: 'green',
         queued: 'blue',

--- a/plugins/pipelines/jobBadge.js
+++ b/plugins/pipelines/jobBadge.js
@@ -62,6 +62,17 @@ module.exports = config => ({
                     return reply.redirect(getUrl(badgeConfig));
                 }
 
+                if (job.state === 'DISABLED') {
+                    return reply.redirect(getUrl(Object.assign(
+                        badgeConfig,
+                        {
+                            builds: [{
+                                status: 'DISABLED'
+                            }],
+                            subject: `${pipeline.name}:${jobName}`
+                        })));
+                }
+
                 const listConfig = {
                     paginate: {
                         page: 1,

--- a/plugins/pipelines/jobBadge.js
+++ b/plugins/pipelines/jobBadge.js
@@ -17,7 +17,7 @@ const idSchema = joi.reach(schema.models.pipeline.base, 'id');
  */
 function getUrl({ badgeService, statusColor, encodeBadgeSubject, builds = [], subject = 'job' }) {
     let color = 'lightgrey';
-    let status = '';
+    let status = 'unknown';
 
     if (builds.length > 0) {
         status = builds[0].status.toLowerCase();

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -793,6 +793,16 @@ describe('pipeline plugin test', () => {
             })
         );
 
+        it('returns 302 to for a job that is disabled', () => {
+            jobMock.state = 'DISABLED';
+
+            return server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
+                assert.equal(reply.statusCode, 302);
+                assert.deepEqual(reply.headers.location,
+                    'foo/bar--test:deploy-disabled-lightgrey');
+            });
+        });
+
         it('returns 302 to unknown for a job that does not exist', () => {
             jobFactoryMock.get.resolves(null);
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -738,7 +738,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'pipeline//lightgrey');
+                assert.deepEqual(reply.headers.location, 'pipeline/unknown/lightgrey');
             });
         });
 
@@ -747,7 +747,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'pipeline//lightgrey');
+                assert.deepEqual(reply.headers.location, 'pipeline/unknown/lightgrey');
             });
         });
 
@@ -756,7 +756,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'pipeline//lightgrey');
+                assert.deepEqual(reply.headers.location, 'pipeline/unknown/lightgrey');
             });
         });
 
@@ -765,7 +765,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'pipeline//lightgrey');
+                assert.deepEqual(reply.headers.location, 'pipeline/unknown/lightgrey');
             });
         });
     });
@@ -808,7 +808,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'job--lightgrey');
+                assert.deepEqual(reply.headers.location, 'job-unknown-lightgrey');
             });
         });
 
@@ -818,7 +818,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(`/pipelines/${id}/${jobName}/badge`).then((reply) => {
                 assert.equal(reply.statusCode, 302);
-                assert.deepEqual(reply.headers.location, 'job**lightgrey');
+                assert.deepEqual(reply.headers.location, 'job*unknown*lightgrey');
             });
         });
     });


### PR DESCRIPTION
If there is no builds, set the default `status` to `unknown`. 