### PR TITLE
fix(1801): Do not allow changes on default collection

### DIFF
--- a/plugins/collections/update.js
+++ b/plugins/collections/update.js
@@ -46,6 +46,12 @@ module.exports = () => ({
                         throw boom.forbidden(`User ${username} does not own this collection`);
                     }
 
+                    if (oldCollection.type === 'default') {
+                        throw boom.forbidden(`
+                            Collection with type "default" cannot be changed by user
+                        `);
+                    }
+
                     Object.assign(oldCollection, request.payload);
 
                     // Check that all pipelines exist before updating the pipelineIds of

--- a/test/plugins/collections.test.js
+++ b/test/plugins/collections.test.js
@@ -618,6 +618,17 @@ describe('collection plugin test', () => {
                 });
         });
 
+        it('returns 403 when the collection to be changed has type "default"', () => {
+            const defaultCollection = Object.assign({}, testCollection, { type: 'default' });
+            const defaultCollectionMock = getMock(defaultCollection);
+
+            collectionFactoryMock.get.withArgs({ id }).resolves(defaultCollectionMock);
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 403);
+            });
+        });
+
         it('returns 404 when the collection id is not found', () => {
             collectionFactoryMock.get.withArgs({ id }).resolves(null);
 


### PR DESCRIPTION
## Context

Previously users are able to change their default collection, we have disabled this on ui. We should also add a guard on api level.

## Objective

Add a check on POST /collection/id to prevent modification on `My pipelines`, which Collection type is `default`

## References

https://github.com/screwdriver-cd/screwdriver/issues/1801

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
