### PR TITLE
fix(1741): adding startFrom to event created by POST /builds

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -108,6 +108,7 @@ module.exports = () => ({
                                     return eventFactory.create({
                                         pipelineId: pipeline.id,
                                         meta,
+                                        startFrom: job.name,
                                         type,
                                         username,
                                         scmContext,

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1798,6 +1798,7 @@ describe('build plugin test', () => {
             jobMock.prNum = 15;
             params.sha = '58393af682d61de87789fb4961645c42180cec5a';
             params.prRef = 'prref';
+            eventConfig.startFrom = jobMock.name;
 
             const scmConfig = {
                 token: 'iamtoken',
@@ -1836,6 +1837,7 @@ describe('build plugin test', () => {
             jobMock.isPR.returns(false);
             jobMock.prNum = null;
             eventConfig.type = 'pipeline';
+            eventConfig.startFrom = jobMock.name;
             params.meta = meta;
 
             return server.inject(options).then((reply) => {
@@ -1880,6 +1882,7 @@ describe('build plugin test', () => {
             jobMock.isPR.returns(false);
             jobMock.prNum = null;
             eventConfig.type = 'pipeline';
+            eventConfig.startFrom = jobMock.name;
 
             return server.inject(options).then((reply) => {
                 expectedLocation = {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently we can created job's build with either POST /event or POST/builds, latter is causing some issue with UI because it's missing startFrom in event data.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Event created as part of POST /builds should have proper startFrom data

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1741

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
