### PR TITLE
feat(1717): get latest build api for pipeline

### DIFF
--- a/plugins/jobs/README.md
+++ b/plugins/jobs/README.md
@@ -50,6 +50,12 @@ Example payload:
 
 `GET /jobs/{id}/builds?page=2&count=30&sort=ascending&sortBy=id`
 
+#### Get latest build for a single job
+`GET /jobs/{id}/latestBuild`
+
+Can search by build status
+`GET /jobs/{id}/latestBuild?status=SUCCESS`
+
 #### Get build metrics for a single job
 `GET /jobs/{id}/metrics/builds`
 

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -151,6 +151,12 @@ Only PR events of specified PR number will be searched when `prNum` is set
 
 `DELETE /pipelines/{pipelineId}/tokens`
 
+#### Get latest build for a single job
+`GET /pipelines/{id}/{jobName}/latestBuild`
+
+Can search by build status
+`GET /pipelines/{id}/{jobName}/latestBuild?status=SUCCESS`
+
 ### Access to Factory methods
 The server supplies factories to plugins in the form of server settings:
 

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -152,10 +152,10 @@ Only PR events of specified PR number will be searched when `prNum` is set
 `DELETE /pipelines/{pipelineId}/tokens`
 
 #### Get latest build for a single job
-`GET /pipelines/{id}/{jobName}/latestBuild`
+`GET /pipelines/{id}/jobs/{jobName}/latestBuild`
 
 Can search by build status
-`GET /pipelines/{id}/{jobName}/latestBuild?status=SUCCESS`
+`GET /pipelines/{id}/jobs/{jobName}/latestBuild?status=SUCCESS`
 
 ### Access to Factory methods
 The server supplies factories to plugins in the form of server settings:

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -22,6 +22,7 @@ const listTokens = require('./tokens/list');
 const removeToken = require('./tokens/remove');
 const removeAllTokens = require('./tokens/removeAll');
 const metricsRoute = require('./metrics');
+const latestBuild = require('./latestBuild');
 
 /**
  * Pipeline API Plugin
@@ -104,7 +105,8 @@ exports.register = (server, options, next) => {
         listTokens(),
         removeToken(),
         removeAllTokens(),
-        metricsRoute()
+        metricsRoute(),
+        latestBuild()
     ]);
 
     next();

--- a/plugins/pipelines/latestBuild.js
+++ b/plugins/pipelines/latestBuild.js
@@ -9,7 +9,7 @@ const statusSchema = joi.reach(schema.models.build.base, 'status');
 
 module.exports = () => ({
     method: 'GET',
-    path: '/pipelines/{id}/{jobName}/latestBuild',
+    path: '/pipelines/{id}/jobs/{jobName}/latestBuild',
     config: {
         description: 'Get latest build for a given job',
         notes: 'Return latest build of status specified',

--- a/plugins/pipelines/latestBuild.js
+++ b/plugins/pipelines/latestBuild.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const boom = require('boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const idSchema = joi.reach(schema.models.job.base, 'id');
+const nameSchema = joi.reach(schema.models.job.base, 'name');
+const statusSchema = joi.reach(schema.models.build.base, 'status');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipelines/{id}/{jobName}/latestBuild',
+    config: {
+        description: 'Get latest build for a given job',
+        notes: 'Return latest build of status specified',
+        tags: ['api', 'job', 'build'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build', 'pipeline']
+        },
+        plugins: {
+            'hapi-swagger': {
+                security: [{ token: [] }]
+            }
+        },
+        handler: (request, reply) => {
+            const jobFactory = request.server.app.jobFactory;
+            const { status } = request.query || {};
+
+            return jobFactory.get({
+                pipelineId: request.params.id,
+                name: request.params.jobName
+            })
+                .then((job) => {
+                    if (!job) {
+                        throw boom.notFound('Job does not exist');
+                    }
+
+                    return job.getLatestBuild({ status });
+                })
+                .then((build) => {
+                    if (Object.keys(build).length === 0) {
+                        throw boom.notFound('There is no such latest build');
+                    }
+
+                    return reply(build.toJson());
+                })
+                .catch(err => reply(boom.boomify(err)));
+        },
+        response: {
+            schema: joi.object()
+        },
+        validate: {
+            params: {
+                id: idSchema,
+                jobName: nameSchema
+            },
+            query: {
+                status: statusSchema
+            }
+        }
+    }
+});

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -13,6 +13,7 @@ const gitlabTestPipelines = require('./data/pipelinesFromGitlab.json');
 const testJob = require('./data/job.json');
 const testJobs = require('./data/jobs.json');
 const testTriggers = require('./data/triggers.json');
+const testBuild = require('./data/build.json');
 const testBuilds = require('./data/builds.json').slice(0, 2);
 const testSecrets = require('./data/secrets.json');
 const testEvents = require('./data/events.json');
@@ -59,6 +60,7 @@ const getTokenMocks = (tokens) => {
 const decorateJobMock = (job) => {
     const mock = hoek.clone(job);
 
+    mock.getLatestBuild = sinon.stub();
     mock.getBuilds = sinon.stub().resolves(getBuildMocks(testBuilds));
     mock.toJson = sinon.stub().returns(job);
 
@@ -748,6 +750,56 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /pipelines/{id}/{jobName}/latestBuild', () => {
+        const id = 1234;
+        const name = 'deploy';
+        let options;
+        let job;
+        let build;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: `/pipelines/${id}/${name}/latestBuild`
+            };
+
+            job = getJobsMocks(testJob);
+            build = getBuildMocks(testBuild);
+
+            jobFactoryMock.get.resolves(job);
+            job.getLatestBuild.resolves(build);
+        });
+
+        it('returns 404 if job does not exist', () => {
+            jobFactoryMock.get.resolves(null);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 200 if found last build', () =>
+            server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 200);
+                assert.calledWith(job.getLatestBuild, {
+                    status: undefined
+                });
+                assert.deepEqual(reply.result, testBuild);
+            })
+        );
+
+        it('return 404 if there is no last build found', () => {
+            const status = 'SUCCESS';
+
+            job.getLatestBuild.resolves({});
+            options.url = `/pipelines/${id}/${name}/latestBuild/latestBuild?status=${status}`;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 404);
             });
         });
     });

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -754,7 +754,7 @@ describe('pipeline plugin test', () => {
         });
     });
 
-    describe('GET /pipelines/{id}/{jobName}/latestBuild', () => {
+    describe('GET /pipelines/{id}/jobs/{jobName}/latestBuild', () => {
         const id = 1234;
         const name = 'deploy';
         let options;
@@ -764,7 +764,7 @@ describe('pipeline plugin test', () => {
         beforeEach(() => {
             options = {
                 method: 'GET',
-                url: `/pipelines/${id}/${name}/latestBuild`
+                url: `/pipelines/${id}/jobs/${name}/latestBuild`
             };
 
             job = getJobsMocks(testJob);
@@ -796,7 +796,7 @@ describe('pipeline plugin test', () => {
             const status = 'SUCCESS';
 
             job.getLatestBuild.resolves({});
-            options.url = `/pipelines/${id}/${name}/latestBuild/latestBuild?status=${status}`;
+            options.url = `/pipelines/${id}/jobs/${name}/latestBuild/latestBuild?status=${status}`;
 
             return server.inject(options).then((reply) => {
                 assert.equal(reply.statusCode, 404);


### PR DESCRIPTION
## Context

Previously we added an endpoint for that returns latest build for a given job using job id, but user might not have job id so they would need to make a separate call to get job id. 

## Objective

Add another endpoint that would retrieve latest build using job name and pipeline id

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1717

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
