### PR TITLE
fix: remove sqlite3

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "screwdriver-scm-router": "^4.1.0",
     "screwdriver-template-validator": "^3.0.6",
     "screwdriver-workflow-parser": "^1.8.8",
-    "sqlite3": "^4.1.0",
     "tinytim": "^0.1.1",
     "uuid": "^3.3.3",
     "verror": "^1.6.1",


### PR DESCRIPTION
Don't think it's needed
Was added from here: https://github.com/screwdriver-cd/screwdriver/pull/985
Related: https://github.com/screwdriver-cd/screwdriver/pull/1761