### PR TITLE
fix: tag/release are triggered by every branch pipelines

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -31,8 +31,7 @@ function determineStartFrom(action, type, targetBranch, pipelineBranch) {
     } else {
         switch (action) {
         case 'release':
-            startFrom = '~release';
-            break;
+            return '~release';
         case 'tag':
             return '~tag';
         default:

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -34,8 +34,7 @@ function determineStartFrom(action, type, targetBranch, pipelineBranch) {
             startFrom = '~release';
             break;
         case 'tag':
-            startFrom = '~tag';
-            break;
+            return '~tag';
         default:
             startFrom = '~commit';
             break;

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -89,14 +89,14 @@ describe('webhooks.determineStartFrom', () => {
         );
     });
 
-    it('determines to "~release:branch" when action is "release" and targetBranch is branch',
+    it('determines to "~release" when action is "release" even targetBranch is branch',
         () => {
             action = 'release';
             targetBranch = 'branch';
 
             assert.equal(
                 determineStartFrom(action, type, targetBranch, pipelineBranch),
-                '~release:branch'
+                '~release'
             );
         });
 
@@ -109,7 +109,7 @@ describe('webhooks.determineStartFrom', () => {
         );
     });
 
-    it('determines to "~tag" when action is "tag" and even targetBranch is branch',
+    it('determines to "~tag" when action is "tag" even targetBranch is branch',
         () => {
             action = 'tag';
             targetBranch = 'branch';
@@ -539,7 +539,7 @@ describe('webhooks plugin test', () => {
                 });
             });
 
-            it('returns 201 on success with non target branch pipeline tag trigger', () => {
+            it('returns 201 with non target branch pipeline tag trigger', () => {
                 const tagWorkflowMock = {
                     nodes: [
                         { name: '~tag' },
@@ -680,20 +680,21 @@ describe('webhooks plugin test', () => {
                 });
             });
 
-            it('returns 201 on success with release branch trigger', () => {
+            it('returns 201 with release non target branch pipeline release trigger', () => {
                 const releaseWorkflowMock = {
                     nodes: [
-                        { name: '~release:branch' },
+                        { name: '~release' },
                         { name: 'main' }
                     ],
                     edges: [
-                        { src: '~release:branch', dest: 'main' }
+                        { src: '~release', dest: 'main' }
                     ]
                 };
 
                 parsed.branch = 'branch';
-                mainJobMock.requires = '~release:branch';
+                mainJobMock.requires = '~release';
                 pipelineMock.workflowGraph = releaseWorkflowMock;
+                pipelineMock.baxterthehacker = 'master';
                 pipelineMock.jobs = Promise.resolve([mainJobMock]);
                 pipelineFactoryMock.list.resolves([pipelineMock]);
                 pipelineFactoryMock.scm.parseUrl.resolves(scmUri);
@@ -708,7 +709,7 @@ describe('webhooks plugin test', () => {
                         scmContext,
                         sha,
                         configPipelineSha: latestSha,
-                        startFrom: '~release:branch',
+                        startFrom: '~release',
                         commitBranch: 'branch',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: undefined,


### PR DESCRIPTION
## Context
`~tag` trigger is not triggered, if you use a pipeline that targets to the non master branch. Only these pipeline have `~tag:master`, the trigger will fire. 
When user creates a tag, all branch pipeline should trigger `~tag` trigger.

The same is the case with `~release` trigger

## Objective
All branch pipeline job search jobs which trigger from `~tag` and `~release`, when tag or release trigger was fired.

## Reference
#823 
On the second pass, tag and release trigger will have tag name filter function.