### PR TITLE
fix(1590): fix readonly

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -33,7 +33,7 @@ const multiBuildClusterEnabled = config.get('multiBuildCluster').enabled;
 const datastoreConfig = config.get('datastore');
 const DatastorePlugin = require(`screwdriver-datastore-${datastoreConfig.plugin}`);
 
-const datastorePluginConfig = datastoreConfig[datastoreConfig.plugin];
+const datastorePluginConfig = Object.assign({}, datastoreConfig[datastoreConfig.plugin]);
 
 // Readonly Datastore
 const datastoreROConfig = datastorePluginConfig.readOnly;
@@ -46,7 +46,7 @@ delete datastorePluginConfig.readOnly;
 
 // Default datastore
 const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem },
-    (datastoreConfig[datastoreConfig.plugin] || {})));
+    (datastorePluginConfig || {})));
 
 // Source Code Plugin
 const scmConfig = { scms: config.get('scms') };


### PR DESCRIPTION
This line `delete datastorePluginConfig.readOnly;` is giving problem:
```
TypeError: Cannot delete property 'readOnly' of #<Object>
```

Looks like `config.get` returns non-writable value. This PR will clone the Obj first before deleting. 
