### PR TITLE
fix: allow pipeline token to fetch metrics

### DIFF
--- a/plugins/events/metrics.js
+++ b/plugins/events/metrics.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'events', 'metrics'],
         auth: {
             strategies: ['token'],
-            scope: ['user', '!guest', 'event']
+            scope: ['user', '!guest', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/jobs/metrics.js
+++ b/plugins/jobs/metrics.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'jobs', 'metrics'],
         auth: {
             strategies: ['token'],
-            scope: ['user', '!guest', 'job']
+            scope: ['user', '!guest', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
Probably a copy/paste mistake from before