### PR TITLE
fix(1747): add a new condition to skip ci check

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "screwdriver-models": "^27.34.8",
     "screwdriver-notifications-email": "^1.1.9",
     "screwdriver-notifications-slack": "^2.3.0",
-    "screwdriver-scm-github": "^9.3.2",
+    "screwdriver-scm-github": "^9.3.3",
     "screwdriver-scm-gitlab": "^1.3.1",
     "screwdriver-scm-router": "^4.1.0",
     "screwdriver-template-validator": "^3.0.6",

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -837,11 +837,18 @@ exports.register = (server, options, next) => {
                     }
 
                     // if skip ci then don't return
-                    if (ignoreUser && ignoreUser.includes(username) && !skipMessage) {
-                        message = `Skipping because user ${username} is ignored`;
-                        request.log(['webhook', hookId], message);
+                    if (ignoreUser && !skipMessage) {
+                        const commitAuthors = Array.isArray(parsed.commitAuthors) ?
+                            parsed.commitAuthors : [username];
+                        const validCommitAuthors = commitAuthors.filter(author =>
+                            !ignoreUser.includes(author));
 
-                        return reply({ message }).code(204);
+                        if (!validCommitAuthors.length) {
+                            message = `Skipping because user ${username} is ignored`;
+                            request.log(['webhook', hookId], message);
+
+                            return reply({ message }).code(204);
+                        }
                     }
 
                     const token = await obtainScmToken(

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -1003,11 +1003,29 @@ describe('webhooks plugin test', () => {
                 });
             });
 
-            it('returns 204 when commits made by ignoreCommitsBy user', () => {
+            it('returns 204 when commits sent by ignoreCommitsBy user', () => {
                 parsed.username = 'batman';
 
                 return server.inject(options).then((reply) => {
                     assert.equal(reply.statusCode, 204);
+                });
+            });
+
+            it('returns 204 when commits made by ignoreCommitsBy user', () => {
+                parsed.commitAuthors = ['batman'];
+
+                return server.inject(options).then((reply) => {
+                    assert.equal(reply.statusCode, 204);
+                });
+            });
+
+            it('returns 201 when sender is ignoreCommitsBy user but commit author is not', () => {
+                parsed.username = 'batman';
+                parsed.commitAuthors = ['notbatman'];
+                pipelineFactoryMock.scm.parseHook.withArgs(reqHeaders, payload).resolves(parsed);
+
+                return server.inject(options).then((reply) => {
+                    assert.equal(reply.statusCode, 201);
                 });
             });
 


### PR DESCRIPTION
… build

## Context

sd incorrectly excludes commit from build when commit is made but is sent by user in ignoreUser

## Objective

add a new condition to ci skip check to prevent SD from skipping legitimate build

## References

https://github.com/screwdriver-cd/screwdriver/issues/1747

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
