### PR TITLE
feat(1333): List pipeline triggers (2)

### DIFF
--- a/plugins/events/README.md
+++ b/plugins/events/README.md
@@ -39,6 +39,9 @@ server.register({
 
 `GET /events/{id}/metrics?startTime=2019-02-01T12:00:00.000Z&endTime=2019-03-01T12:00:00.000`
 
+#### Stops all builds associated with the event
+`PUT /events/{id}/stop`
+
 
 ### Access to Factory methods
 The server supplies factories to plugins in the form of server app values:

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -106,6 +106,10 @@ Only PR events of specified PR number will be searched when `prNum` is set
 
 `GET /pipelines/{id}/jobs?archived={boolean}`
 
+#### Get all triggers
+
+`GET /pipelines/{id}/triggers`
+
 #### Get all pipeline secrets
 
 `GET /pipelines/{id}/secrets`

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -11,6 +11,7 @@ const listRoute = require('./list');
 const badgeRoute = require('./badge');
 const jobBadgeRoute = require('./jobBadge');
 const listJobsRoute = require('./listJobs');
+const listTriggersRoute = require('./listTriggers');
 const listSecretsRoute = require('./listSecrets');
 const listEventsRoute = require('./listEvents');
 const startAllRoute = require('./startAll');
@@ -93,6 +94,7 @@ exports.register = (server, options, next) => {
         badgeRoute({ statusColor }),
         jobBadgeRoute({ statusColor }),
         listJobsRoute(),
+        listTriggersRoute(),
         listSecretsRoute(),
         listEventsRoute(),
         startAllRoute(),

--- a/plugins/pipelines/listTriggers.js
+++ b/plugins/pipelines/listTriggers.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const { EXTERNAL_TRIGGER, JOB_NAME } = schema.config.regex;
+const destSchema = joi.string().regex(EXTERNAL_TRIGGER).max(64);
+const listSchema = joi.array().items(joi.object({
+    jobName: JOB_NAME,
+    triggers: joi.array().items(destSchema)
+})).label('List of triggers');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipelines/{id}/triggers',
+    config: {
+        description: 'Get all jobs for a given pipeline',
+        notes: 'Returns all jobs for a given pipeline',
+        tags: ['api', 'pipelines', 'jobs'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build', 'pipeline']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const { pipelineFactory, triggerFactory } = request.server.app;
+            const pipelineId = request.params.id;
+
+            return pipelineFactory.get(pipelineId)
+                .then((pipeline) => {
+                    if (!pipeline) {
+                        throw boom.notFound('Pipeline does not exist');
+                    }
+
+                    return triggerFactory.getTriggers({ pipelineId });
+                })
+                .then(triggers => reply(triggers.map(t => t.toJson())))
+                .catch(err => reply(boom.boomify(err)));
+        },
+        response: {
+            schema: listSchema
+        }
+    }
+});

--- a/test/plugins/data/triggers.json
+++ b/test/plugins/data/triggers.json
@@ -1,0 +1,14 @@
+[
+    {
+        "jobName": "main",
+        "triggers": ["~sd@123:main", "~sd@234:main"]
+    },
+    {
+        "jobName": "beta",
+        "triggers": []
+    },
+    {
+        "jobName": "prod",
+        "triggers": ["~sd@345:beta", "~sd@456:deploy"]
+    }
+]


### PR DESCRIPTION
## Context
It would be nice if users could see what pipelines/jobs run after jobs in their pipeline are done.

## Objective
This PR adds an endpoint `GET /pipelines/{id}/triggers` that returns an object with jobName and destination trigger data.

Example output:
```
[{
  jobName: 'main',
  triggers: ['~sd@12345:main']
}, {
  jobName: 'beta',
  triggers: ['~sd@12345:test', '~sd@223344:test']
}, {
  jobName: 'prod',
  triggers: ['~sd@556677:deploy']
}]
```

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1333