### PR TITLE
Feature/periodic build

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -20,7 +20,7 @@ function registerDefaultPlugins(server, callback) {
         '../plugins/swagger',
         '../plugins/validator',
         '../plugins/template-validator',
-        '../plugins/command-validator'
+        '../plugins/command-validator',
     ].map(plugin => require(plugin));
 
     async.eachSeries(plugins, (plugin, next) => {
@@ -29,6 +29,15 @@ function registerDefaultPlugins(server, callback) {
                 prefix: '/v4'
             }
         }, next);
+    }, callback);
+}
+
+function registerCustomPlugin(server, callback) {
+    async.eachSeries(['shutdown'], (pluginName, next) => {
+        server.register({
+            register: require(`../plugins/${pluginName}`),
+            options: { terminationGracePeriod: process.env.TERMINATION_GRACE_PERIOD || 30 }
+        }, {}, next);
     }, callback);
 }
 
@@ -94,7 +103,8 @@ module.exports = (server, config) => (
     new Promise((resolve, reject) => {
         async.series([
             async.apply(registerDefaultPlugins, server),
-            async.apply(registerResourcePlugins, server, config)
+            async.apply(registerResourcePlugins, server, config),
+            async.apply(registerCustomPlugin, server)
         ], (err) => {
             if (err) {
                 return reject(err);

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -20,7 +20,7 @@ function registerDefaultPlugins(server, callback) {
         '../plugins/swagger',
         '../plugins/validator',
         '../plugins/template-validator',
-        '../plugins/command-validator',
+        '../plugins/command-validator'
     ].map(plugin => require(plugin));
 
     async.eachSeries(plugins, (plugin, next) => {
@@ -32,6 +32,11 @@ function registerDefaultPlugins(server, callback) {
     }, callback);
 }
 
+/**
+ *
+ * @param {Hapi.Server} server
+ * @param {Function} callback
+ */
 function registerCustomPlugin(server, callback) {
     async.eachSeries(['shutdown'], (pluginName, next) => {
         server.register({

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -33,7 +33,7 @@ function registerDefaultPlugins(server, callback) {
 }
 
 /**
- *
+ * Registers custom plugins for housekeeping tasks of the server
  * @param {Hapi.Server} server
  * @param {Function} callback
  */

--- a/lib/server.js
+++ b/lib/server.js
@@ -147,11 +147,14 @@ module.exports = (config) => {
             server.plugins.shutdown.handler({
                 taskname: 'executor-queue-cleanup',
                 task: async () => {
-                            await server.app.jobFactory.cleanUp()
-                            server.log(["shutdown"], "completed clean up tasks", new Date().toISOString());
+                    await server.app.jobFactory.cleanUp();
+                    server.log(['shutdown'], 'completed clean up tasks', new Date().toISOString());
                 }
-            })
+            });
+
             // Start the server
-            return server.start().then(() => server).catch(err => console.log('Failed to start server', err));
+            return server.start()
+                .then(() => server)
+                .catch(err => console.log('Failed to start server', err));
         });
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -152,14 +152,16 @@ module.exports = (config) => {
                     .generateProfile(username, scmContext, ['user'], metadata)
                 );
             server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
-            server.plugins.shutdown.handler({
-                taskname: 'executor-queue-cleanup',
-                task: () => new Promise(async (resolve) => {
-                    await server.app.jobFactory.cleanUp();
-                    logger.info('completed clean up tasks');
-                    resolve();
-                })
-            });
+            if (server.plugins.shutdown) {
+                server.plugins.shutdown.handler({
+                    taskname: 'executor-queue-cleanup',
+                    task: () => new Promise(async (resolve) => {
+                        await server.app.jobFactory.cleanUp();
+                        logger.info('completed clean up tasks');
+                        resolve();
+                    })
+                });
+            }
 
             // Start the server
             return server.start()

--- a/lib/server.js
+++ b/lib/server.js
@@ -144,8 +144,14 @@ module.exports = (config) => {
                     .generateProfile(username, scmContext, ['user'], metadata)
                 );
             server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
-
+            server.plugins.shutdown.handler({
+                taskname: 'executor-queue-cleanup',
+                task: async () => {
+                            await server.app.jobFactory.cleanUp()
+                            server.log(["shutdown"], "completed clean up tasks", new Date().toISOString());
+                }
+            })
             // Start the server
-            return server.start().then(() => server);
+            return server.start().then(() => server).catch(err => console.log('Failed to start server', err));
         });
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,6 +2,14 @@
 
 const Hapi = require('hapi');
 const registrationMan = require('./registerPlugins');
+const winston = require('winston');
+
+winston.level = process.env.LOG_LEVEL || 'info';
+const logger = new (winston.Logger)({
+    transports: [
+        new (winston.transports.Console)({ timestamp: true })
+    ]
+});
 
 /**
  * If we're throwing errors, let's have them say a little more than just 500
@@ -146,15 +154,16 @@ module.exports = (config) => {
             server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
             server.plugins.shutdown.handler({
                 taskname: 'executor-queue-cleanup',
-                task: async () => {
+                task: () => new Promise(async (resolve) => {
                     await server.app.jobFactory.cleanUp();
-                    server.log(['shutdown'], 'completed clean up tasks', new Date().toISOString());
-                }
+                    logger.info('completed clean up tasks');
+                    resolve();
+                })
             });
 
             // Start the server
             return server.start()
                 .then(() => server)
-                .catch(err => console.log('Failed to start server', err));
+                .catch(err => logger.error('Failed to start server', err));
         });
 };

--- a/plugins/shutdown.js
+++ b/plugins/shutdown.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const Joi = require("joi");
+const tasks = {};
+const taskSchema = Joi.object({
+    taskname: Joi.string().required(),
+    task: Joi.func().required(),
+    timeout: Joi.number().integer()
+});
+
+/**
+ * Hapi interface for plugin to handle serve graceful shutdown
+ * @method register
+ * @param  {Hapi.Server}    server
+ * @param  {Object}         options
+ */
+exports.register = (server, options, next) => {
+    const taskHandler = async (resolve, reject) => {
+        try {
+            await Promise.all(Object.keys(tasks).map(async key => {
+                server.log(["shutdown"], `executing task ${key}`, new Date().toISOString())
+                let item = tasks[key]
+                await item.task();
+            }))
+            resolve()
+        }
+        catch (err) {
+            console.log(err)
+            reject(err)
+        }
+    }
+    const gracefulStop = async () => {
+        try {
+            server.log(["shutdown"], `gracefully shutting down server`, new Date().toISOString());
+            await server.root.stop({
+                timeout: 5000
+            });
+            process.exit(0);
+        }
+        catch (err) {
+            console.log(err)
+            process.exit(1);
+        }
+    }
+
+    const onSigterm = async () => {
+        try {
+            server.log(["shutdown"], "got SIGTERM; running triggers before shutdown", new Date().toISOString());
+            let res = await promiseTimeout(taskHandler, options.terminationGracePeriod * 1000)
+            if(res) {
+                server.log(["shutdown"], res, new Date().toISOString());
+            }
+            await gracefulStop()
+        }
+        catch (err) {
+            console.log(err)
+        }
+    }
+
+    process.on('SIGTERM', onSigterm)
+    server.expose('handler', register);
+    next()
+}
+
+exports.register.attributes = {
+    name: 'shutdown'
+};
+
+function register(task) {
+    let res = taskSchema.validate(task);
+    if (res.error) {
+        return res.error;
+    }
+    tasks[task.taskname] = task;
+}
+
+function promiseTimeout(fn, timeout) {
+    return new Promise(function (resolve, reject) {
+        fn(resolve, reject);
+
+        // Set up the timeout
+        setTimeout(function () {
+            resolve('Promise timed out after ' + timeout + ' ms');
+        }, timeout);
+    });
+}

--- a/plugins/shutdown.js
+++ b/plugins/shutdown.js
@@ -42,8 +42,7 @@ function promiseTimeout(fn, timeout) {
     return Promise.race([
         Promise.resolve(fn),
         new Promise((resolve) => {
-            const id = setTimeout(() => {
-                clearTimeout(id);
+            setTimeout(() => {
                 resolve(`Promise timed out after ${timeout} ms`);
             }, timeout);
         })

--- a/plugins/shutdown.js
+++ b/plugins/shutdown.js
@@ -1,12 +1,43 @@
 'use strict';
 
-const Joi = require("joi");
+const Joi = require('joi');
 const tasks = {};
 const taskSchema = Joi.object({
     taskname: Joi.string().required(),
     task: Joi.func().required(),
     timeout: Joi.number().integer()
 });
+
+/**
+ *
+ * @param {object} task
+ */
+function register(task) {
+    const res = taskSchema.validate(task);
+
+    if (res.error) {
+        return res.error;
+    }
+    tasks[task.taskname] = task;
+
+    return '';
+}
+
+/**
+ *
+ * @param {function} fn
+ * @param {string} timeout
+ */
+function promiseTimeout(fn, timeout) {
+    return new Promise(((resolve, reject) => {
+        fn(resolve, reject);
+
+        // Set up the timeout
+        setTimeout(() => {
+            resolve(`Promise timed out after ${timeout} ms`);
+        }, timeout);
+    }));
+}
 
 /**
  * Hapi interface for plugin to handle serve graceful shutdown
@@ -17,70 +48,52 @@ const taskSchema = Joi.object({
 exports.register = (server, options, next) => {
     const taskHandler = async (resolve, reject) => {
         try {
-            await Promise.all(Object.keys(tasks).map(async key => {
-                server.log(["shutdown"], `executing task ${key}`, new Date().toISOString())
-                let item = tasks[key]
+            await Promise.all(Object.keys(tasks).map(async (key) => {
+                server.log(['shutdown'], `executing task ${key}`, new Date().toISOString());
+                const item = tasks[key];
+
                 await item.task();
-            }))
-            resolve()
+            }));
+            resolve();
+        } catch (err) {
+            console.log(err);
+            reject(err);
         }
-        catch (err) {
-            console.log(err)
-            reject(err)
-        }
-    }
+    };
     const gracefulStop = async () => {
         try {
-            server.log(["shutdown"], `gracefully shutting down server`, new Date().toISOString());
+            server.log(['shutdown'], 'gracefully shutting down server', new Date().toISOString());
             await server.root.stop({
                 timeout: 5000
             });
             process.exit(0);
-        }
-        catch (err) {
-            console.log(err)
+        } catch (err) {
+            console.log(err);
             process.exit(1);
         }
-    }
+    };
 
     const onSigterm = async () => {
         try {
-            server.log(["shutdown"], "got SIGTERM; running triggers before shutdown", new Date().toISOString());
-            let res = await promiseTimeout(taskHandler, options.terminationGracePeriod * 1000)
-            if(res) {
-                server.log(["shutdown"], res, new Date().toISOString());
-            }
-            await gracefulStop()
-        }
-        catch (err) {
-            console.log(err)
-        }
-    }
+            server.log(['shutdown'],
+                'got SIGTERM; running triggers before shutdown',
+                new Date().toISOString());
+            const res = await promiseTimeout(taskHandler, options.terminationGracePeriod * 1000);
 
-    process.on('SIGTERM', onSigterm)
+            if (res) {
+                server.log(['shutdown'], res, new Date().toISOString());
+            }
+            await gracefulStop();
+        } catch (err) {
+            console.log(err);
+        }
+    };
+
+    process.on('SIGTERM', onSigterm);
     server.expose('handler', register);
-    next()
-}
+    next();
+};
 
 exports.register.attributes = {
     name: 'shutdown'
 };
-
-function register(task) {
-    let res = taskSchema.validate(task);
-    if (res.error) {
-        return res.error;
-    }
-    tasks[task.taskname] = task;
-}
-
-function promiseTimeout(fn, timeout) {
-    return new Promise(function (resolve, reject) {
-        fn(resolve, reject);
-
-        // Set up the timeout
-        setTimeout(function () {
-            resolve('Promise timed out after ' + timeout + ' ms');
-        }, timeout);
-    });
-}

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -35,7 +35,10 @@ describe('Register Unit Test Case', () => {
         '../plugins/stats',
         '../plugins/isAdmin'
     ];
-    const pluginLength = expectedPlugins.length + resourcePlugins.length;
+    const customPlugins = [
+        '../plugins/shutdown'
+    ];
+    const pluginLength = expectedPlugins.length + resourcePlugins.length + customPlugins.length;
     const mocks = {};
     const config = {};
     let main;
@@ -63,6 +66,12 @@ describe('Register Unit Test Case', () => {
             mocks[plugin] = sinon.stub();
             mockery.registerMock(plugin, mocks[plugin]);
         });
+
+        customPlugins.forEach((plugin) => {
+            mocks[plugin] = sinon.stub();
+            mockery.registerMock(plugin, mocks[plugin]);
+        });
+
         /* eslint-disable global-require */
         main = require('../../lib/registerPlugins');
         /* eslint-enable global-require */
@@ -108,6 +117,21 @@ describe('Register Unit Test Case', () => {
                         prefix: '/v4'
                     }
                 });
+            });
+        });
+    });
+
+    it('registered custom plugins', () => {
+        serverMock.register.callsArgAsync(2);
+
+        return main(serverMock, config).then(() => {
+            Assert.equal(serverMock.register.callCount, pluginLength);
+
+            customPlugins.forEach((plugin) => {
+                Assert.calledWith(serverMock.register, {
+                    register: mocks[plugin],
+                    options: { terminationGracePeriod: 30 }
+                }, {});
             });
         });
     });

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -189,6 +189,10 @@ describe('server case', () => {
                     }
                 });
 
+                server.plugins.shutdown = {
+                    handler: sinon.stub()
+                };
+
                 return Promise.resolve();
             });
             /* eslint-disable global-require */

--- a/test/plugins/shutdown.test.js
+++ b/test/plugins/shutdown.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const hapi = require('hapi');
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('test shutdown plugin', () => {
+    let plugin;
+    let server;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach((done) => {
+        /* eslint-disable global-require */
+        plugin = require('../../plugins/shutdown');
+        /* eslint-enable global-require */
+
+        server = new hapi.Server();
+        server.connection({
+            port: 1234
+        });
+
+        server.register([{
+            register: plugin
+        }], (err) => {
+            done(err);
+        });
+    });
+
+    afterEach(() => {
+        server = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('registers the plugin', () => {
+        assert.isOk(server.registrations.shutdown);
+    });
+});
+
+describe('test graceful shutdown', () => {
+    before(() => {
+        sinon.stub(process, 'exit');
+    });
+
+    after(() => {
+        process.exit.restore();
+    });
+
+    it('should catch the SIGTERM signal', () => {
+        /* eslint-disable global-require */
+        const plugin = require('../../plugins/shutdown');
+        /* eslint-enable global-require */
+        const options = {
+            terminationGracePeriod: 30
+        };
+        let stopCalled = false;
+        const server = new hapi.Server();
+
+        server.connection({
+            port: 1234
+        });
+
+        server.log = () => { };
+        server.root = { stop: () => { stopCalled = true; } };
+        server.expose = sinon.stub();
+
+        plugin.register(server, options, () => { });
+
+        process.exit(1);
+        process.exit.callsFake(() => {
+            assert.isTrue(stopCalled);
+        });
+        assert(process.exit.isSinonProxy);
+        sinon.assert.called(process.exit);
+        sinon.assert.calledWith(process.exit, 1);
+    });
+});


### PR DESCRIPTION
## Context

Currently when the node process terminates it happens abruptly and the in process messages are lost

## Objective

This PR adds a graceful shutdown plugin which can handle any task registered to be executed during termination

## References

https://github.com/screwdriver-cd/screwdriver/issues/1610

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
