### PR TITLE
[4] fix(1755): Add baseBranch to event and build config

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -25,10 +25,12 @@ const workflowParser = require('screwdriver-workflow-parser');
  * @param  {String}   config.scmContext     SCM context
  * @param  {Build}    config.build          Build object
  * @param  {Boolean}  [config.start]        Whether to start the build or not
+ * @param  {String}   config.baseBranch     Branch name
  * @return {Promise}
  */
-async function createBuild({ jobFactory, buildFactory, eventFactory, pipelineId,
-    jobName, username, scmContext, build, start }) {
+async function createBuild(config) {
+    const { jobFactory, buildFactory, eventFactory, pipelineId, jobName,
+        username, scmContext, build, start } = config;
     const event = await eventFactory.get(build.eventId);
     const job = await jobFactory.get({
         name: jobName,
@@ -46,7 +48,8 @@ async function createBuild({ jobFactory, buildFactory, eventFactory, pipelineId,
             configPipelineSha: event.configPipelineSha,
             scmContext,
             prRef,
-            start: start !== false
+            start: start !== false,
+            baseBranch: config.baseBranch || null
         });
     }
 
@@ -324,7 +327,8 @@ exports.register = (server, options, next) => {
                     jobName: nextJobName,
                     username,
                     scmContext,
-                    build // this is the parentBuild for the next build
+                    build, // this is the parentBuild for the next build
+                    baseBranch: event.baseBranch || null
                 };
 
                 // Just start the build if falls in to these 2 scenarios

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -30,7 +30,7 @@ const workflowParser = require('screwdriver-workflow-parser');
  */
 async function createBuild(config) {
     const { jobFactory, buildFactory, eventFactory, pipelineId, jobName,
-        username, scmContext, build, start } = config;
+        username, scmContext, build, start, baseBranch } = config;
     const event = await eventFactory.get(build.eventId);
     const job = await jobFactory.get({
         name: jobName,
@@ -49,7 +49,7 @@ async function createBuild(config) {
             scmContext,
             prRef,
             start: start !== false,
-            baseBranch: config.baseBranch || null
+            baseBranch
         });
     }
 

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -331,7 +331,8 @@ async function createPREvents(options, request) {
             prNum,
             prTitle,
             // eslint-disable-next-line no-await-in-loop
-            prInfo: await eventFactory.scm.getPrInfo(scmConfig)
+            prInfo: await eventFactory.scm.getPrInfo(scmConfig),
+            baseBranch: branch
         };
 
         if (skipMessage) {
@@ -665,7 +666,7 @@ async function createEvents(eventFactory, userFactory, pipelineFactory,
                 sha,
                 configPipelineSha,
                 changedFiles,
-                commitBranch: branch,
+                baseBranch: branch,
                 causeMessage: `Merged by ${username}`,
                 meta
             };

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1105,7 +1105,8 @@ describe('build plugin test', () => {
                             eventId: 'bbf22a3808c19dc50777258a253805b14fb3ad8b',
                             configPipelineSha,
                             prRef: '',
-                            start: true
+                            start: true,
+                            baseBranch: null
                         });
                         assert.calledWith(triggerFactoryMock.list, {
                             params: { src }
@@ -1178,7 +1179,8 @@ describe('build plugin test', () => {
                             eventId: 'bbf22a3808c19dc50777258a253805b14fb3ad8b',
                             configPipelineSha,
                             prRef: eventMock.pr.ref,
-                            start: true
+                            start: true,
+                            baseBranch: null
                         });
                         // Events should not be created if there is no external pipeline
                         assert.notCalled(eventFactoryMock.create);
@@ -1326,6 +1328,7 @@ describe('build plugin test', () => {
                             { name: 'd', id: 4 }
                         ]
                     };
+                    eventMock.baseBranch = 'master';
                     eventFactoryMock.get.withArgs({ id: 456 }).resolves(parentEventMock);
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'b' }).resolves(jobB);
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'c' }).resolves(jobC);
@@ -1342,7 +1345,8 @@ describe('build plugin test', () => {
                         username: 12345,
                         scmContext: 'github:github.com',
                         configPipelineSha: 'abc123',
-                        prRef: ''
+                        prRef: '',
+                        baseBranch: 'master'
                     };
                     jobCconfig = Object.assign({}, jobBconfig, { jobId: 3 });
                 });

--- a/test/plugins/data/events.json
+++ b/test/plugins/data/events.json
@@ -35,5 +35,6 @@
         "name": "St John",
         "url": "https://github.com/stjohn",
         "username": "stjohn"
-    }
+    },
+    "baseBranch": "master"
 }]

