### PR TITLE
fix: Increase timeout for sd-step func test

### DIFF
--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -119,7 +119,7 @@ defineSupportCode(({ Before, Given, When, Then }) => {
         });
     });
 
-    Then(/^(.*) package is available via sd-step$/, { timeout: 700 * 1000 }, function step(pkg) {
+    Then(/^(.*) package is available via sd-step$/, { timeout: 900 * 1000 }, function step(pkg) {
         return this.waitForBuild(this.buildId).then((response) => {
             Assert.equal(response.statusCode, 200);
             Assert.equal(response.body.status, 'SUCCESS');


### PR DESCRIPTION
## Context

Keeps failing 

```
0:21:06   1) Scenario: Use package via sd-step - features/sd-step.feature:29
00:21:06      Step: Then core/node package is available via sd-step - features/sd-step.feature:25
00:21:06      Step Definition: features/step_definitions/sd-step.js:122
00:21:06      Message:
00:21:06        AssertionError: expected 'RUNNING' to equal 'SUCCESS'
```

## References

Build failure: https://cd.screwdriver.cd/pipelines/1/builds/143483/steps/test

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
