### PR TITLE
fix: fix flaky join functional tests

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -40,7 +40,7 @@ async function createBuild({ jobFactory, buildFactory, eventFactory, pipelineId,
         return buildFactory.create({
             jobId: job.id,
             sha: build.sha,
-            parentBuildId: build.id,
+            parentBuildId: [build.id],
             eventId: build.eventId,
             username,
             configPipelineSha: event.configPipelineSha,

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -122,12 +122,11 @@ function handleNextBuild({ buildConfig, joinList, finishedBuilds, jobId }) {
         if (!noFailedBuilds) {
             return nextBuild ? nextBuild.remove() : null;
         }
-        
-        
+
         // Get upstream buildIds
         const successBuildsIds = successBuildsInJoinList(joinList, finishedBuilds)
             .map(b => b.id);
-        
+
         buildConfig.parentBuildId = successBuildsIds;
 
         // If everything successful so far, create or update
@@ -138,7 +137,7 @@ function handleNextBuild({ buildConfig, joinList, finishedBuilds, jobId }) {
 
             return createBuild(buildConfig);
         }
-        
+
         nextBuild.parentBuildId = successBuildsIds;
 
         return nextBuild.update();


### PR DESCRIPTION
We're getting the following err in func test very often. Trace the code a little bit and found that this is caused by a race condition, when the two upstream builds finish around the same time, they will both try to create the downstream build which is setting the parentBuildId as a String. And eventually one of them won and the `parentBuildId` is the id of the last job instead of an array. 

This PR will fetch the upstreamBuildIds first before creating the build.

```
Step: Then the "JOIN" job is triggered from "PARALLEL1" and "PARALLEL2" - features/workflow.feature:68
12:11:57      Step Definition: features/step_definitions/workflow.js:124
12:11:57      Message:
12:11:57        AssertionError: expected 56372 to be an array
```


