### PR TITLE
fix: fix response code check for DELETE command api

### DIFF
--- a/features/step_definitions/sd-cmd.js
+++ b/features/step_definitions/sd-cmd.js
@@ -66,7 +66,8 @@ defineSupportCode(({ Before, Given, When, Then }) => {
                     return;
                 }
 
-                request({
+                /* eslint-disable-next-line consistent-return */
+                return request({
                     uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
                     + `/${this.command}`,
                     method: 'DELETE',

--- a/plugins/commands/remove.js
+++ b/plugins/commands/remove.js
@@ -33,7 +33,7 @@ function removeCommand(command, storeUrl, authToken) {
             return resolve(response);
         });
     }).then((response) => {
-        if (response.statusCode !== 200) {
+        if (response.statusCode !== 204) {
             throw new Error('An error occured when '
                 + `trying to remove binary from the store:${response.body.message}`);
         }

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -449,10 +449,6 @@ describe('command plugin test', () => {
 
             commandFactoryMock.list.resolves([testCommand]);
             commandTagFactoryMock.list.resolves([testCommandTag]);
-
-            /* nock('http://store.example.com')
-                .delete('/v1/commands/foo/bar/1.0.0')
-                .reply(200, ''); */
         });
 
         afterEach(() => {
@@ -522,7 +518,7 @@ describe('command plugin test', () => {
         it('deletes command if admin user credentials provided and command exists', () => {
             nock('http://store.example.com')
                 .delete('/v1/commands/foo/bar/1.0.0')
-                .reply(200, '');
+                .reply(204, '');
 
             return server.inject(options).then((reply) => {
                 assert.calledOnce(testCommand.remove);
@@ -608,7 +604,7 @@ describe('command plugin test', () => {
         it('deletes command if build credentials provided and pipelineIds match', () => {
             nock('http://store.example.com')
                 .delete('/v1/commands/foo/bar/1.0.0')
-                .reply(200, '');
+                .reply(204, '');
 
             options = {
                 method: 'DELETE',


### PR DESCRIPTION
## Context
- sd-cmd feature test has an error but it's not caught.
    - https://cd.screwdriver.cd/pipelines/1/builds/112699/steps/test
- command DELETE api returns 500 because of checking invalid response code.
    - [Store returns 204](https://github.com/screwdriver-cd/store/blob/1dda93eb2ddb07499561e001079ff37b9cbeb5a8/plugins/commands.js#L145) when deleting command but api expects 200.
    - Command binaries are deleted from s3 (or compatible) but command metadata are not deleted from a datastore. 

## Objective
- This PR enables to catch an error which is caused by DELETE api on sd-cmd feature test.
- This PR also fixes expected response code.