### PR TITLE
fix: setup tokengen to executor

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -130,20 +130,23 @@ module.exports = (config) => {
     return registrationMan(server, config)
         .then(() => {
             // Initialize common data in buildFactory and jobFactory
-            if (server.app.buildFactory) {
-                server.app.buildFactory.apiUri = server.info.uri;
-                server.app.buildFactory.tokenGen = (buildId, metadata, scmContext, expiresIn) =>
-                    server.plugins.auth.generateToken(server.plugins.auth
-                        .generateProfile(buildId, scmContext, ['temporal'], metadata), expiresIn
-                    );
-            }
-            if (server.app.jobFactory) {
-                server.app.jobFactory.apiUri = server.info.uri;
-                server.app.jobFactory.tokenGen = (username, metadata, scmContext) =>
-                    server.plugins.auth.generateToken(server.plugins.auth
-                        .generateProfile(username, scmContext, ['user'], metadata)
-                    );
-            }
+
+            server.app.buildFactory.apiUri = server.info.uri;
+            server.app.buildFactory.executor.tokenGen = server.app.buildFactory.tokenGen =
+                (buildId, metadata, scmContext, expiresIn) => server.plugins.auth.generateToken(
+                    server.plugins.auth.generateProfile(
+                      buildId, scmContext, ['temporal'], metadata
+                    ),
+                    expiresIn
+                );
+
+            server.app.jobFactory.apiUri = server.info.uri;
+            server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen =
+                (username, metadata, scmContext) => server.plugins.auth.generateToken(
+                    server.plugins.auth.generateProfile(
+                        username, scmContext, ['user'], metadata
+                    )
+                );
 
             // Start the server
             return server.start().then(() => server);

--- a/lib/server.js
+++ b/lib/server.js
@@ -132,21 +132,18 @@ module.exports = (config) => {
             // Initialize common data in buildFactory and jobFactory
 
             server.app.buildFactory.apiUri = server.info.uri;
-            server.app.buildFactory.executor.tokenGen = server.app.buildFactory.tokenGen =
-                (buildId, metadata, scmContext, expiresIn) => server.plugins.auth.generateToken(
-                    server.plugins.auth.generateProfile(
-                      buildId, scmContext, ['temporal'], metadata
-                    ),
-                    expiresIn
+            server.app.buildFactory.tokenGen = (buildId, metadata, scmContext, expiresIn) =>
+                server.plugins.auth.generateToken(server.plugins.auth
+                    .generateProfile(buildId, scmContext, ['temporal'], metadata), expiresIn
                 );
+            server.app.buildFactory.executor.tokenGen = server.app.buildFactory.tokenGen;
 
             server.app.jobFactory.apiUri = server.info.uri;
-            server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen =
-                (username, metadata, scmContext) => server.plugins.auth.generateToken(
-                    server.plugins.auth.generateProfile(
-                        username, scmContext, ['user'], metadata
-                    )
+            server.app.jobFactory.tokenGen = (username, metadata, scmContext) =>
+                server.plugins.auth.generateToken(server.plugins.auth
+                    .generateProfile(username, scmContext, ['user'], metadata)
                 );
+            server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
 
             // Start the server
             return server.start().then(() => server);

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -54,9 +54,13 @@ describe('server case', () => {
                 ecosystem,
                 triggerFactory: 'trigger',
                 pipelineFactory: 'pipeline',
-                jobFactory: {},
+                jobFactory: {
+                  executor: {}
+                },
                 userFactory: 'user',
-                buildFactory: {}
+                buildFactory: {
+                  executor: {}
+                }
             }).then((s) => {
                 server = s;
                 // Pretend we actually registered a login plugin
@@ -119,6 +123,10 @@ describe('server case', () => {
             Assert.isObject(server.app.jobFactory);
             Assert.isFunction(server.app.jobFactory.tokenGen);
             Assert.strictEqual(server.app.jobFactory.tokenGen('bar'), 'foo');
+            Assert.isFunction(server.app.buildFactory.executor.tokenGen);
+            Assert.strictEqual(server.app.buildFactory.executor.tokenGen('bar'), 'foo');
+            Assert.isFunction(server.app.jobFactory.executor.userTokenGen);
+            Assert.strictEqual(server.app.jobFactory.executor.userTokenGen('bar'), 'foo');
         });
     });
 
@@ -185,7 +193,18 @@ describe('server case', () => {
         });
 
         it('doesnt affect non-errors', () => (
-            hapiEngine({ ecosystem }).then(server => (
+            hapiEngine({
+                ecosystem,
+                triggerFactory: 'trigger',
+                pipelineFactory: 'pipeline',
+                jobFactory: {
+                  executor: {}
+                },
+                userFactory: 'user',
+                buildFactory: {
+                  executor: {}
+                }
+            }).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/yes'
@@ -196,7 +215,18 @@ describe('server case', () => {
         ));
 
         it('doesnt affect errors', () => (
-            hapiEngine({ ecosystem }).then(server => (
+            hapiEngine({
+                ecosystem,
+                triggerFactory: 'trigger',
+                pipelineFactory: 'pipeline',
+                jobFactory: {
+                  executor: {}
+                },
+                userFactory: 'user',
+                buildFactory: {
+                  executor: {}
+                }
+            }).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/no'
@@ -208,7 +238,18 @@ describe('server case', () => {
         ));
 
         it('defaults to the error message if the stack trace is missing', () => (
-            hapiEngine({ ecosystem }).then(server => (
+            hapiEngine({
+                ecosystem,
+                triggerFactory: 'trigger',
+                pipelineFactory: 'pipeline',
+                jobFactory: {
+                  executor: {}
+                },
+                userFactory: 'user',
+                buildFactory: {
+                  executor: {}
+                }
+            }).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/noStack'
@@ -220,7 +261,18 @@ describe('server case', () => {
         ));
 
         it('responds with error response data', () => (
-            hapiEngine({ ecosystem }).then(server => (
+            hapiEngine({
+                ecosystem,
+                triggerFactory: 'trigger',
+                pipelineFactory: 'pipeline',
+                jobFactory: {
+                  executor: {}
+                },
+                userFactory: 'user',
+                buildFactory: {
+                  executor: {}
+                }
+            }).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/noWithResponse'

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -144,7 +144,12 @@ describe('server case', () => {
         it('callsback errors with register plugins', () => {
             registrationManMock.rejects(new Error('registrationMan fail'));
 
-            return hapiEngine({ ecosystem }).catch((error) => {
+            return hapiEngine({
+                ecosystem: {
+                    ui: 'http://example.com',
+                    allowCors: ''
+                }
+            }).catch((error) => {
                 Assert.strictEqual('registrationMan fail', error.message);
             });
         });

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -11,6 +11,18 @@ describe('server case', () => {
         ui: 'http://example.com',
         allowCors: ['http://mycors.com']
     };
+    const config = {
+        ecosystem,
+        triggerFactory: 'trigger',
+        pipelineFactory: 'pipeline',
+        jobFactory: {
+            executor: {}
+        },
+        userFactory: 'user',
+        buildFactory: {
+            executor: {}
+        }
+    };
 
     before(() => {
         mockery.enable({
@@ -47,30 +59,17 @@ describe('server case', () => {
 
             registrationManMock.resolves(null);
 
-            return hapiEngine({
-                httpd: {
-                    port: 12347
-                },
-                ecosystem,
-                triggerFactory: 'trigger',
-                pipelineFactory: 'pipeline',
-                jobFactory: {
-                    executor: {}
-                },
-                userFactory: 'user',
-                buildFactory: {
-                    executor: {}
-                }
-            }).then((s) => {
-                server = s;
-                // Pretend we actually registered a login plugin
-                server.plugins.auth = {
-                    generateToken: sinon.stub().returns('foo'),
-                    generateProfile: sinon.stub().returns('bar')
-                };
-            }).catch((e) => {
-                error = e;
-            });
+            return hapiEngine(Object.assign({ httpd: { port: 12347 } }, config))
+                .then((s) => {
+                    server = s;
+                    // Pretend we actually registered a login plugin
+                    server.plugins.auth = {
+                        generateToken: sinon.stub().returns('foo'),
+                        generateProfile: sinon.stub().returns('bar')
+                    };
+                }).catch((e) => {
+                    error = e;
+                });
         });
 
         it('populates access-control-allow-origin correctly', (done) => {
@@ -198,18 +197,7 @@ describe('server case', () => {
         });
 
         it('doesnt affect non-errors', () => (
-            hapiEngine({
-                ecosystem,
-                triggerFactory: 'trigger',
-                pipelineFactory: 'pipeline',
-                jobFactory: {
-                    executor: {}
-                },
-                userFactory: 'user',
-                buildFactory: {
-                    executor: {}
-                }
-            }).then(server => (
+            hapiEngine(config).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/yes'
@@ -220,18 +208,7 @@ describe('server case', () => {
         ));
 
         it('doesnt affect errors', () => (
-            hapiEngine({
-                ecosystem,
-                triggerFactory: 'trigger',
-                pipelineFactory: 'pipeline',
-                jobFactory: {
-                    executor: {}
-                },
-                userFactory: 'user',
-                buildFactory: {
-                    executor: {}
-                }
-            }).then(server => (
+            hapiEngine(config).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/no'
@@ -243,18 +220,7 @@ describe('server case', () => {
         ));
 
         it('defaults to the error message if the stack trace is missing', () => (
-            hapiEngine({
-                ecosystem,
-                triggerFactory: 'trigger',
-                pipelineFactory: 'pipeline',
-                jobFactory: {
-                    executor: {}
-                },
-                userFactory: 'user',
-                buildFactory: {
-                    executor: {}
-                }
-            }).then(server => (
+            hapiEngine(config).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/noStack'
@@ -266,18 +232,7 @@ describe('server case', () => {
         ));
 
         it('responds with error response data', () => (
-            hapiEngine({
-                ecosystem,
-                triggerFactory: 'trigger',
-                pipelineFactory: 'pipeline',
-                jobFactory: {
-                    executor: {}
-                },
-                userFactory: 'user',
-                buildFactory: {
-                    executor: {}
-                }
-            }).then(server => (
+            hapiEngine(config).then(server => (
                 server.inject({
                     method: 'GET',
                     url: '/noWithResponse'

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -55,11 +55,11 @@ describe('server case', () => {
                 triggerFactory: 'trigger',
                 pipelineFactory: 'pipeline',
                 jobFactory: {
-                  executor: {}
+                    executor: {}
                 },
                 userFactory: 'user',
                 buildFactory: {
-                  executor: {}
+                    executor: {}
                 }
             }).then((s) => {
                 server = s;
@@ -198,11 +198,11 @@ describe('server case', () => {
                 triggerFactory: 'trigger',
                 pipelineFactory: 'pipeline',
                 jobFactory: {
-                  executor: {}
+                    executor: {}
                 },
                 userFactory: 'user',
                 buildFactory: {
-                  executor: {}
+                    executor: {}
                 }
             }).then(server => (
                 server.inject({
@@ -220,11 +220,11 @@ describe('server case', () => {
                 triggerFactory: 'trigger',
                 pipelineFactory: 'pipeline',
                 jobFactory: {
-                  executor: {}
+                    executor: {}
                 },
                 userFactory: 'user',
                 buildFactory: {
-                  executor: {}
+                    executor: {}
                 }
             }).then(server => (
                 server.inject({
@@ -243,11 +243,11 @@ describe('server case', () => {
                 triggerFactory: 'trigger',
                 pipelineFactory: 'pipeline',
                 jobFactory: {
-                  executor: {}
+                    executor: {}
                 },
                 userFactory: 'user',
                 buildFactory: {
-                  executor: {}
+                    executor: {}
                 }
             }).then(server => (
                 server.inject({
@@ -266,11 +266,11 @@ describe('server case', () => {
                 triggerFactory: 'trigger',
                 pipelineFactory: 'pipeline',
                 jobFactory: {
-                  executor: {}
+                    executor: {}
                 },
                 userFactory: 'user',
                 buildFactory: {
-                  executor: {}
+                    executor: {}
                 }
             }).then(server => (
                 server.inject({


### PR DESCRIPTION
## Context
It's reported that sometimes periodicBulids aren't fired.
And we found following errors in sdapi logs.
```
error: failed to post build event for job xxx: TypeError: this.userTokenGen is not a function
```

The executor-queue sets up `userTokenGen` in `_startPeriodic` method,
https://github.com/screwdriver-cd/executor-queue/blob/master/index.js#L287-L289
and which is called by `job.update` ( and which is called by pipeline.sync etc..).

So if sdapi is restarted, the `userTokenGen` is null until the sdapi is requested to update any jobs, and also periodicBuilds don't work.
https://github.com/screwdriver-cd/executor-queue/blob/master/index.js#L48
https://github.com/screwdriver-cd/executor-queue/blob/master/index.js#L190

tokenGen was splited for purposes in executor-queue, `tokenGen` is for temporal scope and `userTokenGen` is for user scope but these property setup are delayed until `_start` and `_startPeriodic` is called. This change ensures the setup is done just when api is started.
## Objective
This ensures that the executor has `tokenGen` and `userTokengen` when sdapi is started.
I think these should be passed into the constructor of executor in the future, but it needs big refactoring.

If it is effective we remove following codes.
https://github.com/screwdriver-cd/executor-queue/blob/master/index.js#L287-L289
https://github.com/screwdriver-cd/executor-queue/blob/master/index.js#L431-L433

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
