### PR TITLE
fix(1333): Remove toJson for triggers result

### DIFF
--- a/plugins/pipelines/listTriggers.js
+++ b/plugins/pipelines/listTriggers.js
@@ -38,7 +38,7 @@ module.exports = () => ({
 
                     return triggerFactory.getTriggers({ pipelineId });
                 })
-                .then(triggers => reply(triggers.map(t => t.toJson())))
+                .then(triggers => reply(triggers))
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -72,22 +72,6 @@ const getJobsMocks = (jobs) => {
     return decorateJobMock(jobs);
 };
 
-const decorateTriggerMock = (trigger) => {
-    const mock = hoek.clone(trigger);
-
-    mock.toJson = sinon.stub().returns(trigger);
-
-    return mock;
-};
-
-const getTriggersMocks = (triggers) => {
-    if (Array.isArray(triggers)) {
-        return triggers.map(decorateTriggerMock);
-    }
-
-    return decorateTriggerMock(triggers);
-};
-
 const decoratePipelineMock = (pipeline) => {
     const mock = hoek.clone(pipeline);
 
@@ -732,7 +716,7 @@ describe('pipeline plugin test', () => {
                 url: `/pipelines/${id}/triggers`
             };
             pipelineMock = getPipelineMocks(testPipeline);
-            triggerFactoryMock.getTriggers.resolves(getTriggersMocks(testTriggers));
+            triggerFactoryMock.getTriggers.resolves(testTriggers);
             pipelineFactoryMock.get.resolves(pipelineMock);
         });
 


### PR DESCRIPTION
## Context

Models already handles getTriggers result, so no need to do an additional `toJson` here.

## Objective

This PR removes `toJson` from getTriggers result.
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1333