### PR TITLE
feat(1610): Add parseInt to terminationgraceperiod

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -42,7 +42,7 @@ function registerCustomPlugin(server, callback) {
         server.register({
             register: require(`../plugins/${pluginName}`),
             options: {
-                terminationGracePeriod: parseInt(process.env.TERMINATION_GRACE_PERIOD, 2)
+                terminationGracePeriod: parseInt(process.env.TERMINATION_GRACE_PERIOD, 10)
                     || 30
             }
         }, {}, next);

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -41,7 +41,10 @@ function registerCustomPlugin(server, callback) {
     async.eachSeries(['shutdown'], (pluginName, next) => {
         server.register({
             register: require(`../plugins/${pluginName}`),
-            options: { terminationGracePeriod: process.env.TERMINATION_GRACE_PERIOD || 30 }
+            options: {
+                terminationGracePeriod: parseInt(process.env.TERMINATION_GRACE_PERIOD, 2)
+                    || 30
+            }
         }, {}, next);
     }, callback);
 }


### PR DESCRIPTION
env var

## Context
The env var from k8s is type string for terminationGracePeriodSceonds

## Objective

This adds a parseInt to the env var

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
