### PR TITLE
fix(1634): make restart PR build always use latest sha on the PR

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -180,7 +180,8 @@ module.exports = () => ({
                         // User has good permissions, create an event
                         .then(() => {
                             // If there is parentEvent, pass workflowGraph and sha to payload
-                            if (payload.parentEventId) {
+                            // Skip PR, for PR builds, we should always start from latest commit
+                            if (payload.parentEventId && !prNum) {
                                 return eventFactory.get(parentEventId)
                                     .then((parentEvent) => {
                                         payload.workflowGraph = parentEvent.workflowGraph;

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -523,8 +523,7 @@ describe('event plugin test', () => {
 
         it('returns 201 when it successfully creates a PR event with parent event', () => {
             eventConfig.parentEventId = parentEventId;
-            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
-            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.sha = testBuild.sha;
             eventConfig.startFrom = 'PR-1:main';
             eventConfig.prNum = '1';
             eventConfig.prRef = 'prref';
@@ -550,7 +549,7 @@ describe('event plugin test', () => {
                 assert.equal(reply.statusCode, 201);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
-                assert.notCalled(eventFactoryMock.scm.getCommitSha);
+                assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
             });


### PR DESCRIPTION
## Context

make restart PR build always use latest sha on the PR

## References

https://github.com/screwdriver-cd/screwdriver/issues/1634

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
