### PR TITLE
fix: [1] allow piped sd-cmd execution.

### DIFF
--- a/features/step_definitions/sd-cmd.js
+++ b/features/step_definitions/sd-cmd.js
@@ -162,7 +162,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
             }
         }).then((response) => {
             Assert.equal(response.statusCode, 200);
-            Assert.equal(response.body.command,
+            Assert.include(response.body.command,
                 `sd-cmd exec ${this.commandNamespace}/${this.command}@1 ${args}`);
         });
     });


### PR DESCRIPTION
## Context

Because we add piped `sd-cmd` execution test.

## Objective

This PR allows piped `sd-cmd` execution.
e.g. `dd if=/dev/zero bs=65537 count=1 | sd-cmd exec screwdriver-cd-test/binary-func-test@1 foo bar`

## References

- https://github.com/screwdriver-cd/sd-cmd/pull/35
- This blocks https://github.com/screwdriver-cd-test/functional-commands/pull/5

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
