### PR TITLE
fix: update executor-queue version

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "screwdriver-executor-docker": "^4.2.0",
     "screwdriver-executor-k8s": "^13.6.1",
     "screwdriver-executor-k8s-vm": "^2.10.0",
-    "screwdriver-executor-queue": "^2.4.11",
+    "screwdriver-executor-queue": "^2.4.22",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-models": "^27.34.2",
     "screwdriver-notifications-email": "^1.1.9",


### PR DESCRIPTION
## Context
After merged [this PR](https://github.com/screwdriver-cd/executor-queue/pull/68
), I ran screwdriver pipeline twice and create [0.718](https://github.com/screwdriver-cd/screwdriver/releases/tag/v0.5.718) and [0.719](https://github.com/screwdriver-cd/screwdriver/releases/tag/v0.5.719). 

However both v0.5.718 and v0.5.719 does not have new executor-queue(2.4.22). 
I update package.json to install new executor-queue.

## Objective

Update executor-queue version.

## References
[screwdriver-executor-queue - npm](https://www.npmjs.com/package/screwdriver-executor-queue)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
