### PR TITLE
fix(1675): Always pass in causeMessage to build create

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -28,9 +28,9 @@ module.exports = () => ({
             const scm = buildFactory.scm;
             const username = request.auth.credentials.username;
             const scmContext = request.auth.credentials.scmContext;
-            const meta = request.payload.meta;
+            const { meta, jobId } = request.payload;
             const payload = {
-                jobId: request.payload.jobId,
+                jobId,
                 apiUri: request.server.info.uri,
                 username,
                 scmContext
@@ -125,6 +125,12 @@ module.exports = () => ({
                                     if (prInfo) {
                                         payload.prRef = prInfo.ref;
                                     }
+
+                                    const displayLabel = scmContext.split(':')[0];
+                                    const displayName = displayLabel ?
+                                        `${displayLabel}:${user.username}` : user.username;
+
+                                    payload.causeMessage = `Started by ${displayName}`;
 
                                     return buildFactory.create(payload);
                                 });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1823,6 +1823,7 @@ describe('build plugin test', () => {
                 id: 12345
             };
             params = {
+                causeMessage: `Started by github:${username}`,
                 jobId: 1234,
                 eventId: 12345,
                 apiUri: 'http://localhost:12345',


### PR DESCRIPTION
## Context

Functional tests are failing when calling build create API endpoint directly. This is because the new executor changes expect `causeMessage` to be passed in.

## Objective

This PR always passes in causeMessage to build create.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1675

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
