### PR TITLE
fix(1816): Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "winston": "^2.4.4"
   },
   "devDependencies": {
-    "@octokit/rest": "^16.33.1",
+    "@octokit/rest": "~16.33",
     "chai": "~3.5.0",
     "chai-as-promised": "^6.0.0",
     "chai-jwt": "^2.0.0",


### PR DESCRIPTION
## Context
Because don't import breaking change about [#1816](https://github.com/screwdriver-cd/screwdriver/issues/1816)
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Pined version to `16.33.x`
- Support old API about request URL
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1816
https://github.com/octokit/rest.js/commit/e891d4e31c41e7a6afe0c8257404bf1f51607f5e#diff-0071a9eb9e809c9aacfc547f7514add6L1066
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.