### PR TITLE
fix: Update README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ All the possible environment variables are [defined here](config/custom-environm
 npm test
 ```
 
+_Note: You might run into [memory issues running all the unit tests](https://stackoverflow.com/questions/26094420/fatal-error-call-and-retry-last-allocation-failed-process-out-of-memory/48895989#48895989). You can update your `~/.bashrc` file with the line below to ensure there's enough memory for tests to run:_
+
+```bash
+export NODE_OPTIONS=--max_old_space_size=4096
+```
+
 ### Functional tests
 
 Fork `functional-*` repositories to your organization from [screwdriver-cd-test](https://github.com/screwdriver-cd-test)


### PR DESCRIPTION
## Context

Sometimes people will see out of memory issues when running `npm test` locally.

## Objective

This PR updates the README with further `npm test` instructions to work around the out of memory issues.

## References

Related to https://medium.com/@vuongtran/how-to-solve-process-out-of-memory-in-node-js-5f0de8f8464c

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
