### PR TITLE
fix: convert number to string

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -30,7 +30,12 @@ const notificationConfig = config.get('notifications');
 const multiBuildClusterEnabled = config.get('multiBuildCluster').enabled;
 
 // Default cluster environment variable
-const clusterEnv = config.get('build').environment;
+const clusterEnvConfig = config.get('build').environment; // readonly
+const clusterEnv = Object.assign({}, clusterEnvConfig);
+
+Object.keys(clusterEnv).forEach((k) => {
+    clusterEnv[k] = String(clusterEnv[k]);
+});
 
 // Setup Datastore
 const datastoreConfig = config.get('datastore');


### PR DESCRIPTION
We set default cluster env as `SD_VERSION:4`
However, launcher expects environment to be type `string:string`
Converting here so that cluster admins don't need to remember to set it to string. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1070
