### PR TITLE
fix: upgrade screwdriver-coverage-sonar

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "screwdriver-command-validator": "^1.0.5",
     "screwdriver-config-parser": "^4.11.1",
     "screwdriver-coverage-bookend": "^1.0.2",
-    "screwdriver-coverage-sonar": "^1.0.22",
+    "screwdriver-coverage-sonar": "^1.0.23",
     "screwdriver-data-schema": "^18.46.3",
     "screwdriver-datastore-sequelize": "^5.7.2",
     "screwdriver-executor-docker": "^4.2.0",


### PR DESCRIPTION
## Context

Upgrading screwdriver-coverage-sonar to pull in https://github.com/screwdriver-cd/coverage-sonar/pull/24

## Objective

This upgrades sonar-scanner-cli to latest version

## References

https://github.com/screwdriver-cd/coverage-sonar/pull/24

