### PR TITLE
fix: Increase unit test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 3000 --exit",
+    "test": "jenkins-mocha --recursive --timeout 4000 --exit",
     "start": "./bin/server",
     "functional": "cucumber-js --format=pretty --tags 'not @ignore'",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",


### PR DESCRIPTION
## Context

The unit tests have been failing with timeout.

## Objective

This PR increases unit test timeout from 3000 to 4000.

## References

Failing builds: https://cd.screwdriver.cd/pipelines/1/builds/152628/steps/test, https://cd.screwdriver.cd/pipelines/1/builds/152619/steps/test

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
