### PR TITLE
fix: webhook error when finding pipelines to trigger

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -165,11 +165,17 @@ function stopJob({ job, prNum, action }) {
  * @returns {Boolean}               True if the pipeline contains the triggered job
  */
 function hasTriggeredJob(pipeline, startFrom) {
-    const nextJobs = workflowParser.getNextJobs(pipeline.workflowGraph, {
-        trigger: startFrom
-    });
+    try {
+        const nextJobs = workflowParser.getNextJobs(pipeline.workflowGraph, {
+            trigger: startFrom
+        });
 
-    return nextJobs.length > 0;
+        return nextJobs.length > 0;
+    } catch (err) {
+        winston.error(`Error finding triggered jobs for ${pipeline.id}: ${err}`);
+
+        return false;
+    }
 }
 
 /**

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -1378,7 +1378,19 @@ describe('webhooks plugin test', () => {
                         branch: Promise.resolve('fix-1')
                     });
 
-                    pipelineFactoryMock.list.resolves([pipelineMock, pMock1, pMock2, pMock3]);
+                    const pMock4 = getPipelineMocks({
+                        id: 'pipelineHash4',
+                        scmUri: 'github.com:123456:fix-2',
+                        annotations: {},
+                        admins: {
+                            baxterthehacker: false
+                        },
+                        branch: Promise.resolve('fix-1')
+                    });
+
+                    pipelineFactoryMock.list.resolves([
+                        pipelineMock, pMock1, pMock2, pMock3, pMock4
+                    ]);
 
                     return server.inject(options).then((reply) => {
                         assert.equal(reply.statusCode, 201);


### PR DESCRIPTION
## Context

When processing webhooks, there could be pipelines which do not have a valid workflow graph. For example child pipelines which does not have any events.

## Objective

Webhook processing should be resilient to errors in pipelines on non commit branch.  

## References

```
data: TypeError: Cannot read property 'edges' of undefined
at Object.getNextJobs (/usr/src/app/node_modules/screwdriver-workflow-parser/lib/getNextJobs.js:29:19)
at hasTriggeredJob (/usr/src/app/node_modules/screwdriver-api/plugins/webhooks/index.js:168:37)
at pipelinesOnOtherBranch.filter.p (/usr/src/app/node_modules/screwdriver-api/plugins/webhooks/index.js:272:9)
at Array.filter (<anonymous>)
at triggeredPipelines (/usr/src/app/node_modules/screwdriver-api/plugins/webhooks/index.js:271:53)
at <anonymous>
```

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
