### PR TITLE
feat(1830): add cluster level config for cache strategy

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -261,10 +261,11 @@ executor:
           password: QUEUE_REDIS_PASSWORD
           tls: QUEUE_REDIS_TLS_ENABLED
         database: QUEUE_REDIS_DATABASE
-  # build cache strategies: s3, disk, with s3 as default option to store cache
-  cache:
-      strategy: CACHE_STRATEGY
-      path: CACHE_PATH
+
+# build cache strategies: s3, disk, with s3 as default option to store cache
+cache:
+  strategy: CACHE_STRATEGY
+  path: CACHE_PATH
 
 scms:
   __name: SCM_SETTINGS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -261,6 +261,9 @@ executor:
           password: QUEUE_REDIS_PASSWORD
           tls: QUEUE_REDIS_TLS_ENABLED
         database: QUEUE_REDIS_DATABASE
+  # build cache strategies: s3, disk, with s3 as default option to store cache
+  cache:
+      strategy: CACHE_STRATEGY
 
 scms:
   __name: SCM_SETTINGS

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -264,6 +264,7 @@ executor:
   # build cache strategies: s3, disk, with s3 as default option to store cache
   cache:
       strategy: CACHE_STRATEGY
+      path: CACHE_PATH
 
 scms:
   __name: SCM_SETTINGS

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -178,10 +178,11 @@ executor:
           password: "THIS-IS-A-PASSWORD"
           tls: false
         database: 0
+
 # build cache strategies: s3, disk, with s3 as default option to store cache
-  cache:
-      strategy: s3
-      path: ""
+cache:
+  strategy: s3
+  path: ""
 
 scms: {}
 #   github:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -181,6 +181,7 @@ executor:
 # build cache strategies: s3, disk, with s3 as default option to store cache
   cache:
       strategy: s3
+      path: ""
 
 scms: {}
 #   github:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -178,6 +178,9 @@ executor:
           password: "THIS-IS-A-PASSWORD"
           tls: false
         database: 0
+# build cache strategies: s3, disk, with s3 as default option to store cache
+  cache:
+      strategy: s3
 
 scms: {}
 #   github:


### PR DESCRIPTION
## Context

Screwdriver supports aws s3 cache strategy to store build cache. Need option / strategy to store build cache to disk.

## Objective

- Add cluster-level configuration  for cache strategies (s3, disk)
- Default: s3

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
