### PR TITLE
feat: implement artifacts preview for screwdriver backend

### DIFF
--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -7,7 +7,7 @@ const uuid = require('uuid/v4');
 
 const idSchema = joi.reach(schema.models.build.base, 'id');
 const artifactSchema = joi.string().label('Artifact Name');
-const downloadSchema = joi.string().valid(['', 'false', 'true']).label('Flag to trigger download');
+const typeSchema = joi.string().valid(['', 'download', 'preview']).label('Flag to trigger type either to download or preview');
 
 module.exports = config => ({
     method: 'GET',
@@ -42,8 +42,8 @@ module.exports = config => ({
             let baseUrl = `${config.ecosystem.store}/v1/builds/`
                 + `${buildId}/ARTIFACTS/${encodedArtifact}?token=${token}`;
 
-            if (request.query.download) {
-                baseUrl += `&download=${request.query.download}`;
+            if (request.query.type) {
+                baseUrl += `&type=${request.query.type}`;
             }
 
             return reply().redirect().location(baseUrl);
@@ -54,7 +54,7 @@ module.exports = config => ({
                 name: artifactSchema
             },
             query: {
-                download: downloadSchema
+                type: typeSchema
             }
         }
     }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2799,6 +2799,20 @@ describe('build plugin test', () => {
                 assert.deepEqual(reply.headers.location, url);
             });
         });
+
+        it.only('redirects to store for an artifact preview request', () => {
+            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/manifest?token=sign&type=preview`;
+
+            return server.inject({
+                url: `/builds/${id}/artifacts/${artifact}?type=preview`,
+                credentials: {
+                    scope: ['user']
+                }
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 302);
+                assert.deepEqual(reply.headers.location, url);
+            });
+        });
     });
 
     describe('POST /builds/{id}/token', () => {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2800,7 +2800,7 @@ describe('build plugin test', () => {
             });
         });
 
-        it.only('redirects to store for an artifact preview request', () => {
+        it('redirects to store for an artifact preview request', () => {
             const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/manifest?token=sign&type=preview`;
 
             return server.inject({

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2787,10 +2787,10 @@ describe('build plugin test', () => {
         });
 
         it('redirects to store for an artifact download request', () => {
-            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/manifest?token=sign&download=true`;
+            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/manifest?token=sign&type=download`;
 
             return server.inject({
-                url: `/builds/${id}/artifacts/${artifact}?download=true`,
+                url: `/builds/${id}/artifacts/${artifact}?type=download`,
                 credentials: {
                     scope: ['user']
                 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Making necessary changes to implement artifacts for screwdriver backend.

Instead of receiving `download=true`, now query params will be receiving `type=preview` or `type=download`. 


## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Backend will forward its request from UI to Store with proper access authentication token setup. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

UI: https://github.com/screwdriver-cd/ui/pull/465
Backend: https://github.com/screwdriver-cd/screwdriver/pull/1703
Store: https://github.com/screwdriver-cd/store/pull/88


## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
