### PR TITLE
fix(1754): [1] Add cluster level coverage plugin setting (enable or not)

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -340,7 +340,7 @@ notifications:
 
 coverage:
   plugin: COVERAGE_PLUGIN
-  enabled: COVERAGE_PLUGIN_DEFAULT_ENABLED
+  default: COVERAGE_PLUGIN_DEFAULT_ENABLED
   sonar:
     # Screwdriver API url
     sdApiUrl: URI

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -340,7 +340,7 @@ notifications:
 
 coverage:
   plugin: COVERAGE_PLUGIN
-  enabled: COVERAGE_PLUGIN_ENABLED
+  enabled: COVERAGE_PLUGIN_DEFAULT_ENABLED
   sonar:
     # Screwdriver API url
     sdApiUrl: URI

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -340,6 +340,7 @@ notifications:
 
 coverage:
   plugin: COVERAGE_PLUGIN
+  enabled: COVERAGE_PLUGIN_ENABLED
   sonar:
     # Screwdriver API url
     sdApiUrl: URI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -231,7 +231,8 @@ webhooks:
   # Upper limit on incoming uploads to builds
   maxBytes: 1048576 # 1MB
 
-coverage: {}
+coverage:
+  enabled: true
   # plugin: sonar
   # sonar:
   #   sdApiUrl: https://api.screwdriver.cd

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -232,7 +232,7 @@ webhooks:
   maxBytes: 1048576 # 1MB
 
 coverage:
-  enabled: true
+  default: true
   # plugin: sonar
   # sonar:
   #   sdApiUrl: https://api.screwdriver.cd


### PR DESCRIPTION
## Context
When we use coverage-bookend, coverage scanning is executed all jobs, including jobs which is not necessary to scan.
It must be leads to longer build time, or surging database size.

## Objective
- Add cluster level config of coverage plugin (`default`: `true` / `false`）
- Default value is `true`.

## References
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1754
Other PRs
[2] https://github.com/screwdriver-cd/coverage-bookend/pull/4
[3] https://github.com/screwdriver-cd/coverage-base/pull/11

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.