### PR TITLE
Fix coverage-sonar version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "screwdriver-command-validator": "^1.0.5",
     "screwdriver-config-parser": "^4.11.5",
     "screwdriver-coverage-bookend": "^1.0.3",
-    "screwdriver-coverage-sonar": "^1.0.22",
+    "screwdriver-coverage-sonar": "^1.0.25",
     "screwdriver-data-schema": "^18.47.7",
     "screwdriver-datastore-sequelize": "^5.8.1",
     "screwdriver-executor-docker": "^4.2.0",


### PR DESCRIPTION
## Context
I want to import [coverage-sonar#30](https://github.com/screwdriver-cd/coverage-sonar/pull/30)
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- `screwdriver-coverage-sonar` is version up 1.0.25 from 1.0.22
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
