### PR TITLE
fix: fix search pattern to get triggered pipelines

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -247,7 +247,7 @@ async function triggeredPipelines(pipelineFactory, scmConfig, branch, type, acti
     const { scmUri } = scmConfig;
     const splitUri = scmUri.split(':');
     const scmRepoId = `${splitUri[0]}:${splitUri[1]}`;
-    const listConfig = { search: { field: 'scmUri', keyword: `${scmRepoId}%` } };
+    const listConfig = { search: { field: 'scmUri', keyword: `${scmRepoId}:%` } };
 
     const pipelines = await pipelineFactory.list(listConfig);
 

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -493,7 +493,7 @@ describe('webhooks plugin test', () => {
                 return server.inject(options).then((reply) => {
                     assert.equal(reply.statusCode, 201);
                     assert.calledWith(pipelineFactoryMock.list, {
-                        search: { field: 'scmUri', keyword: 'github.com:123456%' } });
+                        search: { field: 'scmUri', keyword: 'github.com:123456:%' } });
                     assert.calledWith(eventFactoryMock.create, {
                         pipelineId: pipelineMock.id,
                         type: 'pipeline',


### PR DESCRIPTION
## Context
`triggeredPipelines`  gets triggered pipelines based on same SCM repo ID,
but it also get another pipelines based on different SCM repo IDs, which caused by incorrect search query.
Given scmRepoId `github:123:master`, current `triggeredPipelines` fetches also pipelines of `github:1237` and `github:123245`.

## Objective
This fix `triggeredPipelines` to get correct pipelines.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
