### PR TITLE
fix: enable taking sort param for pipeline metrics

### DIFF
--- a/plugins/pipelines/metrics.js
+++ b/plugins/pipelines/metrics.js
@@ -25,7 +25,7 @@ module.exports = () => ({
         handler: (request, reply) => {
             const factory = request.server.app.pipelineFactory;
             const { id } = request.params;
-            const { aggregateInterval, page, count } = request.query;
+            const { aggregateInterval, page, count, sort } = request.query;
             let { startTime, endTime } = request.query;
 
             return factory.get(id)
@@ -34,7 +34,7 @@ module.exports = () => ({
                         throw boom.notFound('Pipeline does not exist');
                     }
 
-                    let config = { page, count };
+                    let config = { page, count, sort };
 
                     // Only when either page or count is unavailable
                     // check whether startTime and endTime are valid

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2034,7 +2034,8 @@ describe('pipeline plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.calledWith(pipelineMock.getMetrics, {
                     page,
-                    count
+                    count,
+                    sort: 'descending'
                 });
             });
         });


### PR DESCRIPTION
## Context

Allow taking is `sort` as query param.

## Objective

Collections card view needs information of latest page of data. Model has by default `ascending` as sort order.

## References

https://github.com/screwdriver-cd/models/pull/404

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
