### PR TITLE
fix: add admin only endpoint to mark "trusted"

### DIFF
--- a/plugins/commands/index.js
+++ b/plugins/commands/index.js
@@ -8,6 +8,7 @@ const listRoute = require('./list');
 const removeRoute = require('./remove');
 const listTagsRoute = require('./listTags');
 const listVersionsRoute = require('./listVersions');
+const updateTrustedRoute = require('./updateTrusted');
 
 /**
  * Command API Plugin
@@ -71,7 +72,8 @@ exports.register = (server, options, next) => {
         removeRoute(),
         listRoute(),
         listVersionsRoute(),
-        listTagsRoute()
+        listTagsRoute(),
+        updateTrustedRoute()
     ]);
 
     next();

--- a/plugins/commands/updateTrusted.js
+++ b/plugins/commands/updateTrusted.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const baseSchema = schema.models.command.base;
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/commands/{namespace}/{name}/trusted',
+    config: {
+        description: "Update a command's trusted property",
+        notes: 'Returns null if successful',
+        tags: ['api', 'commands', 'trusted'],
+        auth: {
+            strategies: ['token'],
+            scope: ['admin', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: async (request, reply) => {
+            const { name, namespace } = request.params;
+            const { commandFactory } = request.server.app;
+            const { trusted } = request.payload;
+
+            // get the earliest entry
+            const commands = await commandFactory.list({
+                params: { namespace, name },
+                paginate: { count: 1 },
+                sortBy: 'id',
+                sort: 'ascending'
+            });
+
+            if (commands.length === 0) {
+                throw boom.notFound(`Command ${namespace}/${name} does not exist`);
+            }
+
+            const command = commands[0];
+
+            command.trusted = trusted;
+
+            return command.update().then(() => reply().code(204), err => reply(boom.boomify(err)));
+        },
+        validate: {
+            params: {
+                namespace: joi.reach(baseSchema, 'namespace'),
+                name: joi.reach(baseSchema, 'name')
+            },
+            payload: {
+                trusted: joi.reach(baseSchema, 'trusted')
+            }
+        }
+    }
+});

--- a/plugins/templates/index.js
+++ b/plugins/templates/index.js
@@ -9,6 +9,7 @@ const listTagsRoute = require('./listTags');
 const listVersionsRoute = require('./listVersions');
 const removeRoute = require('./remove');
 const removeTagRoute = require('./removeTag');
+const updateTrustedRoute = require('./updateTrusted');
 
 /**
  * Template API Plugin
@@ -73,7 +74,8 @@ exports.register = (server, options, next) => {
         listTagsRoute(),
         listVersionsRoute(),
         removeRoute(),
-        removeTagRoute()
+        removeTagRoute(),
+        updateTrustedRoute()
     ]);
 
     next();

--- a/plugins/templates/updateTrusted.js
+++ b/plugins/templates/updateTrusted.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const baseSchema = schema.models.template.base;
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/templates/{name}/trusted',
+    config: {
+        description: "Update a template's trusted property",
+        notes: 'Returns null if successful',
+        tags: ['api', 'templates', 'trusted'],
+        auth: {
+            strategies: ['token'],
+            scope: ['admin', '!guest']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: async (request, reply) => {
+            const { name } = request.params;
+            const { templateFactory } = request.server.app;
+            const { trusted } = request.payload;
+
+            // get the earliest entry
+            const templates = await templateFactory.list({
+                params: { name },
+                paginate: { count: 1 },
+                sortBy: 'id',
+                sort: 'ascending'
+            });
+
+            if (templates.length === 0) {
+                throw boom.notFound(`Template ${name} does not exist`);
+            }
+
+            const template = templates[0];
+
+            template.trusted = trusted;
+
+            return template.update().then(() => reply().code(204), err => reply(boom.boomify(err)));
+        },
+        validate: {
+            params: {
+                name: joi.reach(baseSchema, 'name')
+            },
+            payload: {
+                trusted: joi.reach(baseSchema, 'trusted')
+            }
+        }
+    }
+});

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -1294,4 +1294,72 @@ describe('command plugin test', () => {
             });
         });
     });
+
+    describe('PUT /commands/trusted', () => {
+        let options;
+        let testCommand;
+
+        const payload = {
+            trusted: true
+        };
+
+        beforeEach(() => {
+            options = {
+                method: 'PUT',
+                url: '/commands/foo/bar/trusted',
+                payload,
+                credentials: {
+                    scope: ['admin']
+                }
+            };
+
+            testCommand = decorateObj({
+                id: 1,
+                namespace: 'foo',
+                name: 'bar',
+                tag: 'stable',
+                version: '1.0.0',
+                update: sinon.stub().resolves(null)
+            });
+
+            commandFactoryMock.list.resolves([testCommand]);
+        });
+
+        it('returns 404 when command does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Command foo/bar does not exist'
+            };
+
+            commandFactoryMock.list.resolves([]);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 403 when user does not have admin permissions', () => {
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'Insufficient scope'
+            };
+
+            options.credentials.scope = ['user'];
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 403);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('update to mark command trusted', () => {
+            server.inject(options).then((reply) => {
+                assert.calledOnce(testCommand.update);
+                assert.equal(reply.statusCode, 204);
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

To provide admins access to mark certain template & command as trusted

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

To add separate endpoints for template & command for marking trusted

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/1427

blocked by: 
https://github.com/screwdriver-cd/data-schema/pull/340

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
