### PR TITLE
fix: update github to octokit for functional test

### DIFF
--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -25,7 +25,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
             .then((response) => {
                 this.jwt = response.body.token;
 
-                return github.createBranch(this.gitToken, branch, this.repoOrg, this.repoName);
+                return github.createBranch(branch, this.repoOrg, this.repoName);
             })
             // wait not to trigger builds when create a pipeline
             .then(() => this.promiseToWait(WAIT_TIME))
@@ -65,9 +65,9 @@ defineSupportCode(({ Before, Given, When, Then }) => {
     When(/^a new commit is pushed to "(.*)" branch$/, {
         timeout: TIMEOUT
     }, function step(branch) {
-        return github.createBranch(this.gitToken, branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(this.gitToken, branch, this.repoOrg, this.repoName))
-            .then((data) => {
+        return github.createBranch(branch, this.repoOrg, this.repoName)
+            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+            .then(({ data }) => {
                 this.sha = data.commit.sha;
             });
     });

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "winston": "^2.4.4"
   },
   "devDependencies": {
+    "@octokit/rest": "^16.28.3",
     "chai": "~3.5.0",
     "chai-as-promised": "^6.0.0",
     "chai-jwt": "^2.0.0",
@@ -124,7 +125,6 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "form-data": "^2.3.3",
-    "github": "^8.1.1",
     "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
     "mz": "^2.6.0",


### PR DESCRIPTION
## Context
Github module is deprecated, but functest is used it.
Update github module to @octokit/rest for functest.

## Objective
- Update `github.js` and related tests for functest.
- Add `@octokit/rest` and delete `github` to `package.json`.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.