### PR TITLE
fix(1058): Allow creator and cause message to be passed into event create (3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "screwdriver-config-parser": "^4.11.1",
     "screwdriver-coverage-bookend": "^1.0.2",
     "screwdriver-coverage-sonar": "^1.0.16",
-    "screwdriver-data-schema": "^18.45.1",
+    "screwdriver-data-schema": "^18.45.2",
     "screwdriver-datastore-sequelize": "^5.7.1",
     "screwdriver-executor-docker": "^4.2.0",
     "screwdriver-executor-k8s": "^13.6.1",

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -66,6 +66,8 @@ module.exports = () => ({
             const username = request.auth.credentials.username;
             const isValidToken = request.server.plugins.pipelines.isValidToken;
             const meta = request.payload.meta;
+            const causeMessage = request.payload.causeMessage;
+            const creator = request.payload.creator;
 
             return Promise.resolve().then(() => {
                 const buildId = request.payload.buildId;
@@ -109,6 +111,14 @@ module.exports = () => ({
 
                 if (meta) {
                     payload.meta = meta;
+                }
+
+                if (causeMessage) {
+                    payload.causeMessage = causeMessage;
+                }
+
+                if (creator) {
+                    payload.creator = creator;
                 }
 
                 // Trigger "~pr" needs to have PR number given


### PR DESCRIPTION
## Context
When an event is started by a periodic build, it can be hard for users to know if the build was started manually by a user, through a commit, or by Screwdriver automatically.

## Objective
This PR allows `creator` and `causeMessage` to be passed into POST event endpoint.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1058
Blocked by https://github.com/screwdriver-cd/data-schema/pull/329, https://github.com/screwdriver-cd/models/pull/367