### PR TITLE
fix(1737): Sort by createTime when getting builds for job

### DIFF
--- a/plugins/jobs/README.md
+++ b/plugins/jobs/README.md
@@ -43,6 +43,13 @@ Example payload:
 }
 ```
 
+#### Get list of builds for a single job
+`GET /jobs/{id}/builds`
+
+`GET /jobs/{id}/builds?page=2&count=30&sort=ascending`
+
+`GET /jobs/{id}/builds?page=2&count=30&sort=ascending&sortBy=id`
+
 #### Get build metrics for a single job
 `GET /jobs/{id}/metrics/builds`
 

--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -31,8 +31,13 @@ module.exports = () => ({
                     }
 
                     const config = {
-                        sort: request.query.sort
+                        sort: request.query.sort,
+                        sortBy: 'createTime'
                     };
+
+                    if (request.query.sortBy) {
+                        config.sortBy = request.query.sortBy;
+                    }
 
                     if (request.query.page || request.query.count) {
                         config.paginate = {

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -320,7 +320,8 @@ describe('job plugin test', () => {
             server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 200);
                 assert.calledWith(job.getBuilds, {
-                    sort: 'descending'
+                    sort: 'descending',
+                    sortBy: 'createTime'
                 });
                 assert.deepEqual(reply.result, testBuilds);
             })
@@ -336,7 +337,25 @@ describe('job plugin test', () => {
                         count: 30,
                         page: 2
                     },
-                    sort: 'ascending'
+                    sort: 'ascending',
+                    sortBy: 'createTime'
+                });
+                assert.deepEqual(reply.result, testBuilds);
+            });
+        });
+
+        it('pass in the correct params to getBuilds with all params', () => {
+            options.url = `/jobs/${id}/builds?page=2&count=30&sort=ascending&sortBy=id`;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.calledWith(job.getBuilds, {
+                    paginate: {
+                        count: 30,
+                        page: 2
+                    },
+                    sort: 'ascending',
+                    sortBy: 'id'
                 });
                 assert.deepEqual(reply.result, testBuilds);
             });
@@ -352,7 +371,8 @@ describe('job plugin test', () => {
                         page: undefined,
                         count: 30
                     },
-                    sort: 'descending'
+                    sort: 'descending',
+                    sortBy: 'createTime'
                 });
                 assert.deepEqual(reply.result, testBuilds);
             });


### PR DESCRIPTION
## Context

Sorting by build ID is slow. We want to sort by `createTime` to take advantage of the DB index.

## Objective

This PR adds `createTime` as the sort key. Should work since models and datastore-sequelize already handle `sortBy` key: https://github.com/screwdriver-cd/models/blob/master/lib/job.js#L161-L163, https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L444-L449

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1737

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
