### PR TITLE
fix(1701): PR authors should not be able to restart builds if `restrictPR` is on

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -3,6 +3,7 @@
 const boom = require('boom');
 const urlLib = require('url');
 const validationSchema = require('screwdriver-data-schema');
+const ANNOT_RESTRICT_PR = 'screwdriver.cd/restrictPR';
 
 module.exports = () => ({
     method: 'POST',
@@ -159,9 +160,16 @@ module.exports = () => ({
                                         payload.prInfo = prInfo;
                                         payload.prRef = prInfo.ref;
                                         payload.chainPR = pipeline.chainPR;
+                                        let restrictPR = 'none';
 
-                                        // PR author should be able to rerun their own PR build
-                                        if (prInfo.username === username) {
+                                        if (pipeline.annotations &&
+                                            pipeline.annotations[ANNOT_RESTRICT_PR]) {
+                                            restrictPR = pipeline.annotations[ANNOT_RESTRICT_PR];
+                                        }
+
+                                        // PR author should be able to rerun their own PR build if restrictPR is not on
+                                        if (restrictPR === 'none' &&
+                                            prInfo.username === username) {
                                             return Promise.resolve();
                                         }
 


### PR DESCRIPTION
## Context

PR author should not be allowed to restart PR if restrictPR annotation is turned on.

## Objective

Add a check to enforce restrictPR before allowing PR author to restart builds

## References

https://github.com/screwdriver-cd/screwdriver/issues/1701

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
