### PR TITLE
fix: post build api creating build twice

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -112,7 +112,8 @@ module.exports = () => ({
                                         type,
                                         username,
                                         scmContext,
-                                        sha
+                                        sha,
+                                        skipMessage: 'skip build creation'
                                     });
                                 })
                                 .then((event) => {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1836,7 +1836,8 @@ describe('build plugin test', () => {
                 username,
                 scmContext,
                 sha: testBuild.sha,
-                meta
+                meta,
+                skipMessage: 'skip build creation'
             };
 
             jobMock.pipeline = sinon.stub().resolves(pipelineMock)();

--- a/test/plugins/data/validator.output.json
+++ b/test/plugins/data/validator.output.json
@@ -78,6 +78,7 @@
             }
         ]
     },
+    "parameters": {},
     "workflowGraph": {
         "nodes": [
             { "name": "~pr" },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
previous commit breaks an functional test where POST /build would actually create build twice

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add a skipMessage when we create event so it would skip build creation
 
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/1773

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
