### PR TITLE
fix: call pipeline.getJobs instead of pipeline.jobs

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -362,7 +362,7 @@ async function pullRequestClosed(options, request, reply) {
     }
 
     return pipeline.sync()
-        .then(p => p.jobs)
+        .then(p => p.getJobs({ type: 'pr' }))
         .then((jobs) => {
             const prJobs = jobs.filter(j => j.name.includes(name));
 
@@ -404,7 +404,7 @@ async function pullRequestSync(options, request, reply) {
 
         options.resolvedChainPR = resolveChainPR(chainPR, p);
 
-        await p.jobs.then(jobs => jobs.filter(j => j.name.includes(name)))
+        await p.getJobs({ type: 'pr' }).then(jobs => jobs.filter(j => j.name.includes(name)))
             .then(prJobs => Promise.all(prJobs.map(j => stopJob({ job: j, prNum, action }))));
 
         request.log(['webhook', hookId], `Job(s) for ${name} stopped`);

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -365,7 +365,7 @@ describe('webhooks plugin test', () => {
                 workflowGraph,
                 sync: sinon.stub(),
                 getConfiguration: sinon.stub(),
-                jobs: Promise.resolve([mainJobMock, jobMock]),
+                getJobs: sinon.stub().resolves([mainJobMock, jobMock]),
                 branch: Promise.resolve('master'),
                 update: sinon.stub()
             };


### PR DESCRIPTION
call pipeline.getJobs to get non-archived pr jobs instead of calling pipeline.jobs to get all the jobs

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1603