--- a/test/plugins/data/eventsPr.json
+++ b/test/plugins/data/eventsPr.json
@@ -37,5 +37,6 @@
         "name": "St John",
         "url": "https://github.com/stjohn",
         "username": "stjohn"
-    }
+    },
+    "baseBranch": "master"
 }]

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -315,6 +315,7 @@ describe('event plugin test', () => {
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.parentEventId = 888;
+            eventConfig.baseBranch = 'master';
             eventFactoryMock.get.resolves(getEventMock(testEvent));
 
             return server.inject(options).then((reply) => {
@@ -404,6 +405,7 @@ describe('event plugin test', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
             options.payload.parentEventId = parentEventId;
 
             return server.inject(options).then((reply) => {
@@ -416,7 +418,6 @@ describe('event plugin test', () => {
                 assert.equal(reply.statusCode, 201);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
-                assert.notCalled(eventFactoryMock.scm.getCommitSha);
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
             });
         });
@@ -425,6 +426,7 @@ describe('event plugin test', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
             testEvent.configPipelineSha = 'configPipelineSha';
             eventConfig.configPipelineSha = 'configPipelineSha';
             options.payload.parentEventId = parentEventId;
@@ -440,7 +442,6 @@ describe('event plugin test', () => {
                 assert.equal(reply.statusCode, 201);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
-                assert.notCalled(eventFactoryMock.scm.getCommitSha);
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
                 delete testEvent.configPipelineSha;
             });
@@ -564,6 +565,7 @@ describe('event plugin test', () => {
                 username: 'myself'
             };
             eventConfig.changedFiles = ['screwdriver.yaml'];
+            eventConfig.baseBranch = 'master';
 
             return server.inject(options).then((reply) => {
                 expectedLocation = {

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -508,7 +508,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~tag',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: undefined,
                         meta: {
@@ -572,7 +572,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~tag',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: undefined,
                         meta: {
@@ -647,7 +647,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~release',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: undefined,
                         meta: {
@@ -717,7 +717,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~release',
-                        commitBranch: 'branch',
+                        baseBranch: 'branch',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: undefined,
                         meta: {
@@ -782,7 +782,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles,
                         meta: {}
@@ -858,7 +858,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit:master',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles,
                         meta: {}
@@ -872,7 +872,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit:master',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles,
                         meta: {}
@@ -886,7 +886,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles,
                         meta: {}
@@ -942,7 +942,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: ['lib/test.js'],
                         meta: {}
@@ -956,7 +956,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: ['lib/test.js'],
                         meta: {}
@@ -993,7 +993,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         changedFiles,
                         causeMessage: `Merged by ${username}`,
                         skipMessage: 'Skipping due to the commit message: [skip ci]',
@@ -1045,7 +1045,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         changedFiles,
                         causeMessage: 'Merged by batman',
                         skipMessage: 'Skipping due to the commit message: [skip ci]',
@@ -1230,7 +1230,8 @@ describe('webhooks plugin test', () => {
                         startFrom: '~pr',
                         type: 'pr',
                         username,
-                        webhooks: true
+                        webhooks: true,
+                        baseBranch: 'master'
                     };
                 });
 
@@ -1251,7 +1252,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                         assert.notCalled(pipelineFactoryMock.scm.getCommitRefSha);
@@ -1331,7 +1333,8 @@ describe('webhooks plugin test', () => {
                             prInfo,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
                             chainPR: false,
-                            changedFiles
+                            changedFiles,
+                            baseBranch: 'master'
                         });
                         assert.calledWith(eventFactoryMock.create, {
                             pipelineId: pMock2.id,
@@ -1348,7 +1351,8 @@ describe('webhooks plugin test', () => {
                             prInfo,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
                             chainPR: false,
-                            changedFiles
+                            changedFiles,
+                            baseBranch: 'master'
                         });
                         assert.calledWith(eventFactoryMock.create, {
                             pipelineId,
@@ -1365,7 +1369,8 @@ describe('webhooks plugin test', () => {
                             prInfo,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
                             chainPR: false,
-                            changedFiles
+                            changedFiles,
+                            baseBranch: 'master'
                         });
                         assert.neverCalledWith(eventFactoryMock.create, sinon.match({
                             pipelineId,
@@ -1403,7 +1408,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Reopened by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     });
@@ -1482,7 +1488,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     });
@@ -1531,7 +1538,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     });
@@ -1569,7 +1577,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Opened by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     });
@@ -1610,7 +1619,8 @@ describe('webhooks plugin test', () => {
                         startFrom: '~pr',
                         changedFiles,
                         causeMessage: 'Synchronized by github:baxterthehacker',
-                        chainPR: false
+                        chainPR: false,
+                        baseBranch: 'master'
                     };
 
                     model1 = {
@@ -1659,7 +1669,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     })
@@ -1738,7 +1749,8 @@ describe('webhooks plugin test', () => {
                             prInfo,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
                             chainPR: false,
-                            changedFiles
+                            changedFiles,
+                            baseBranch: 'master'
                         });
                         assert.calledWith(eventFactoryMock.create, {
                             pipelineId: pMock2.id,
@@ -1755,7 +1767,8 @@ describe('webhooks plugin test', () => {
                             prInfo,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
                             chainPR: false,
-                            changedFiles
+                            changedFiles,
+                            baseBranch: 'master'
                         });
                         assert.calledWith(eventFactoryMock.create, {
                             pipelineId,
@@ -1772,7 +1785,8 @@ describe('webhooks plugin test', () => {
                             prInfo,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
                             chainPR: false,
-                            changedFiles
+                            changedFiles,
+                            baseBranch: 'master'
                         });
                         assert.neverCalledWith(eventFactoryMock.create, sinon.match({
                             pipelineId,
@@ -1810,7 +1824,8 @@ describe('webhooks plugin test', () => {
                             webhooks: true,
                             changedFiles,
                             causeMessage: 'Synchronized by github:baxterthehacker',
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.isOk(model1.update.calledBefore(eventFactoryMock.create));
                         assert.isOk(model2.update.calledBefore(eventFactoryMock.create));
@@ -1885,7 +1900,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     });
@@ -1923,7 +1939,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     });
@@ -1970,7 +1987,8 @@ describe('webhooks plugin test', () => {
                             prRef,
                             changedFiles,
                             causeMessage: `Synchronized by ${scmDisplayName}:${username}`,
-                            chainPR: false
+                            chainPR: false,
+                            baseBranch: 'master'
                         });
                         assert.equal(reply.statusCode, 201);
                     });

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -996,7 +996,7 @@ describe('webhooks plugin test', () => {
                         sha,
                         configPipelineSha: latestSha,
                         startFrom: '~commit',
-                        commitBranch: 'master',
+                        baseBranch: 'master',
                         causeMessage: `Merged by ${username}`,
                         changedFiles: ['lib/test.js'],
                         meta: {}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To use branch info in the restarted build and triggered build, I added branch info to event and build config when they are created. And use that info when creating new event.

PR build was failed because related PRs are not merged.
It may success after related PRs will be merged.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
* Add branch info to event and build config when they are created.
* Use branch info when creating new event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1755
https://github.com/screwdriver-cd/screwdriver/issues/1760

Related PRs:
https://github.com/screwdriver-cd/data-schema/pull/357
https://github.com/screwdriver-cd/models/pull/396
https://github.com/screwdriver-cd/scm-base/pull/72

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
