### PR TITLE
fix: use cucumber 6

### DIFF
--- a/features/step_definitions/api-token.js
+++ b/features/step_definitions/api-token.js
@@ -4,59 +4,94 @@ const Assert = require('chai').assert;
 const jwt = require('jsonwebtoken');
 const request = require('../support/request');
 const sdapi = require('../support/sdapi');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, When, Then } = require('cucumber');
 
-defineSupportCode(({ Before, Given, When, Then }) => {
-    Before('@apitoken', function hook() {
-        this.loginResponse = null;
-        this.testToken = null;
-        this.updatedToken = null;
+Before('@apitoken', function hook() {
+    this.loginResponse = null;
+    this.testToken = null;
+    this.updatedToken = null;
+});
+
+Given(/^"calvin" does not own a token named "([^"]*)"$/, function step(token) {
+    // Ensure there won't be a conflict: delete the token if it's already there
+    return sdapi.cleanupToken({
+        token,
+        instance: this.instance,
+        namespace: this.namespace,
+        jwt: this.jwt
     });
+});
 
-    Given(/^"calvin" does not own a token named "([^"]*)"$/, function step(token) {
-        // Ensure there won't be a conflict: delete the token if it's already there
-        return sdapi.cleanupToken({
-            token,
-            instance: this.instance,
-            namespace: this.namespace,
-            jwt: this.jwt
-        });
+When(/^a new API token named "([^"]*)" is generated$/, function step(tokenName) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/tokens`,
+        method: 'POST',
+        auth: {
+            bearer: this.jwt
+        },
+        body: {
+            name: tokenName
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 201);
+        Assert.strictEqual(response.body.lastUsed, '');
+        // Check that it's a base64 value of the right length to be a token
+        // encoded with https://www.npmjs.com/package/base64url
+        Assert.match(response.body.value, /[a-zA-Z0-9_-]{43}/);
+        this.testToken = response.body;
     });
+});
 
-    When(/^a new API token named "([^"]*)" is generated$/, function step(tokenName) {
-        return request({
-            uri: `${this.instance}/${this.namespace}/tokens`,
-            method: 'POST',
-            auth: {
-                bearer: this.jwt
-            },
-            body: {
-                name: tokenName
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 201);
-            Assert.strictEqual(response.body.lastUsed, '');
-            // Check that it's a base64 value of the right length to be a token
-            // encoded with https://www.npmjs.com/package/base64url
-            Assert.match(response.body.value, /[a-zA-Z0-9_-]{43}/);
+When(/^the token is used to log in$/, function step() {
+    return this.loginWithToken(this.testToken.value);
+});
+
+Then(/^a valid JWT is received that represents "calvin"$/, function step() {
+    Assert.strictEqual(this.loginResponse.statusCode, 200);
+
+    const decodedToken = jwt.decode(this.loginResponse.body.token);
+
+    Assert.strictEqual(decodedToken.username, this.username);
+});
+
+Then(/^the "([^"]*)" token's 'last used' property is updated$/, function step(tokenName) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/tokens`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        const lastUsed = response.body
+            .find(token => token.name === tokenName)
+            .lastUsed;
+
+        Assert.notEqual(lastUsed, '');
+    });
+});
+
+Given(/^"calvin" owns an existing API token named "([^"]*)"$/, function step(tokenName) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/tokens`,
+        method: 'POST',
+        auth: {
+            bearer: this.jwt
+        },
+        body: {
+            name: tokenName
+        },
+        json: true
+    }).then((response) => {
+        Assert.oneOf(response.statusCode, [409, 201]);
+
+        if (response.statusCode === 201) {
             this.testToken = response.body;
-        });
-    });
 
-    When(/^the token is used to log in$/, function step() {
-        return this.loginWithToken(this.testToken.value);
-    });
+            return null;
+        }
 
-    Then(/^a valid JWT is received that represents "calvin"$/, function step() {
-        Assert.strictEqual(this.loginResponse.statusCode, 200);
-
-        const decodedToken = jwt.decode(this.loginResponse.body.token);
-
-        Assert.strictEqual(decodedToken.username, this.username);
-    });
-
-    Then(/^the "([^"]*)" token's 'last used' property is updated$/, function step(tokenName) {
         return request({
             uri: `${this.instance}/${this.namespace}/tokens`,
             method: 'GET',
@@ -64,148 +99,111 @@ defineSupportCode(({ Before, Given, When, Then }) => {
                 bearer: this.jwt
             },
             json: true
-        }).then((response) => {
-            const lastUsed = response.body
-                .find(token => token.name === tokenName)
-                .lastUsed;
+        }).then((listResponse) => {
+            Assert.strictEqual(listResponse.statusCode, 200);
 
-            Assert.notEqual(lastUsed, '');
+            this.testToken = listResponse.body
+                .find(token => token.name === tokenName);
         });
     });
+});
 
-    Given(/^"calvin" owns an existing API token named "([^"]*)"$/, function step(tokenName) {
-        return request({
-            uri: `${this.instance}/${this.namespace}/tokens`,
-            method: 'POST',
-            auth: {
-                bearer: this.jwt
-            },
-            body: {
-                name: tokenName
-            },
-            json: true
-        }).then((response) => {
-            Assert.oneOf(response.statusCode, [409, 201]);
+When(/^he lists all his tokens$/, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/tokens`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 200);
 
-            if (response.statusCode === 201) {
-                this.testToken = response.body;
-
-                return null;
-            }
-
-            return request({
-                uri: `${this.instance}/${this.namespace}/tokens`,
-                method: 'GET',
-                auth: {
-                    bearer: this.jwt
-                },
-                json: true
-            }).then((listResponse) => {
-                Assert.strictEqual(listResponse.statusCode, 200);
-
-                this.testToken = listResponse.body
-                    .find(token => token.name === tokenName);
-            });
-        });
+        this.tokenList = response.body;
     });
+});
 
-    When(/^he lists all his tokens$/, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/tokens`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
+Then(/^his "([^"]*)" token is in the list$/, function step(tokenName) {
+    const match = this.tokenList.find(token => token.name === tokenName);
 
-            this.tokenList = response.body;
-        });
+    Assert.isOk(match);
+
+    this.testToken = match;
+});
+
+Then(/^his token is safely described$/, function step() {
+    const expectedKeys = ['id', 'name', 'lastUsed'];
+    const forbiddenKeys = ['hash', 'value'];
+
+    expectedKeys.forEach(property =>
+        Assert.property(this.testToken, property));
+
+    forbiddenKeys.forEach(property =>
+        Assert.notProperty(this.testToken, property));
+});
+
+When(/^he changes the label associated with the token$/, function step() {
+    // Make sure update is getting called with a value that isn't already there
+    this.newDescription = this.testToken.description === 'tiger' ? 'not tiger' : 'tiger';
+
+    return request({
+        uri: `${this.instance}/${this.namespace}/tokens/${this.testToken.id}`,
+        method: 'PUT',
+        auth: {
+            bearer: this.jwt
+        },
+        body: {
+            description: this.newDescription
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 200);
+
+        this.updatedToken = response.body;
     });
+});
 
-    Then(/^his "([^"]*)" token is in the list$/, function step(tokenName) {
-        const match = this.tokenList.find(token => token.name === tokenName);
+Then(/^his token will have that new label$/, function step() {
+    Assert.strictEqual(this.updatedToken.description, this.newDescription);
+});
 
-        Assert.isOk(match);
+Then(/^the token's 'last used' property will not be updated$/, function step() {
+    Assert.strictEqual(this.updatedToken.lastUsed, this.testToken.lastUsed);
+});
 
-        this.testToken = match;
+When(/^he revokes the token$/, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/tokens/${this.testToken.id}`,
+        method: 'DELETE',
+        auth: {
+            bearer: this.jwt
+        }
+    }).then(response => Assert.strictEqual(response.statusCode, 204));
+});
+
+Then(/^the login attempt fails$/, function step() {
+    Assert.strictEqual(this.loginResponse.statusCode, 401);
+});
+
+When(/^he refreshes the token$/, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/tokens/${this.testToken.id}/refresh`,
+        method: 'PUT',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 200);
+
+        this.updatedToken = response.body;
     });
+});
 
-    Then(/^his token is safely described$/, function step() {
-        const expectedKeys = ['id', 'name', 'lastUsed'];
-        const forbiddenKeys = ['hash', 'value'];
+When(/^the old token value is used to log in$/, function step() {
+    return this.loginWithToken(this.testToken.value);
+});
 
-        expectedKeys.forEach(property =>
-            Assert.property(this.testToken, property));
-
-        forbiddenKeys.forEach(property =>
-            Assert.notProperty(this.testToken, property));
-    });
-
-    When(/^he changes the label associated with the token$/, function step() {
-        // Make sure update is getting called with a value that isn't already there
-        this.newDescription = this.testToken.description === 'tiger' ? 'not tiger' : 'tiger';
-
-        return request({
-            uri: `${this.instance}/${this.namespace}/tokens/${this.testToken.id}`,
-            method: 'PUT',
-            auth: {
-                bearer: this.jwt
-            },
-            body: {
-                description: this.newDescription
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
-
-            this.updatedToken = response.body;
-        });
-    });
-
-    Then(/^his token will have that new label$/, function step() {
-        Assert.strictEqual(this.updatedToken.description, this.newDescription);
-    });
-
-    Then(/^the token's 'last used' property will not be updated$/, function step() {
-        Assert.strictEqual(this.updatedToken.lastUsed, this.testToken.lastUsed);
-    });
-
-    When(/^he revokes the token$/, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/tokens/${this.testToken.id}`,
-            method: 'DELETE',
-            auth: {
-                bearer: this.jwt
-            }
-        }).then(response => Assert.strictEqual(response.statusCode, 204));
-    });
-
-    Then(/^the login attempt fails$/, function step() {
-        Assert.strictEqual(this.loginResponse.statusCode, 401);
-    });
-
-    When(/^he refreshes the token$/, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/tokens/${this.testToken.id}/refresh`,
-            method: 'PUT',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
-
-            this.updatedToken = response.body;
-        });
-    });
-
-    When(/^the old token value is used to log in$/, function step() {
-        return this.loginWithToken(this.testToken.value);
-    });
-
-    When(/^the new token value is used to log in$/, function step() {
-        return this.loginWithToken(this.updatedToken.value);
-    });
+When(/^the new token value is used to log in$/, function step() {
+    return this.loginWithToken(this.updatedToken.value);
 });

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -4,124 +4,122 @@ const Assert = require('chai').assert;
 const request = require('../support/request');
 const jwt = require('jsonwebtoken');
 const TIMEOUT = 240 * 1000;
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, Then } = require('cucumber');
 
-defineSupportCode(({ Before, Given, Then }) => {
-    Before('@auth', function hook() {
-        this.repoOrg = this.testOrg;
-        this.repoName = 'functional-auth';
-        this.pipelineId = null;
-    });
+Before('@auth', function hook() {
+    this.repoOrg = this.testOrg;
+    this.repoName = 'functional-auth';
+    this.pipelineId = null;
+});
 
-    Given(/^an existing repository with these users and permissions:$/, table => table);
+Given(/^an existing repository with these users and permissions:$/, table => table);
 
-    Given(/^an existing pipeline with that repository$/, () => null);
+Given(/^an existing pipeline with that repository$/, () => null);
 
-    Given(/^"([^"]*)" is logged in$/, { timeout: TIMEOUT }, function step(user) {
-        if (!(this.apiToken)) {
-            throw new Error('insufficient set up, missing access key');
+Given(/^"([^"]*)" is logged in$/, { timeout: TIMEOUT }, function step(user) {
+    if (!(this.apiToken)) {
+        throw new Error('insufficient set up, missing access key');
+    }
+
+    return this.getJwt(this.apiToken).then((response) => {
+        const accessToken = response.body.token;
+        const decodedToken = jwt.decode(accessToken);
+
+        this.jwt = accessToken;
+
+        Assert.equal(response.statusCode, 200);
+
+        switch (user) {
+        case 'calvin':
+            Assert.strictEqual(decodedToken.username, this.username);
+            break;
+        case 'github:calvin':
+            Assert.strictEqual(decodedToken.username, this.username);
+            Assert.strictEqual(decodedToken.scmContext, this.scmContext);
+            break;
+        default:
+            return Promise.resolve('pending');
         }
 
-        return this.getJwt(this.apiToken).then((response) => {
-            const accessToken = response.body.token;
-            const decodedToken = jwt.decode(accessToken);
-
-            this.jwt = accessToken;
-
-            Assert.equal(response.statusCode, 200);
-
-            switch (user) {
-            case 'calvin':
-                Assert.strictEqual(decodedToken.username, this.username);
-                break;
-            case 'github:calvin':
-                Assert.strictEqual(decodedToken.username, this.username);
-                Assert.strictEqual(decodedToken.scmContext, this.scmContext);
-                break;
-            default:
-                return Promise.resolve('pending');
-            }
-
-            return null;
-        });
+        return null;
     });
+});
 
-    Then(/^they can see the pipeline$/, { timeout: TIMEOUT }, function step() {
-        return request({ // make sure pipeline exists (TODO: move to Given an existing pipeline with that repository scenario)
-            uri: `${this.instance}/${this.namespace}/pipelines`,
-            method: 'POST',
-            auth: {
-                bearer: this.jwt
-            },
-            body: {
-                checkoutUrl: `git@${this.scmHostname}:${this.repoOrg}/${this.repoName}.git#master`
-            },
-            json: true
-        }).then((response) => {
-            Assert.oneOf(response.statusCode, [409, 201]);
+Then(/^they can see the pipeline$/, { timeout: TIMEOUT }, function step() {
+    return request({ // make sure pipeline exists (TODO: move to Given an existing pipeline with that repository scenario)
+        uri: `${this.instance}/${this.namespace}/pipelines`,
+        method: 'POST',
+        auth: {
+            bearer: this.jwt
+        },
+        body: {
+            checkoutUrl: `git@${this.scmHostname}:${this.repoOrg}/${this.repoName}.git#master`
+        },
+        json: true
+    }).then((response) => {
+        Assert.oneOf(response.statusCode, [409, 201]);
 
-            if (response.statusCode === 201) {
-                this.pipelineId = response.body.id;
-            } else {
-                const str = response.body.message;
-                const id = str.split(': ')[1];
+        if (response.statusCode === 201) {
+            this.pipelineId = response.body.id;
+        } else {
+            const str = response.body.message;
+            const id = str.split(': ')[1];
 
-                this.pipelineId = id;
-            }
-        })
-            .then(() => request({
-                method: 'GET',
-                url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}`,
-                followAllRedirects: true,
-                json: true,
-                auth: {
-                    bearer: this.jwt
-                }
-            }))
-            .then((response) => {
-                Assert.strictEqual(response.statusCode, 200);
-            });
-    });
-
-    Then(/^they can start the "main" job$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/events`,
-            method: 'POST',
-            body: {
-                pipelineId: this.pipelineId,
-                startFrom: 'main'
-            },
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((resp) => {
-            Assert.equal(resp.statusCode, 201);
-            this.eventId = resp.body.id;
-        }).then(() => request({
-            uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+            this.pipelineId = id;
+        }
+    })
+        .then(() => request({
             method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        })).then((resp) => {
-            Assert.equal(resp.statusCode, 200);
-            this.buildId = resp.body[0].id;
-        });
-    });
-
-    Then(/^they can delete the pipeline$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            method: 'DELETE',
-            auth: {
-                bearer: this.jwt
-            },
             url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}`,
-            json: true
-        })
-            .then((resp) => {
-                Assert.strictEqual(resp.statusCode, 204);
-            });
+            followAllRedirects: true,
+            json: true,
+            auth: {
+                bearer: this.jwt
+            }
+        }))
+        .then((response) => {
+            Assert.strictEqual(response.statusCode, 200);
+        });
+});
+
+Then(/^they can start the "main" job$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/events`,
+        method: 'POST',
+        body: {
+            pipelineId: this.pipelineId,
+            startFrom: 'main'
+        },
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((resp) => {
+        Assert.equal(resp.statusCode, 201);
+        this.eventId = resp.body.id;
+    }).then(() => request({
+        uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    })).then((resp) => {
+        Assert.equal(resp.statusCode, 200);
+        this.buildId = resp.body[0].id;
     });
+});
+
+Then(/^they can delete the pipeline$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        method: 'DELETE',
+        auth: {
+            bearer: this.jwt
+        },
+        url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}`,
+        json: true
+    })
+        .then((resp) => {
+            Assert.strictEqual(resp.statusCode, 204);
+        });
 });

--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -2,7 +2,7 @@
 
 const Assert = require('chai').assert;
 const request = require('../support/request');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, Then, When, After } = require('cucumber');
 
 // Timeout of 15 seconds
 const TIMEOUT = 15 * 1000;
@@ -53,249 +53,247 @@ function deleteCollection(id) {
     });
 }
 
-defineSupportCode(({ Before, Given, Then, When, After }) => {
-    Before('@collections', function hook() {
-        this.repoOrg = this.testOrg;
-        this.repoName = 'functional-collections';
-        this.pipelineId = null;
-        this.firstCollectionId = null;
-        this.secondCollectionId = null;
-    });
+Before('@collections', function hook() {
+    this.repoOrg = this.testOrg;
+    this.repoName = 'functional-collections';
+    this.pipelineId = null;
+    this.firstCollectionId = null;
+    this.secondCollectionId = null;
+});
 
-    When(/^they check the default collection$/, { timeout: TIMEOUT }, function step() {
-        return this.ensurePipelineExists({ repoName: this.repoName })
-            .then(() => request({
-                uri: `${this.instance}/${this.namespace}/collections`,
-                method: 'GET',
-                auth: {
-                    bearer: this.jwt
-                },
-                json: true
-            })
-                .then((response) => {
-                    Assert.strictEqual(response.statusCode, 200);
-                    this.defaultCollectionId = response.body.find(collection =>
-                        collection.type === 'default'
-                    ).id;
-                    Assert.notEqual(this.defaultCollectionId, undefined);
-                })
-            );
-    });
-
-    Then(/^they can see the default collection contains that pipeline$/, { timeout: TIMEOUT },
-        function step() {
-            const pipelineId = parseInt(this.pipelineId, 10);
-
-            return request({
-                uri: `${this.instance}/${this.namespace}/collections/${this.defaultCollectionId}`,
-                method: 'GET',
-                auth: {
-                    bearer: this.jwt
-                },
-                json: true
-            }).then((response) => {
-                Assert.strictEqual(response.statusCode, 200);
-                // TODO: May need to change back
-                // Assert.deepEqual(response.body.pipelineIds, [pipelineId]);
-                Assert.include(response.body.pipelineIds, pipelineId);
-            });
-        });
-
-    When(/^they create a new collection "myCollection" with that pipeline$/,
-        { timeout: TIMEOUT }, function step() {
-            return this.ensurePipelineExists({ repoName: this.repoName })
-                .then(() => {
-                    const requestBody = {
-                        name: 'myCollection',
-                        pipelineIds: [this.pipelineId]
-                    };
-
-                    return createCollection.call(this, requestBody);
-                })
-                .then((response) => {
-                    Assert.strictEqual(response.statusCode, 201);
-                    this.firstCollectionId = response.body.id;
-                });
-        });
-
-    Then(/^they can see that collection$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
-            Assert.strictEqual(response.body.name, 'myCollection');
-        });
-    });
-
-    Then(/^the collection contains that pipeline$/, { timeout: TIMEOUT }, function step() {
-        const pipelineId = parseInt(this.pipelineId, 10);
-
-        return request({
-            uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
-            Assert.deepEqual(response.body.pipelineIds, [pipelineId]);
-        });
-    });
-
-    When(/^they create a new collection "myCollection"$/, { timeout: TIMEOUT }, function step() {
-        return createCollection.call(this, { name: 'myCollection' })
-            .then((response) => {
-                Assert.strictEqual(response.statusCode, 201);
-                this.firstCollectionId = response.body.id;
-            });
-    });
-
-    Then(/^the collection is empty$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
-            Assert.deepEqual(response.body.pipelineIds, []);
-        });
-    });
-
-    When(/^they update the collection "myCollection" with that pipeline$/,
-        { timeout: TIMEOUT }, function step() {
-            return this.ensurePipelineExists({ repoName: this.repoName })
-                .then(() => {
-                    const pipelineId = parseInt(this.pipelineId, 10);
-
-                    return request({
-                        uri: `${this.instance}/${this.namespace}/collections/` +
-                            `${this.firstCollectionId}`,
-                        method: 'PUT',
-                        auth: {
-                            bearer: this.jwt
-                        },
-                        body: {
-                            pipelineIds: [pipelineId]
-                        },
-                        json: true
-                    }).then((response) => {
-                        Assert.strictEqual(response.statusCode, 200);
-                    });
-                });
-        });
-
-    Given(/^they have a collection "myCollection"$/, { timeout: TIMEOUT }, function step() {
-        return createCollection.call(this, { name: 'myCollection' })
-            .then((response) => {
-                Assert.oneOf(response.statusCode, [409, 201]);
-
-                if (response.statusCode === 201) {
-                    this.firstCollectionId = response.body.id;
-                } else {
-                    const str = response.body.message;
-
-                    [, this.firstCollectionId] = str.split(': ');
-                }
-            });
-    });
-
-    Given(/^they have a collection "anotherCollection"$/, { timeout: TIMEOUT }, function step() {
-        return createCollection.call(this, { name: 'anotherCollection' })
-            .then((response) => {
-                Assert.oneOf(response.statusCode, [409, 201]);
-
-                if (response.statusCode === 201) {
-                    this.secondCollectionId = response.body.id;
-                } else {
-                    const str = response.body.message;
-
-                    [, this.secondCollectionId] = str.split(': ');
-                }
-            });
-    });
-
-    When(/^they fetch all their collections$/, { timeout: TIMEOUT }, function step() {
-        return request({
+When(/^they check the default collection$/, { timeout: TIMEOUT }, function step() {
+    return this.ensurePipelineExists({ repoName: this.repoName })
+        .then(() => request({
             uri: `${this.instance}/${this.namespace}/collections`,
             method: 'GET',
             auth: {
                 bearer: this.jwt
             },
             json: true
-        }).then((response) => {
-            Assert.strictEqual(response.statusCode, 200);
-            this.collections = response.body;
-        });
-    });
-
-    Then(/^they can see those collections and the default collection$/, function step() {
-        const normalCollectionNames = this.collections.filter(c => c.type === 'normal')
-            .map(c => c.name);
-        const defaultCollection = this.collections.filter(c => c.type === 'default');
-
-        Assert.strictEqual(normalCollectionNames.length, 2);
-        Assert.strictEqual(defaultCollection.length, 1);
-        Assert.ok(normalCollectionNames.includes('myCollection'));
-        Assert.ok(normalCollectionNames.includes('anotherCollection'));
-    });
-
-    When(/^they delete that collection$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
-            method: 'DELETE',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
         })
             .then((response) => {
-                Assert.strictEqual(response.statusCode, 204);
-            });
-    });
+                Assert.strictEqual(response.statusCode, 200);
+                this.defaultCollectionId = response.body.find(collection =>
+                    collection.type === 'default'
+                ).id;
+                Assert.notEqual(this.defaultCollectionId, undefined);
+            })
+        );
+});
 
-    Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step() {
+Then(/^they can see the default collection contains that pipeline$/, { timeout: TIMEOUT },
+    function step() {
+        const pipelineId = parseInt(this.pipelineId, 10);
+
         return request({
-            uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+            uri: `${this.instance}/${this.namespace}/collections/${this.defaultCollectionId}`,
             method: 'GET',
             auth: {
                 bearer: this.jwt
             },
             json: true
         }).then((response) => {
-            Assert.strictEqual(response.statusCode, 404);
-            this.firstCollectionId = null;
+            Assert.strictEqual(response.statusCode, 200);
+            // TODO: May need to change back
+            // Assert.deepEqual(response.body.pipelineIds, [pipelineId]);
+            Assert.include(response.body.pipelineIds, pipelineId);
         });
     });
 
-    When(/^they create another collection with the same name "myCollection"$/,
-        { timeout: TIMEOUT }, function step() {
-            return createCollection.call(this, { name: 'myCollection' })
-                .then((response) => {
-                    Assert.ok(response);
-                    this.lastResponse = response;
+When(/^they create a new collection "myCollection" with that pipeline$/,
+    { timeout: TIMEOUT }, function step() {
+        return this.ensurePipelineExists({ repoName: this.repoName })
+            .then(() => {
+                const requestBody = {
+                    name: 'myCollection',
+                    pipelineIds: [this.pipelineId]
+                };
+
+                return createCollection.call(this, requestBody);
+            })
+            .then((response) => {
+                Assert.strictEqual(response.statusCode, 201);
+                this.firstCollectionId = response.body.id;
+            });
+    });
+
+Then(/^they can see that collection$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 200);
+        Assert.strictEqual(response.body.name, 'myCollection');
+    });
+});
+
+Then(/^the collection contains that pipeline$/, { timeout: TIMEOUT }, function step() {
+    const pipelineId = parseInt(this.pipelineId, 10);
+
+    return request({
+        uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 200);
+        Assert.deepEqual(response.body.pipelineIds, [pipelineId]);
+    });
+});
+
+When(/^they create a new collection "myCollection"$/, { timeout: TIMEOUT }, function step() {
+    return createCollection.call(this, { name: 'myCollection' })
+        .then((response) => {
+            Assert.strictEqual(response.statusCode, 201);
+            this.firstCollectionId = response.body.id;
+        });
+});
+
+Then(/^the collection is empty$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 200);
+        Assert.deepEqual(response.body.pipelineIds, []);
+    });
+});
+
+When(/^they update the collection "myCollection" with that pipeline$/,
+    { timeout: TIMEOUT }, function step() {
+        return this.ensurePipelineExists({ repoName: this.repoName })
+            .then(() => {
+                const pipelineId = parseInt(this.pipelineId, 10);
+
+                return request({
+                    uri: `${this.instance}/${this.namespace}/collections/` +
+                            `${this.firstCollectionId}`,
+                    method: 'PUT',
+                    auth: {
+                        bearer: this.jwt
+                    },
+                    body: {
+                        pipelineIds: [pipelineId]
+                    },
+                    json: true
+                }).then((response) => {
+                    Assert.strictEqual(response.statusCode, 200);
                 });
+            });
+    });
+
+Given(/^they have a collection "myCollection"$/, { timeout: TIMEOUT }, function step() {
+    return createCollection.call(this, { name: 'myCollection' })
+        .then((response) => {
+            Assert.oneOf(response.statusCode, [409, 201]);
+
+            if (response.statusCode === 201) {
+                this.firstCollectionId = response.body.id;
+            } else {
+                const str = response.body.message;
+
+                [, this.firstCollectionId] = str.split(': ');
+            }
         });
+});
 
-    Then(/^they receive an error regarding unique collections$/, function step() {
-        Assert.strictEqual(this.lastResponse.statusCode, 409);
-        Assert.strictEqual(this.lastResponse.body.message,
-            `Collection already exists with the ID: ${this.firstCollectionId}`);
+Given(/^they have a collection "anotherCollection"$/, { timeout: TIMEOUT }, function step() {
+    return createCollection.call(this, { name: 'anotherCollection' })
+        .then((response) => {
+            Assert.oneOf(response.statusCode, [409, 201]);
+
+            if (response.statusCode === 201) {
+                this.secondCollectionId = response.body.id;
+            } else {
+                const str = response.body.message;
+
+                [, this.secondCollectionId] = str.split(': ');
+            }
+        });
+});
+
+When(/^they fetch all their collections$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/collections`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 200);
+        this.collections = response.body;
+    });
+});
+
+Then(/^they can see those collections and the default collection$/, function step() {
+    const normalCollectionNames = this.collections.filter(c => c.type === 'normal')
+        .map(c => c.name);
+    const defaultCollection = this.collections.filter(c => c.type === 'default');
+
+    Assert.strictEqual(normalCollectionNames.length, 2);
+    Assert.strictEqual(defaultCollection.length, 1);
+    Assert.ok(normalCollectionNames.includes('myCollection'));
+    Assert.ok(normalCollectionNames.includes('anotherCollection'));
+});
+
+When(/^they delete that collection$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        method: 'DELETE',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    })
+        .then((response) => {
+            Assert.strictEqual(response.statusCode, 204);
+        });
+});
+
+Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.strictEqual(response.statusCode, 404);
+        this.firstCollectionId = null;
+    });
+});
+
+When(/^they create another collection with the same name "myCollection"$/,
+    { timeout: TIMEOUT }, function step() {
+        return createCollection.call(this, { name: 'myCollection' })
+            .then((response) => {
+                Assert.ok(response);
+                this.lastResponse = response;
+            });
     });
 
-    After('@collections', function hook() {
-        // Delete the collections created in the functional tests if they exist
-        return Promise.all([
-            deleteCollection.call(this, this.firstCollectionId),
-            deleteCollection.call(this, this.secondCollectionId)
-        ]);
-    });
+Then(/^they receive an error regarding unique collections$/, function step() {
+    Assert.strictEqual(this.lastResponse.statusCode, 409);
+    Assert.strictEqual(this.lastResponse.body.message,
+        `Collection already exists with the ID: ${this.firstCollectionId}`);
+});
+
+After('@collections', function hook() {
+    // Delete the collections created in the functional tests if they exist
+    return Promise.all([
+        deleteCollection.call(this, this.firstCollectionId),
+        deleteCollection.call(this, this.secondCollectionId)
+    ]);
 });

--- a/features/step_definitions/events.js
+++ b/features/step_definitions/events.js
@@ -2,62 +2,60 @@
 
 const Assert = require('chai').assert;
 const request = require('../support/request');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, Then } = require('cucumber');
 
 const TIMEOUT = 240 * 1000;
 
-defineSupportCode(({ Before, Given, Then }) => {
-    Before('@events', function hook() {
-        this.repoName = 'functional-events';
+Before('@events', function hook() {
+    this.repoName = 'functional-events';
 
-        // Reset shared information
-        this.pipelineId = null;
-        this.eventId = null;
-        this.jwt = null;
+    // Reset shared information
+    this.pipelineId = null;
+    this.eventId = null;
+    this.jwt = null;
+});
+
+Given(/^an existing pipeline with the workflow:$/, { timeout: TIMEOUT }, function step(table) {
+    return this.ensurePipelineExists({ repoName: this.repoName })
+        .then(() => table);
+});
+
+Given(/^"calvin" has admin permission to the pipeline$/, () => null);
+
+Then(/^an event is created$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/events`,
+        method: 'GET',
+        json: true,
+        auth: {
+            bearer: this.jwt
+        }
+    }).then(response => Assert.equal(response.body[0].id, this.eventId));
+});
+
+Then(/^the "main" build succeeds$/, { timeout: TIMEOUT }, function step() {
+    return this.waitForBuild(this.buildId).then((resp) => {
+        Assert.equal(resp.body.status, 'SUCCESS');
+        Assert.equal(resp.statusCode, 200);
     });
+});
 
-    Given(/^an existing pipeline with the workflow:$/, { timeout: TIMEOUT }, function step(table) {
-        return this.ensurePipelineExists({ repoName: this.repoName })
-            .then(() => table);
-    });
-
-    Given(/^"calvin" has admin permission to the pipeline$/, () => null);
-
-    Then(/^an event is created$/, { timeout: TIMEOUT }, function step() {
+Then(/^the "publish" build succeeds with the same eventId as the "main" build$/,
+    { timeout: TIMEOUT }, function step() {
         return request({
-            uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/events`,
+            uri: `${this.instance}/${this.namespace}/jobs/${this.secondJobId}/builds`,
             method: 'GET',
             json: true,
             auth: {
                 bearer: this.jwt
             }
-        }).then(response => Assert.equal(response.body[0].id, this.eventId));
-    });
+        }).then((response) => {
+            this.secondBuildId = response.body[0].id;
 
-    Then(/^the "main" build succeeds$/, { timeout: TIMEOUT }, function step() {
-        return this.waitForBuild(this.buildId).then((resp) => {
-            Assert.equal(resp.body.status, 'SUCCESS');
-            Assert.equal(resp.statusCode, 200);
-        });
-    });
-
-    Then(/^the "publish" build succeeds with the same eventId as the "main" build$/,
-        { timeout: TIMEOUT }, function step() {
-            return request({
-                uri: `${this.instance}/${this.namespace}/jobs/${this.secondJobId}/builds`,
-                method: 'GET',
-                json: true,
-                auth: {
-                    bearer: this.jwt
-                }
-            }).then((response) => {
-                this.secondBuildId = response.body[0].id;
-
-                return this.waitForBuild(this.secondBuildId).then((resp) => {
-                    Assert.equal(resp.body.status, 'SUCCESS');
-                    Assert.equal(resp.statusCode, 200);
-                    Assert.equal(resp.body.eventId, this.eventId);
-                });
+            return this.waitForBuild(this.secondBuildId).then((resp) => {
+                Assert.equal(resp.body.status, 'SUCCESS');
+                Assert.equal(resp.statusCode, 200);
+                Assert.equal(resp.body.eventId, this.eventId);
             });
         });
-});
+    });

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -4,283 +4,281 @@ const Assert = require('chai').assert;
 const request = require('../support/request');
 const sdapi = require('../support/sdapi');
 const github = require('../support/github');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, When, Then } = require('cucumber');
 
 const TIMEOUT = 500 * 1000;
 
-defineSupportCode(({ Before, Given, When, Then }) => {
-    Before({
-        tags: '@gitflow',
-        timeout: TIMEOUT
-    }, function hook() {
-        this.branch = 'darrenBranch';
-        this.tag = 'v1.0';
-        this.repoOrg = this.testOrg;
-        this.repoName = 'functional-git';
+Before({
+    tags: '@gitflow',
+    timeout: TIMEOUT
+}, function hook() {
+    this.branch = 'darrenBranch';
+    this.tag = 'v1.0';
+    this.repoOrg = this.testOrg;
+    this.repoName = 'functional-git';
 
-        // Reset shared information
-        this.pullRequestNumber = null;
-        this.pipelineId = null;
+    // Reset shared information
+    this.pullRequestNumber = null;
+    this.pipelineId = null;
 
-        return request({ // TODO : perform this in the before-hook for all func tests
-            method: 'GET',
-            url: `${this.instance}/${this.namespace}/auth/token?api_token=${this.apiToken}`,
-            followAllRedirects: true,
-            json: true
-        }).then((response) => {
-            this.jwt = response.body.token;
-        }).then(() =>
-            github.cleanUpRepository(this.branch, this.tag, this.repoOrg, this.repoName)
-        ).catch(() => Assert.fail('failed to clean up repository'));
+    return request({ // TODO : perform this in the before-hook for all func tests
+        method: 'GET',
+        url: `${this.instance}/${this.namespace}/auth/token?api_token=${this.apiToken}`,
+        followAllRedirects: true,
+        json: true
+    }).then((response) => {
+        this.jwt = response.body.token;
+    }).then(() =>
+        github.cleanUpRepository(this.branch, this.tag, this.repoOrg, this.repoName)
+    ).catch(() => Assert.fail('failed to clean up repository'));
+});
+
+Given(/^an existing pipeline$/, {
+    timeout: TIMEOUT
+}, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/pipelines`,
+        method: 'POST',
+        auth: {
+            bearer: this.jwt
+        },
+        body: {
+            checkoutUrl: `git@${this.scmHostname}:${this.repoOrg}/${this.repoName}.git#master`
+        },
+        json: true
+    }).then((response) => {
+        Assert.oneOf(response.statusCode, [409, 201]);
+
+        if (response.statusCode === 201) {
+            this.pipelineId = response.body.id;
+        } else {
+            const str = response.body.message;
+            const id = str.split(': ')[1];
+
+            this.pipelineId = id;
+        }
     });
+});
 
-    Given(/^an existing pipeline$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/pipelines`,
-            method: 'POST',
-            auth: {
-                bearer: this.jwt
-            },
-            body: {
-                checkoutUrl: `git@${this.scmHostname}:${this.repoOrg}/${this.repoName}.git#master`
-            },
-            json: true
-        }).then((response) => {
-            Assert.oneOf(response.statusCode, [409, 201]);
+Given(/^an existing pull request targeting the pipeline's branch$/, {
+    timeout: TIMEOUT
+}, function step() {
+    const branch = this.branch;
 
-            if (response.statusCode === 201) {
-                this.pipelineId = response.body.id;
-            } else {
-                const str = response.body.message;
-                const id = str.split(': ')[1];
-
-                this.pipelineId = id;
-            }
-        });
-    });
-
-    Given(/^an existing pull request targeting the pipeline's branch$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        const branch = this.branch;
-
-        return github.createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(() =>
-                github.createPullRequest(branch, this.repoOrg, this.repoName)
-            )
-            .then(({ data }) => {
-                this.pullRequestNumber = data.number;
-                this.sha = data.head.sha;
-            })
-            .catch((err) => {
-                // throws an error if a PR already exists, so this is fine
-                Assert.strictEqual(err.status, 422);
-            });
-    });
-
-    Given(/^a pipeline with all stopped builds$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        const jobs = ['main', 'tag-triggered', 'release-triggered'];
-        const builds = [];
-
-        jobs.forEach((jobName) => {
-            builds.push(sdapi.cleanupBuilds({
-                instance: this.instance,
-                pipelineId: this.pipelineId,
-                jobName,
-                jwt: this.jwt
-            }));
-        });
-
-        return Promise.all(builds)
-            .catch(() => Assert.fail('failed to clean up builds'));
-    });
-
-    When(/^a pull request is opened$/, { timeout: TIMEOUT }, function step() {
-        const branch = this.branch;
-
-        return github.createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(() =>
-                github.createPullRequest(branch, this.repoOrg, this.repoName)
-            )
-            .then(({ data }) => {
-                this.pullRequestNumber = data.number;
-                this.sha = data.head.sha;
-            });
-    });
-
-    When(/^it is targeting the pipeline's branch$/, () => null);
-
-    When(/^the pull request is closed$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        return sdapi.searchForBuild({
-            instance: this.instance,
-            pipelineId: this.pipelineId,
-            pullRequestNumber: this.pullRequestNumber,
-            desiredSha: this.sha,
-            desiredStatus: ['RUNNING', 'SUCCESS', 'FAILURE'],
-            jwt: this.jwt
-        }).then((buildData) => {
-            this.previousBuildId = buildData.id;
-        }).then(() => github.closePullRequest(this.repoOrg, this.repoName,
-            this.pullRequestNumber)
-        );
-    });
-
-    When(/^new changes are pushed to that pull request$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        return sdapi.searchForBuild({
-            instance: this.instance,
-            pipelineId: this.pipelineId,
-            pullRequestNumber: this.pullRequestNumber,
-            desiredSha: this.sha,
-            desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
-            jwt: this.jwt
-        }).then((buildData) => {
-            this.previousBuildId = buildData.id;
-        }).then(() => github.createFile(this.branch, this.repoOrg,
-            this.repoName))
-            .then(({ data }) => {
-                this.sha = data.commit.sha;
-            });
-    });
-
-    When(/^a new commit is pushed$/, () => null);
-
-    When(/^it is against the pipeline's branch$/, { timeout: TIMEOUT }, function step() {
-        this.testBranch = 'master';
-
-        return github.createFile(this.testBranch, this.repoOrg, this.repoName)
-            .then(({ data }) => {
-                this.sha = data.commit.sha;
-            });
-    });
-
-    When(/^a tag is created$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        const branch = this.branch;
-        const tag = this.tag;
-
-        return github.createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(({ data }) => {
-                this.sha = data.commit.sha;
-
-                return github.createTag(tag, branch, this.repoOrg, this.repoName);
-            });
-    });
-
-    When(/^an annotated tag is created$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        const branch = this.branch;
-        const tag = this.tag;
-
-        return github.createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(({ data }) => {
-                this.sha = data.commit.sha;
-
-                return github.createAnnotatedTag(tag, branch, this.repoOrg, this.repoName);
-            });
-    });
-
-    When(/^a release is created$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        const branch = this.branch;
-        const tag = this.tag;
-
-        return github.createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(({ data }) => {
-                this.sha = data.commit.sha;
-
-                return github.createTag(tag, branch, this.repoOrg, this.repoName);
-            })
-            .then(() => github.createRelease(tag, this.repoOrg, this.repoName));
-    });
-
-    When(/^a release with annotated tag is created$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        const branch = this.branch;
-        const tag = this.tag;
-
-        return github.createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(({ data }) => {
-                this.sha = data.commit.sha;
-
-                return github.createAnnotatedTag(tag, branch, this.repoOrg, this.repoName);
-            })
-            .then(() => github.createRelease(tag, this.repoOrg, this.repoName));
-    });
-
-    Then(/^a new build from "([^"]+)" should be created to test that change$/, {
-        timeout: TIMEOUT
-    }, function step(job) {
-        return sdapi.searchForBuild({
-            instance: this.instance,
-            pipelineId: this.pipelineId,
-            pullRequestNumber: this.pullRequestNumber,
-            desiredSha: this.sha,
-            desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS'],
-            jwt: this.jwt,
-            jobName: job
+    return github.createBranch(branch, this.repoOrg, this.repoName)
+        .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+        .then(() =>
+            github.createPullRequest(branch, this.repoOrg, this.repoName)
+        )
+        .then(({ data }) => {
+            this.pullRequestNumber = data.number;
+            this.sha = data.head.sha;
         })
-            .then((data) => {
-                const build = data;
-
-                Assert.oneOf(build.status, ['QUEUED', 'RUNNING', 'SUCCESS']);
-                this.jobId = build.jobId;
-            });
-    });
-
-    Then(/^the build should know they are in a pull request/, function step() {
-        return request({
-            json: true,
-            method: 'GET',
-            uri: `${this.instance}/${this.namespace}/jobs/${this.jobId}`,
-            auth: {
-                bearer: this.jwt
-            }
-        })
-            .then((response) => {
-                Assert.strictEqual(response.statusCode, 200);
-                Assert.match(response.body.name, /^PR-(.*)$/);
-            });
-    });
-
-    Then(/^any existing builds should be stopped$/, {
-        timeout: TIMEOUT
-    }, function step() {
-        const desiredStatus = ['ABORTED', 'SUCCESS', 'FAILURE'];
-
-        return sdapi.waitForBuildStatus({
-            buildId: this.previousBuildId,
-            instance: this.instance,
-            desiredStatus,
-            jwt: this.jwt
-        }).then((buildData) => {
-            // TODO: save the status so the next step can verify the github status
-            Assert.oneOf(buildData.status, desiredStatus);
+        .catch((err) => {
+            // throws an error if a PR already exists, so this is fine
+            Assert.strictEqual(err.status, 422);
         });
+});
+
+Given(/^a pipeline with all stopped builds$/, {
+    timeout: TIMEOUT
+}, function step() {
+    const jobs = ['main', 'tag-triggered', 'release-triggered'];
+    const builds = [];
+
+    jobs.forEach((jobName) => {
+        builds.push(sdapi.cleanupBuilds({
+            instance: this.instance,
+            pipelineId: this.pipelineId,
+            jobName,
+            jwt: this.jwt
+        }));
     });
 
-    Then(/^the GitHub status should be updated to reflect the build's status$/, function step() {
-        return github.getStatus(this.repoOrg, this.repoName, this.sha)
-            .then(({ data }) => {
-                data.statuses.forEach(status =>
-                    Assert.oneOf(status.state, ['success', 'pending']));
-            });
+    return Promise.all(builds)
+        .catch(() => Assert.fail('failed to clean up builds'));
+});
+
+When(/^a pull request is opened$/, { timeout: TIMEOUT }, function step() {
+    const branch = this.branch;
+
+    return github.createBranch(branch, this.repoOrg, this.repoName)
+        .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+        .then(() =>
+            github.createPullRequest(branch, this.repoOrg, this.repoName)
+        )
+        .then(({ data }) => {
+            this.pullRequestNumber = data.number;
+            this.sha = data.head.sha;
+        });
+});
+
+When(/^it is targeting the pipeline's branch$/, () => null);
+
+When(/^the pull request is closed$/, {
+    timeout: TIMEOUT
+}, function step() {
+    return sdapi.searchForBuild({
+        instance: this.instance,
+        pipelineId: this.pipelineId,
+        pullRequestNumber: this.pullRequestNumber,
+        desiredSha: this.sha,
+        desiredStatus: ['RUNNING', 'SUCCESS', 'FAILURE'],
+        jwt: this.jwt
+    }).then((buildData) => {
+        this.previousBuildId = buildData.id;
+    }).then(() => github.closePullRequest(this.repoOrg, this.repoName,
+        this.pullRequestNumber)
+    );
+});
+
+When(/^new changes are pushed to that pull request$/, {
+    timeout: TIMEOUT
+}, function step() {
+    return sdapi.searchForBuild({
+        instance: this.instance,
+        pipelineId: this.pipelineId,
+        pullRequestNumber: this.pullRequestNumber,
+        desiredSha: this.sha,
+        desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+        jwt: this.jwt
+    }).then((buildData) => {
+        this.previousBuildId = buildData.id;
+    }).then(() => github.createFile(this.branch, this.repoOrg,
+        this.repoName))
+        .then(({ data }) => {
+            this.sha = data.commit.sha;
+        });
+});
+
+When(/^a new commit is pushed$/, () => null);
+
+When(/^it is against the pipeline's branch$/, { timeout: TIMEOUT }, function step() {
+    this.testBranch = 'master';
+
+    return github.createFile(this.testBranch, this.repoOrg, this.repoName)
+        .then(({ data }) => {
+            this.sha = data.commit.sha;
+        });
+});
+
+When(/^a tag is created$/, {
+    timeout: TIMEOUT
+}, function step() {
+    const branch = this.branch;
+    const tag = this.tag;
+
+    return github.createBranch(branch, this.repoOrg, this.repoName)
+        .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+        .then(({ data }) => {
+            this.sha = data.commit.sha;
+
+            return github.createTag(tag, branch, this.repoOrg, this.repoName);
+        });
+});
+
+When(/^an annotated tag is created$/, {
+    timeout: TIMEOUT
+}, function step() {
+    const branch = this.branch;
+    const tag = this.tag;
+
+    return github.createBranch(branch, this.repoOrg, this.repoName)
+        .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+        .then(({ data }) => {
+            this.sha = data.commit.sha;
+
+            return github.createAnnotatedTag(tag, branch, this.repoOrg, this.repoName);
+        });
+});
+
+When(/^a release is created$/, {
+    timeout: TIMEOUT
+}, function step() {
+    const branch = this.branch;
+    const tag = this.tag;
+
+    return github.createBranch(branch, this.repoOrg, this.repoName)
+        .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+        .then(({ data }) => {
+            this.sha = data.commit.sha;
+
+            return github.createTag(tag, branch, this.repoOrg, this.repoName);
+        })
+        .then(() => github.createRelease(tag, this.repoOrg, this.repoName));
+});
+
+When(/^a release with annotated tag is created$/, {
+    timeout: TIMEOUT
+}, function step() {
+    const branch = this.branch;
+    const tag = this.tag;
+
+    return github.createBranch(branch, this.repoOrg, this.repoName)
+        .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+        .then(({ data }) => {
+            this.sha = data.commit.sha;
+
+            return github.createAnnotatedTag(tag, branch, this.repoOrg, this.repoName);
+        })
+        .then(() => github.createRelease(tag, this.repoOrg, this.repoName));
+});
+
+Then(/^a new build from "([^"]+)" should be created to test that change$/, {
+    timeout: TIMEOUT
+}, function step(job) {
+    return sdapi.searchForBuild({
+        instance: this.instance,
+        pipelineId: this.pipelineId,
+        pullRequestNumber: this.pullRequestNumber,
+        desiredSha: this.sha,
+        desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS'],
+        jwt: this.jwt,
+        jobName: job
+    })
+        .then((data) => {
+            const build = data;
+
+            Assert.oneOf(build.status, ['QUEUED', 'RUNNING', 'SUCCESS']);
+            this.jobId = build.jobId;
+        });
+});
+
+Then(/^the build should know they are in a pull request/, function step() {
+    return request({
+        json: true,
+        method: 'GET',
+        uri: `${this.instance}/${this.namespace}/jobs/${this.jobId}`,
+        auth: {
+            bearer: this.jwt
+        }
+    })
+        .then((response) => {
+            Assert.strictEqual(response.statusCode, 200);
+            Assert.match(response.body.name, /^PR-(.*)$/);
+        });
+});
+
+Then(/^any existing builds should be stopped$/, {
+    timeout: TIMEOUT
+}, function step() {
+    const desiredStatus = ['ABORTED', 'SUCCESS'];
+
+    return sdapi.waitForBuildStatus({
+        buildId: this.previousBuildId,
+        instance: this.instance,
+        desiredStatus,
+        jwt: this.jwt
+    }).then((buildData) => {
+        // TODO: save the status so the next step can verify the github status
+        Assert.oneOf(buildData.status, desiredStatus);
     });
+});
+
+Then(/^the GitHub status should be updated to reflect the build's status$/, function step() {
+    return github.getStatus(this.repoOrg, this.repoName, this.sha)
+        .then(({ data }) => {
+            data.statuses.forEach(status =>
+                Assert.oneOf(status.state, ['success', 'pending']));
+        });
 });

--- a/features/step_definitions/metadata.js
+++ b/features/step_definitions/metadata.js
@@ -3,83 +3,81 @@
 const Assert = require('chai').assert;
 const request = require('../support/request');
 const sdapi = require('../support/sdapi');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, Then } = require('cucumber');
 
 const TIMEOUT = 240 * 1000;
 
-defineSupportCode(({ Before, Given, Then }) => {
-    Before({
-        tags: '@metadata'
-    }, function hook() {
-        this.repoOrg = this.testOrg;
-        this.repoName = 'functional-metadata';
-        this.pipelineId = null;
-        this.eventId = null;
-        this.meta = null;
-        this.jwt = null;
+Before({
+    tags: '@metadata'
+}, function hook() {
+    this.repoOrg = this.testOrg;
+    this.repoName = 'functional-metadata';
+    this.pipelineId = null;
+    this.eventId = null;
+    this.meta = null;
+    this.jwt = null;
+});
+
+Given(/^a metadata starts with an empty object$/, { timeout: TIMEOUT }, () => null);
+
+Then(/^the "(BAR|BAZ)" job is started$/, { timeout: TIMEOUT }, function step(jobName) {
+    switch (jobName) {
+    case 'BAR':
+        this.jobName = 'second';
+        break;
+    case 'BAZ':
+        this.jobName = 'third';
+        break;
+    default:
+        throw new Error('jobName is neither BAR or BAZ');
+    }
+
+    return sdapi.searchForBuild({
+        instance: this.instance,
+        pipelineId: this.pipelineId,
+        desiredSha: this.sha,
+        desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+        jobName: this.jobName,
+        jwt: this.jwt
+    }).then((build) => {
+        this.buildId = build.id;
     });
+});
 
-    Given(/^a metadata starts with an empty object$/, { timeout: TIMEOUT }, () => null);
+Then(/^add the { "(.*)": "(.*)" } to metadata/, function step(key, value) {
+    this.expectedMeta = this.expectedMeta || {};
+    this.expectedMeta[key] = value;
+});
 
-    Then(/^the "(BAR|BAZ)" job is started$/, { timeout: TIMEOUT }, function step(jobName) {
-        switch (jobName) {
-        case 'BAR':
-            this.jobName = 'second';
-            break;
-        case 'BAZ':
-            this.jobName = 'third';
-            break;
-        default:
-            throw new Error('jobName is neither BAR or BAZ');
+Then(/^in the build, the { "(?:.*)": "(?:.*)" } is available from metadata$/, () => null);
+
+Then(/^the build succeeded$/, { timeout: TIMEOUT }, function step() {
+    return this.waitForBuild(this.buildId).then((resp) => {
+        Assert.equal(resp.body.status, 'SUCCESS');
+        Assert.equal(resp.statusCode, 200);
+    });
+});
+
+Then(/^the event is done$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/jobs/${this.thirdJobId}/builds`,
+        method: 'GET',
+        json: true,
+        auth: {
+            bearer: this.jwt
         }
+    }).then((response) => {
+        this.buildId = response.body[0].id;
+        this.meta = response.body[0].meta;
 
-        return sdapi.searchForBuild({
-            instance: this.instance,
-            pipelineId: this.pipelineId,
-            desiredSha: this.sha,
-            desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
-            jobName: this.jobName,
-            jwt: this.jwt
-        }).then((build) => {
-            this.buildId = build.id;
-        });
-    });
-
-    Then(/^add the { "(.*)": "(.*)" } to metadata/, function step(key, value) {
-        this.expectedMeta = this.expectedMeta || {};
-        this.expectedMeta[key] = value;
-    });
-
-    Then(/^in the build, the { "(?:.*)": "(?:.*)" } is available from metadata$/, () => null);
-
-    Then(/^the build succeeded$/, { timeout: TIMEOUT }, function step() {
         return this.waitForBuild(this.buildId).then((resp) => {
-            Assert.equal(resp.body.status, 'SUCCESS');
             Assert.equal(resp.statusCode, 200);
         });
     });
+});
 
-    Then(/^the event is done$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/jobs/${this.thirdJobId}/builds`,
-            method: 'GET',
-            json: true,
-            auth: {
-                bearer: this.jwt
-            }
-        }).then((response) => {
-            this.buildId = response.body[0].id;
-            this.meta = response.body[0].meta;
-
-            return this.waitForBuild(this.buildId).then((resp) => {
-                Assert.equal(resp.statusCode, 200);
-            });
-        });
-    });
-
-    Then(/^a record of the metadata is stored$/, { timeout: TIMEOUT }, function step() {
-        Object.keys(this.expectedMeta).forEach((key) => {
-            Assert.equal(this.meta[key], this.expectedMeta[key]);
-        });
+Then(/^a record of the metadata is stored$/, { timeout: TIMEOUT }, function step() {
+    Object.keys(this.expectedMeta).forEach((key) => {
+        Assert.equal(this.meta[key], this.expectedMeta[key]);
     });
 });

--- a/features/step_definitions/sd-cmd.js
+++ b/features/step_definitions/sd-cmd.js
@@ -2,225 +2,223 @@
 
 const Assert = require('chai').assert;
 const request = require('../support/request');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, When, Then } = require('cucumber');
 
 const TIMEOUT = 240 * 1000;
 
-defineSupportCode(({ Before, Given, When, Then }) => {
-    Before({
-        tags: '@sd-cmd'
-    }, function hook() {
-        this.repoOrg = this.testOrg;
-        this.repoName = 'functional-commands';
-        this.pipelineId = null;
-        this.configPipelineId = null;
-        this.buildPipelineIds = {};
-        this.jwt = null;
-        this.image = null;
-        this.command = null;
-        this.commandNamespace = 'screwdriver-cd-test';
+Before({
+    tags: '@sd-cmd'
+}, function hook() {
+    this.repoOrg = this.testOrg;
+    this.repoName = 'functional-commands';
+    this.pipelineId = null;
+    this.configPipelineId = null;
+    this.buildPipelineIds = {};
+    this.jwt = null;
+    this.image = null;
+    this.command = null;
+    this.commandNamespace = 'screwdriver-cd-test';
 
-        return request({ // TODO : perform this in the before-hook for all func tests
-            method: 'GET',
-            url: `${this.instance}/${this.namespace}/auth/token?api_token=${this.apiToken}`,
-            followAllRedirects: true,
-            json: true
-        }).then((response) => {
-            this.jwt = response.body.token;
-        });
+    return request({ // TODO : perform this in the before-hook for all func tests
+        method: 'GET',
+        url: `${this.instance}/${this.namespace}/auth/token?api_token=${this.apiToken}`,
+        followAllRedirects: true,
+        json: true
+    }).then((response) => {
+        this.jwt = response.body.token;
     });
+});
 
-    Given(/^(.*) command in (.*) format$/,
-        { timeout: TIMEOUT }, function step(command, format) {
-            return request({
-                uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
-                    + `/${this.command}/latest`,
-                method: 'GET',
-                json: true,
-                auth: {
-                    bearer: this.jwt
-                }
-            }).then((response) => {
-                Assert.equal(response.body.name, command);
-                Assert.equal(response.body.namespace, this.commandNamespace);
-                Assert.equal(response.body.format, format);
-
-                this.command = command;
-            });
-        });
-
-    Given(/^(.+) command does not exist yet$/,
-        { timeout: TIMEOUT }, function step(command) {
-            this.command = command;
-
-            return request({
-                uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
-                + `/${this.command}`,
-                method: 'GET',
-                json: true,
-                auth: {
-                    bearer: this.jwt
-                }
-            }).then((response) => {
-                if (response.statusCode === 404) {
-                    return;
-                }
-
-                /* eslint-disable-next-line consistent-return */
-                return request({
-                    uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
-                    + `/${this.command}`,
-                    method: 'DELETE',
-                    json: true,
-                    auth: {
-                        bearer: this.jwt
-                    }
-                }).then((resp) => {
-                    Assert.equal(resp.statusCode, 204);
-                });
-            });
-        });
-
-    Given(/^"([^"]+)" version of the command is uploaded with "([^"]+)" tag$/, {
-        timeout: TIMEOUT
-    }, function step(version, tag) {
-        const jobName = `publish-${tag}`;
-
-        return request({
-            uri: `${this.instance}/${this.namespace}/events`,
-            method: 'POST',
-            json: true,
-            body: {
-                pipelineId: this.pipelineId,
-                startFrom: jobName
-            },
-            auth: {
-                bearer: this.jwt
-            }
-        }).then((response) => {
-            Assert.equal(response.statusCode, 201);
-            this.eventId = response.body.id;
-        }).then(() => request({
-            uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        })).then((response) => {
-            Assert.equal(response.statusCode, 200);
-
-            this.buildId = response.body[0].id;
-
-            return this.waitForBuild(this.buildId).then((resp) => {
-                Assert.equal(resp.statusCode, 200);
-                Assert.equal(resp.body.status, 'SUCCESS');
-            });
-        });
-    });
-
-    When(/^execute (.+) job$/, {
-        timeout: TIMEOUT
-    }, function step(jobName) {
-        return request({
-            uri: `${this.instance}/${this.namespace}/events`,
-            method: 'POST',
-            json: true,
-            body: {
-                pipelineId: this.pipelineId,
-                startFrom: jobName
-            },
-            auth: {
-                bearer: this.jwt
-            }
-        }).then((response) => {
-            Assert.equal(response.statusCode, 201);
-            this.eventId = response.body.id;
-        }).then(() => request({
-            uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        })).then((response) => {
-            Assert.equal(response.statusCode, 200);
-
-            this.buildId = response.body[0].id;
-        });
-    });
-
-    When(/^"([^"]+)" step executes the command with arguments: "([^"]+)"$/, {
-        timeout: TIMEOUT
-    }, function step(stepName, args) {
-        return request({
-            uri: `${this.instance}/${this.namespace}/builds/${this.buildId}/steps/${stepName}`,
-            method: 'GET',
-            json: true,
-            auth: {
-                bearer: this.jwt
-            }
-        }).then((response) => {
-            Assert.equal(response.statusCode, 200);
-            Assert.include(response.body.command,
-                `sd-cmd exec ${this.commandNamespace}/${this.command}@1 ${args}`);
-        });
-    });
-
-    Then(/^the job is completed successfully$/, { timeout: 700 * 1000 }, function step() {
-        return this.waitForBuild(this.buildId).then((response) => {
-            Assert.equal(response.statusCode, 200);
-            Assert.equal(response.body.status, 'SUCCESS');
-        });
-    });
-
-    Then(/^the command is published with (.+) format$/, {
-        timeout: TIMEOUT
-    }, function step(format) {
+Given(/^(.*) command in (.*) format$/,
+    { timeout: TIMEOUT }, function step(command, format) {
         return request({
             uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
-                + `/${this.command}/latest`,
+                    + `/${this.command}/latest`,
             method: 'GET',
             json: true,
             auth: {
                 bearer: this.jwt
             }
         }).then((response) => {
-            Assert.equal(response.body.name, this.command);
+            Assert.equal(response.body.name, command);
             Assert.equal(response.body.namespace, this.commandNamespace);
             Assert.equal(response.body.format, format);
+
+            this.command = command;
         });
     });
 
-    Then(/^"([^"]+)" is tagged with "([^"]+)"$/, {
-        timeout: TIMEOUT
-    }, function step(version, tag) {
+Given(/^(.+) command does not exist yet$/,
+    { timeout: TIMEOUT }, function step(command) {
+        this.command = command;
+
         return request({
             uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
-                + `/${this.command}/${tag}`,
+                + `/${this.command}`,
             method: 'GET',
             json: true,
             auth: {
                 bearer: this.jwt
             }
         }).then((response) => {
-            Assert.equal(response.body.version, version);
+            if (response.statusCode === 404) {
+                return;
+            }
+
+            /* eslint-disable-next-line consistent-return */
+            return request({
+                uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
+                    + `/${this.command}`,
+                method: 'DELETE',
+                json: true,
+                auth: {
+                    bearer: this.jwt
+                }
+            }).then((resp) => {
+                Assert.equal(resp.statusCode, 204);
+            });
         });
     });
 
-    Then(/^"([^"]+)" tag is removed from "([^"]+)"$/, {
-        timeout: TIMEOUT
-    }, function step(tag, version) {
-        return request({
-            uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
-                + `/${this.command}/${tag}`,
-            method: 'GET',
-            json: true,
-            auth: {
-                bearer: this.jwt
-            }
-        }).then((response) => {
-            Assert.notEqual(response.body.version, version);
+Given(/^"([^"]+)" version of the command is uploaded with "([^"]+)" tag$/, {
+    timeout: TIMEOUT
+}, function step(version, tag) {
+    const jobName = `publish-${tag}`;
+
+    return request({
+        uri: `${this.instance}/${this.namespace}/events`,
+        method: 'POST',
+        json: true,
+        body: {
+            pipelineId: this.pipelineId,
+            startFrom: jobName
+        },
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((response) => {
+        Assert.equal(response.statusCode, 201);
+        this.eventId = response.body.id;
+    }).then(() => request({
+        uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    })).then((response) => {
+        Assert.equal(response.statusCode, 200);
+
+        this.buildId = response.body[0].id;
+
+        return this.waitForBuild(this.buildId).then((resp) => {
+            Assert.equal(resp.statusCode, 200);
+            Assert.equal(resp.body.status, 'SUCCESS');
         });
+    });
+});
+
+When(/^execute (.+) job$/, {
+    timeout: TIMEOUT
+}, function step(jobName) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/events`,
+        method: 'POST',
+        json: true,
+        body: {
+            pipelineId: this.pipelineId,
+            startFrom: jobName
+        },
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((response) => {
+        Assert.equal(response.statusCode, 201);
+        this.eventId = response.body.id;
+    }).then(() => request({
+        uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    })).then((response) => {
+        Assert.equal(response.statusCode, 200);
+
+        this.buildId = response.body[0].id;
+    });
+});
+
+When(/^"([^"]+)" step executes the command with arguments: "([^"]+)"$/, {
+    timeout: TIMEOUT
+}, function step(stepName, args) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/builds/${this.buildId}/steps/${stepName}`,
+        method: 'GET',
+        json: true,
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((response) => {
+        Assert.equal(response.statusCode, 200);
+        Assert.include(response.body.command,
+            `sd-cmd exec ${this.commandNamespace}/${this.command}@1 ${args}`);
+    });
+});
+
+Then(/^the job is completed successfully$/, { timeout: 700 * 1000 }, function step() {
+    return this.waitForBuild(this.buildId).then((response) => {
+        Assert.equal(response.statusCode, 200);
+        Assert.equal(response.body.status, 'SUCCESS');
+    });
+});
+
+Then(/^the command is published with (.+) format$/, {
+    timeout: TIMEOUT
+}, function step(format) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
+                + `/${this.command}/latest`,
+        method: 'GET',
+        json: true,
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((response) => {
+        Assert.equal(response.body.name, this.command);
+        Assert.equal(response.body.namespace, this.commandNamespace);
+        Assert.equal(response.body.format, format);
+    });
+});
+
+Then(/^"([^"]+)" is tagged with "([^"]+)"$/, {
+    timeout: TIMEOUT
+}, function step(version, tag) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
+                + `/${this.command}/${tag}`,
+        method: 'GET',
+        json: true,
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((response) => {
+        Assert.equal(response.body.version, version);
+    });
+});
+
+Then(/^"([^"]+)" tag is removed from "([^"]+)"$/, {
+    timeout: TIMEOUT
+}, function step(tag, version) {
+    return request({
+        uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
+                + `/${this.command}/${tag}`,
+        method: 'GET',
+        json: true,
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((response) => {
+        Assert.notEqual(response.body.version, version);
     });
 });

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -4,134 +4,133 @@
 
 const Assert = require('chai').assert;
 const request = require('../support/request');
-const { defineSupportCode } = require('cucumber');
+const sdapi = require('../support/sdapi');
+const { Before, Given, When, Then } = require('cucumber');
 
 const TIMEOUT = 240 * 1000;
 
-defineSupportCode(({ Before, Given, When, Then }) => {
-    Before({
-        tags: '@sd-step'
-    }, function hook() {
-        this.repoOrg = this.testOrg;
-        this.repoName = 'functional-shared-steps';
-        this.pipelineId = null;
-        this.jwt = null;
-        this.image = null;
-        this.expectedImage = null;
-        this.commands = null;
-    });
+Before({
+    tags: '@sd-step'
+}, function hook() {
+    this.repoOrg = this.testOrg;
+    this.repoName = 'functional-shared-steps';
+    this.pipelineId = null;
+    this.jwt = null;
+    this.image = null;
+    this.expectedImage = null;
+    this.commands = null;
+});
 
-    Given(/^an existing pipeline with (.*) image and (.*) package$/,
-        { timeout: TIMEOUT }, function step(image, pkg) {
-            return this.getJwt(this.apiToken)
-                .then((response) => {
-                    this.jwt = response.body.token;
-                    this.expectedImage = image;
+Given(/^an existing pipeline with (.*) image and (.*) package$/,
+    { timeout: TIMEOUT }, function step(image, pkg) {
+        return this.getJwt(this.apiToken)
+            .then((response) => {
+                this.jwt = response.body.token;
+                this.expectedImage = image;
 
-                    return request({
-                        uri: `${this.instance}/${this.namespace}/pipelines`,
-                        method: 'POST',
-                        auth: {
-                            bearer: this.jwt
-                        },
-                        body: {
-                            checkoutUrl:
+                return request({
+                    uri: `${this.instance}/${this.namespace}/pipelines`,
+                    method: 'POST',
+                    auth: {
+                        bearer: this.jwt
+                    },
+                    body: {
+                        checkoutUrl:
                                 `git@${this.scmHostname}:${this.repoOrg}/${this.repoName}`
                                     + '.git#master'
-                        },
-                        json: true
-                    });
-                })
-                .then((response) => {
-                    Assert.oneOf(response.statusCode, [409, 201]);
-
-                    if (response.statusCode === 201) {
-                        this.pipelineId = response.body.id;
-                    } else {
-                        const str = response.body.message;
-                        const id = str.split(': ')[1];
-
-                        this.pipelineId = id;
-                    }
+                    },
+                    json: true
                 });
-        });
-
-    When(/^the (main|tilde|hat|specify) job is started$/,
-        { timeout: TIMEOUT }, function step(jobName) {
-            return request({
-                uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/jobs`,
-                method: 'GET',
-                json: true,
-                auth: {
-                    bearer: this.jwt
-                }
             })
-                .then((response) => {
-                    Assert.equal(response.statusCode, 200);
+            .then((response) => {
+                Assert.oneOf(response.statusCode, [409, 201]);
 
-                    for (let i = 0; i < response.body.length; i += 1) {
-                        if (response.body[i].name === jobName) {
-                            this.jobId = response.body[i].id;
-                            this.image = response.body[i].permutations[0].image;
-                            this.commands = response.body[i].permutations[0].commands;
-                            break;
-                        }
-                    }
-                    Assert.equal(this.image, this.expectedImage);
-                })
-                .then(() =>
-                    request({
-                        uri: `${this.instance}/${this.namespace}/builds`,
-                        method: 'POST',
-                        body: {
-                            jobId: this.jobId
-                        },
-                        auth: {
-                            bearer: this.jwt
-                        },
-                        json: true
-                    }).then((resp) => {
-                        Assert.equal(resp.statusCode, 201);
+                if (response.statusCode === 201) {
+                    this.pipelineId = response.body.id;
+                } else {
+                    const str = response.body.message;
+                    const id = str.split(': ')[1];
 
-                        this.buildId = resp.body.id;
-                    })
-                );
-        });
-
-    When(/^sd-step command is executed to use (.*) package$/,
-        { timeout: TIMEOUT }, function step(pkg) {
-            this.commands.forEach((c) => {
-                if (c.name === 'sd_step') {
-                    Assert.include(c.command, pkg);
-                } else if (c.name.match(/^sd_step_/)) {
-                    Assert.include(c.command, '--pkg-version');
+                    this.pipelineId = id;
                 }
             });
-        });
+    });
 
-    When(/^sd-step command is executed to use (.*) package with specified version (.*)$/, {
-        timeout: TIMEOUT
-    }, function step(pkg, version) {
+When(/^the (main|tilde|hat|specify) job is started$/,
+    { timeout: TIMEOUT }, function step(jobName) {
+        return request({
+            uri: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/jobs`,
+            method: 'GET',
+            json: true,
+            auth: {
+                bearer: this.jwt
+            }
+        })
+            .then((response) => {
+                Assert.equal(response.statusCode, 200);
+
+                for (let i = 0; i < response.body.length; i += 1) {
+                    if (response.body[i].name === jobName) {
+                        this.jobId = response.body[i].id;
+                        this.image = response.body[i].permutations[0].image;
+                        this.commands = response.body[i].permutations[0].commands;
+                        break;
+                    }
+                }
+                Assert.equal(this.image, this.expectedImage);
+            })
+            .then(() =>
+                request({
+                    uri: `${this.instance}/${this.namespace}/builds`,
+                    method: 'POST',
+                    body: {
+                        jobId: this.jobId
+                    },
+                    auth: {
+                        bearer: this.jwt
+                    },
+                    json: true
+                }).then((resp) => {
+                    Assert.equal(resp.statusCode, 201);
+
+                    this.buildId = resp.body.id;
+                })
+            );
+    });
+
+When(/^sd-step command is executed to use (.*) package$/,
+    { timeout: TIMEOUT }, function step(pkg) {
         this.commands.forEach((c) => {
             if (c.name === 'sd_step') {
-                Assert.include(c.command, `--pkg-version "${version}" ${pkg}`);
+                Assert.include(c.command, pkg);
+            } else if (c.name.match(/^sd_step_/)) {
+                Assert.include(c.command, '--pkg-version');
             }
         });
     });
 
-    Then(/^(.*) package is available via sd-step$/, { timeout: 900 * 1000 }, function step(pkg) {
-        return this.waitForBuild(this.buildId).then((response) => {
-            Assert.equal(response.statusCode, 200);
-            Assert.oneOf(response.body.status, ['SUCCESS', 'RUNNING']);
-        });
+When(/^sd-step command is executed to use (.*) package with specified version (.*)$/, {
+    timeout: TIMEOUT
+}, function step(pkg, version) {
+    this.commands.forEach((c) => {
+        if (c.name === 'sd_step') {
+            Assert.include(c.command, `--pkg-version "${version}" ${pkg}`);
+        }
     });
+});
 
-    Then(/^(.*) package is available via sd-step with specified version (.*)$/, {
-        timeout: TIMEOUT
-    }, function step(pkg, version) {
-        return this.waitForBuild(this.buildId).then((response) => {
-            Assert.equal(response.statusCode, 200);
-            Assert.equal(response.body.status, 'SUCCESS');
-        });
+Then(/^(.*) package is available via sd-step$/, { timeout: 700 * 1000 }, function step(pkg) {
+    return this.waitForBuild(this.buildId).then((response) => {
+        Assert.equal(response.statusCode, 200);
+        Assert.equal(response.body.status, 'SUCCESS');
+    });
+});
+
+Then(/^(.*) package is available via sd-step with specified version (.*)$/, {
+    timeout: TIMEOUT
+}, function step(pkg, version) {
+    return this.waitForBuild(this.buildId).then((response) => {
+        Assert.equal(response.statusCode, 200);
+        Assert.equal(response.body.status, 'SUCCESS');
     });
 });

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -2,155 +2,153 @@
 
 const Assert = require('chai').assert;
 const request = require('../support/request');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, When, Then, After } = require('cucumber');
 
 const TIMEOUT = 240 * 1000;
 
-defineSupportCode(({ Before, Given, When, Then, After }) => {
-    Before({
-        tags: '@secrets'
-    }, function hook() {
-        this.repoName = 'functional-secrets';
-        this.pipelineId = null;
-        this.secretId = null;
+Before({
+    tags: '@secrets'
+}, function hook() {
+    this.repoName = 'functional-secrets';
+    this.pipelineId = null;
+    this.secretId = null;
+});
+
+Given(/^an existing repository for secret with these users and permissions:$/,
+    { timeout: TIMEOUT }, function step(table) {
+        return this.ensurePipelineExists({ repoName: this.repoName })
+            .then(() => table);
     });
 
-    Given(/^an existing repository for secret with these users and permissions:$/,
-        { timeout: TIMEOUT }, function step(table) {
-            return this.ensurePipelineExists({ repoName: this.repoName })
-                .then(() => table);
-        });
+Given(/^an existing pipeline with that repository with the workflow:$/, table => table);
 
-    Given(/^an existing pipeline with that repository with the workflow:$/, table => table);
+When(/^a secret "foo" is added globally$/, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/secrets`,
+        method: 'POST',
+        body: {
+            pipelineId: this.pipelineId,
+            name: 'FOO',
+            value: 'secrets',
+            allowInPR: false
+        },
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.equal(response.statusCode, 201);
 
-    When(/^a secret "foo" is added globally$/, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/secrets`,
-            method: 'POST',
-            body: {
-                pipelineId: this.pipelineId,
-                name: 'FOO',
-                value: 'secrets',
-                allowInPR: false
-            },
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.equal(response.statusCode, 201);
+        this.secretId = response.body.id;
+    });
+});
 
-            this.secretId = response.body.id;
+When(/^the "main" job is started$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/events`,
+        method: 'POST',
+        body: {
+            pipelineId: this.pipelineId,
+            startFrom: 'main'
+        },
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((resp) => {
+        Assert.equal(resp.statusCode, 201);
+        this.eventId = resp.body.id;
+    }).then(() => request({
+        uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    })).then((resp) => {
+        Assert.equal(resp.statusCode, 200);
+        this.buildId = resp.body[0].id;
+    });
+});
+
+Then(/^the "foo" secret should be available in the build$/,
+    { timeout: TIMEOUT }, function step() {
+        return this.waitForBuild(this.buildId).then((response) => {
+            Assert.equal(response.body.status, 'SUCCESS');
+            Assert.equal(response.statusCode, 200);
         });
     });
 
-    When(/^the "main" job is started$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/events`,
-            method: 'POST',
-            body: {
-                pipelineId: this.pipelineId,
-                startFrom: 'main'
-            },
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((resp) => {
-            Assert.equal(resp.statusCode, 201);
-            this.eventId = resp.body.id;
-        }).then(() => request({
-            uri: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        })).then((resp) => {
+When(/^the "second" job is started$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/jobs/${this.secondJobId}/builds`,
+        method: 'GET',
+        json: true,
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((response) => {
+        this.secondBuildId = response.body[0].id;
+
+        return this.waitForBuild(this.secondBuildId).then((resp) => {
+            Assert.equal(resp.body.status, 'SUCCESS');
             Assert.equal(resp.statusCode, 200);
-            this.buildId = resp.body[0].id;
         });
     });
+});
 
-    Then(/^the "foo" secret should be available in the build$/,
-        { timeout: TIMEOUT }, function step() {
-            return this.waitForBuild(this.buildId).then((response) => {
-                Assert.equal(response.body.status, 'SUCCESS');
-                Assert.equal(response.statusCode, 200);
-            });
-        });
-
-    When(/^the "second" job is started$/, { timeout: TIMEOUT }, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/jobs/${this.secondJobId}/builds`,
-            method: 'GET',
-            json: true,
-            auth: {
-                bearer: this.jwt
-            }
-        }).then((response) => {
-            this.secondBuildId = response.body[0].id;
-
-            return this.waitForBuild(this.secondBuildId).then((resp) => {
-                Assert.equal(resp.body.status, 'SUCCESS');
-                Assert.equal(resp.statusCode, 200);
-            });
-        });
+Then(/^the user can view the secret exists$/, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.isNotNull(response.body.name);
+        Assert.equal(response.statusCode, 200);
     });
+});
 
-    Then(/^the user can view the secret exists$/, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.isNotNull(response.body.name);
-            Assert.equal(response.statusCode, 200);
-        });
+Then(/^the user can not view the secret exists$/, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.equal(response.statusCode, 403);
     });
+});
 
-    Then(/^the user can not view the secret exists$/, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.equal(response.statusCode, 403);
-        });
+Then(/^the user can not view the value$/, function step() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/jobs/${this.secondJobId}/builds`,
+        method: 'GET',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.isUndefined(response.body.value);
+        Assert.equal(response.statusCode, 200);
     });
+});
 
-    Then(/^the user can not view the value$/, function step() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/jobs/${this.secondJobId}/builds`,
-            method: 'GET',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.isUndefined(response.body.value);
-            Assert.equal(response.statusCode, 200);
-        });
-    });
-
-    After({
-        tags: '@secrets'
-    }, function hook() {
-        return request({
-            uri: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
-            method: 'DELETE',
-            auth: {
-                bearer: this.jwt
-            },
-            json: true
-        }).then((response) => {
-            Assert.equal(response.statusCode, 204);
-        });
+After({
+    tags: '@secrets'
+}, function hook() {
+    return request({
+        uri: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
+        method: 'DELETE',
+        auth: {
+            bearer: this.jwt
+        },
+        json: true
+    }).then((response) => {
+        Assert.equal(response.statusCode, 204);
     });
 });

--- a/features/step_definitions/server.js
+++ b/features/step_definitions/server.js
@@ -2,40 +2,38 @@
 
 const request = require('request');
 const Assert = require('chai').assert;
-const { defineSupportCode } = require('cucumber');
+const { Given, When, Then } = require('cucumber');
 
-defineSupportCode(({ Given, When, Then }) => {
-    Given(/^a running API server$/, next => next());
+Given(/^a running API server$/, next => next());
 
-    When(/^I access the status endpoint$/, function step(callback) {
-        request.get(`${this.instance}/v4/status`, (err, result) => {
-            this.body = result ? result.body : null;
-            callback(err);
-        });
+When(/^I access the status endpoint$/, function step(callback) {
+    request.get(`${this.instance}/v4/status`, (err, result) => {
+        this.body = result ? result.body : null;
+        callback(err);
     });
+});
 
-    When(/^I access the versions endpoint$/, function step(callback) {
-        request.get(`${this.instance}/v4/versions`, (err, result) => {
-            this.body = result ? JSON.parse(result.body) : null;
-            callback(err);
-        });
+When(/^I access the versions endpoint$/, function step(callback) {
+    request.get(`${this.instance}/v4/versions`, (err, result) => {
+        this.body = result ? JSON.parse(result.body) : null;
+        callback(err);
     });
+});
 
-    Then(/^I should get an OK response$/, function step(callback) {
-        Assert.equal(this.body, 'OK');
-        callback(null);
-    });
+Then(/^I should get an OK response$/, function step(callback) {
+    Assert.equal(this.body, 'OK');
+    callback(null);
+});
 
-    Then(/^I should get a list of versions$/, function step(callback) {
-        Assert.property(this.body, 'versions');
-        Assert.property(this.body, 'licenses');
-        Assert.isAbove(this.body.licenses.length, 0);
+Then(/^I should get a list of versions$/, function step(callback) {
+    Assert.property(this.body, 'versions');
+    Assert.property(this.body, 'licenses');
+    Assert.isAbove(this.body.licenses.length, 0);
 
-        const sampleLicense = this.body.licenses.pop();
+    const sampleLicense = this.body.licenses.pop();
 
-        Assert.property(sampleLicense, 'name');
-        Assert.property(sampleLicense, 'repository');
-        Assert.property(sampleLicense, 'licenses');
-        callback(null);
-    });
+    Assert.property(sampleLicense, 'name');
+    Assert.property(sampleLicense, 'repository');
+    Assert.property(sampleLicense, 'licenses');
+    callback(null);
 });

--- a/features/step_definitions/templates.js
+++ b/features/step_definitions/templates.js
@@ -4,68 +4,66 @@ const fs = require('mz/fs');
 const request = require('../support/request');
 const path = require('path');
 const Assert = require('chai').assert;
-const { defineSupportCode } = require('cucumber');
+const { Given, Then, When } = require('cucumber');
 
-defineSupportCode(({ Given, When, Then }) => {
-    Given(/^a (valid|invalid)\b job-level template$/, function step(templateType) {
-        let targetFile = '';
+Given(/^a (valid|invalid)\b job-level template$/, function step(templateType) {
+    let targetFile = '';
 
-        switch (templateType) {
-        case 'valid':
-            targetFile = path.resolve(__dirname, '../data/valid-template.yaml');
-            break;
-        case 'invalid':
-            targetFile = path.resolve(__dirname, '../data/invalid-template.yaml');
-            break;
-        default:
-            return Promise.reject('Template type is neither valid or invalid');
-        }
+    switch (templateType) {
+    case 'valid':
+        targetFile = path.resolve(__dirname, '../data/valid-template.yaml');
+        break;
+    case 'invalid':
+        targetFile = path.resolve(__dirname, '../data/invalid-template.yaml');
+        break;
+    default:
+        return Promise.reject('Template type is neither valid or invalid');
+    }
 
-        return fs.readFile(targetFile, 'utf8')
-            .then((contents) => {
-                this.templateContents = contents;
+    return fs.readFile(targetFile, 'utf8')
+        .then((contents) => {
+            this.templateContents = contents;
+        });
+});
+
+When(/^they submit it to the API$/, function step() {
+    return this.getJwt(this.apiToken)
+        .then((response) => {
+            const jwt = response.body.token;
+
+            return request({
+                uri: `${this.instance}/${this.namespace}/validator/template`,
+                method: 'POST',
+                auth: {
+                    bearer: jwt
+                },
+                body: {
+                    yaml: this.templateContents
+                },
+                json: true
             });
-    });
+        })
+        .then((response) => {
+            Assert.equal(response.statusCode, 200);
 
-    When(/^they submit it to the API$/, function step() {
-        return this.getJwt(this.apiToken)
-            .then((response) => {
-                const jwt = response.body.token;
+            this.body = response.body;
+        });
+});
 
-                return request({
-                    uri: `${this.instance}/${this.namespace}/validator/template`,
-                    method: 'POST',
-                    auth: {
-                        bearer: jwt
-                    },
-                    body: {
-                        yaml: this.templateContents
-                    },
-                    json: true
-                });
-            })
-            .then((response) => {
-                Assert.equal(response.statusCode, 200);
+Then(/^they are notified it has (no|some) errors$/, function step(quantity) {
+    switch (quantity) {
+    case 'no':
+        Assert.equal(this.body.errors.length, 0);
+        break;
+    case 'some':
+        Assert.equal(this.body.errors.length, 2);
 
-                this.body = response.body;
-            });
-    });
+        Assert.equal(this.body.errors[0].message, '"description" is required');
+        Assert.equal(this.body.errors[1].message, '"image" must be a string');
+        break;
+    default:
+        return Promise.resolve('pending');
+    }
 
-    Then(/^they are notified it has (no|some) errors$/, function step(quantity) {
-        switch (quantity) {
-        case 'no':
-            Assert.equal(this.body.errors.length, 0);
-            break;
-        case 'some':
-            Assert.equal(this.body.errors.length, 2);
-
-            Assert.equal(this.body.errors[0].message, '"description" is required');
-            Assert.equal(this.body.errors[1].message, '"image" must be a string');
-            break;
-        default:
-            return Promise.resolve('pending');
-        }
-
-        return null;
-    });
+    return null;
 });

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -3,204 +3,202 @@
 const Assert = require('chai').assert;
 const github = require('../support/github');
 const sdapi = require('../support/sdapi');
-const { defineSupportCode } = require('cucumber');
+const { Before, Given, When, Then } = require('cucumber');
 
 const TIMEOUT = 240 * 1000;
 const WAIT_TIME = 3;
 
-defineSupportCode(({ Before, Given, When, Then }) => {
-    Before({
-        tags: '@workflow'
-    }, function hook() {
-        this.repoOrg = this.testOrg;
-        this.repoName = 'functional-workflow';
-        this.pipelineId = null;
-        this.builds = null;
-    });
+Before({
+    tags: '@workflow'
+}, function hook() {
+    this.repoOrg = this.testOrg;
+    this.repoName = 'functional-workflow';
+    this.pipelineId = null;
+    this.builds = null;
+});
 
-    Given(/^an existing pipeline on "(.*)" branch with the workflow jobs:$/, {
-        timeout: TIMEOUT
-    }, function step(branch, table) {
-        return this.getJwt(this.apiToken)
-            .then((response) => {
-                this.jwt = response.body.token;
+Given(/^an existing pipeline on "(.*)" branch with the workflow jobs:$/, {
+    timeout: TIMEOUT
+}, function step(branch, table) {
+    return this.getJwt(this.apiToken)
+        .then((response) => {
+            this.jwt = response.body.token;
 
-                return github.createBranch(branch, this.repoOrg, this.repoName);
-            })
-            // wait not to trigger builds when create a pipeline
-            .then(() => this.promiseToWait(WAIT_TIME))
-            .then(() => this.createPipeline(this.repoName, branch))
-            .then((response) => {
-                Assert.oneOf(response.statusCode, [409, 201]);
+            return github.createBranch(branch, this.repoOrg, this.repoName);
+        })
+    // wait not to trigger builds when create a pipeline
+        .then(() => this.promiseToWait(WAIT_TIME))
+        .then(() => this.createPipeline(this.repoName, branch))
+        .then((response) => {
+            Assert.oneOf(response.statusCode, [409, 201]);
 
-                if (response.statusCode === 201) {
-                    this.pipelineId = response.body.id;
-                } else {
-                    this.pipelineId = response.body.message.split(/\s*:\s*/)[1];
+            if (response.statusCode === 201) {
+                this.pipelineId = response.body.id;
+            } else {
+                this.pipelineId = response.body.message.split(/\s*:\s*/)[1];
+            }
+
+            return this.getPipeline(this.pipelineId);
+        })
+        .then((response) => {
+            const expectedJobs = table.hashes();
+
+            this.jobs = response.body;
+
+            for (let i = 0; i < expectedJobs.length; i += 1) {
+                const job = this.jobs.find(j => j.name === expectedJobs[i].job);
+
+                Assert.ok(job, 'Given job does not exist on pipeline');
+
+                const requiresList = expectedJobs[i].requires.split(/\s*,\s*/);
+                const requires = job.permutations[0].requires;
+
+                for (let j = 0; j < requiresList.length; j += 1) {
+                    Assert.ok(requires.includes(requiresList[j]),
+                        'pipeline should have specific edges');
                 }
+            }
+        });
+});
 
-                return this.getPipeline(this.pipelineId);
-            })
-            .then((response) => {
-                const expectedJobs = table.hashes();
+When(/^a new commit is pushed to "(.*)" branch$/, {
+    timeout: TIMEOUT
+}, function step(branch) {
+    return github.createBranch(branch, this.repoOrg, this.repoName)
+        .then(() => github.createFile(branch, this.repoOrg, this.repoName))
+        .then(({ data }) => {
+            this.sha = data.commit.sha;
+        });
+});
 
-                this.jobs = response.body;
+When(/^a pull request is opened to "(.*)" branch$/, (branch, callback) => {
+    // Write code here that turns the phrase above into concrete actions
+    callback(null, 'pending');
+});
 
-                for (let i = 0; i < expectedJobs.length; i += 1) {
-                    const job = this.jobs.find(j => j.name === expectedJobs[i].job);
+Then(/^the "(.*)" job is triggered$/, {
+    timeout: TIMEOUT
+}, function step(jobName) {
+    return sdapi.searchForBuild({
+        instance: this.instance,
+        pipelineId: this.pipelineId,
+        desiredSha: this.sha,
+        desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+        jobName,
+        jwt: this.jwt
+    })
+        .then((build) => {
+            this.eventId = build.eventId;
+            const job = this.jobs.find(j => j.name === jobName);
 
-                    Assert.ok(job, 'Given job does not exist on pipeline');
+            Assert.equal(build.jobId, job.id);
 
-                    const requiresList = expectedJobs[i].requires.split(/\s*,\s*/);
-                    const requires = job.permutations[0].requires;
+            this.buildId = build.id;
+        });
+});
 
-                    for (let j = 0; j < requiresList.length; j += 1) {
-                        Assert.ok(requires.includes(requiresList[j]),
-                            'pipeline should have specific edges');
-                    }
-                }
+Then(/^the "(.*)" job is triggered from "([^"]*)"$/, {
+    timeout: TIMEOUT
+}, function step(triggeredJobName, parentJobName) {
+    return sdapi.findEventBuilds({
+        instance: this.instance,
+        eventId: this.eventId,
+        jwt: this.jwt,
+        jobs: this.jobs,
+        jobName: triggeredJobName
+    })
+        .then((builds) => {
+            this.builds = builds;
+            const parentJob = this.jobs.find(j => j.name === parentJobName);
+            const parentBuild = this.builds.find(b => b.jobId === parentJob.id);
+            const triggeredJob = this.jobs.find(j => j.name === triggeredJobName);
+            const triggeredBuild = this.builds.find(b => b.jobId === triggeredJob.id);
+
+            Assert.equal(parentBuild.id, triggeredBuild.parentBuildId);
+
+            this.buildId = triggeredBuild.id;
+        });
+});
+
+Then(/^the "(.*)" job is triggered from "([^"]*)" and "([^"]*)"$/, {
+    timeout: TIMEOUT
+}, function step(joinJobName, parentJobName1, parentJobName2) {
+    return sdapi.findEventBuilds({
+        instance: this.instance,
+        eventId: this.eventId,
+        jwt: this.jwt,
+        jobs: this.jobs,
+        jobName: joinJobName
+    })
+        .then((builds) => {
+            this.builds = builds;
+            const joinJob = this.jobs.find(j => j.name === joinJobName);
+            const joinBuild = this.builds.find(b => b.jobId === joinJob.id);
+
+            [parentJobName1, parentJobName2].forEach((jobName) => {
+                const parentJob = this.jobs.find(j => j.name === jobName);
+                const parentBuild = this.builds.find(b => b.jobId === parentJob.id);
+
+                Assert.oneOf(parentBuild.id, joinBuild.parentBuildId);
             });
-    });
+        });
+});
 
-    When(/^a new commit is pushed to "(.*)" branch$/, {
-        timeout: TIMEOUT
-    }, function step(branch) {
-        return github.createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(({ data }) => {
-                this.sha = data.commit.sha;
-            });
-    });
+Then(/^the "(.*)" job is not triggered$/, {
+    timeout: TIMEOUT
+}, function step(jobName) {
+    return sdapi.findBuilds({
+        instance: this.instance,
+        pipelineId: this.pipelineId,
+        jobName,
+        jwt: this.jwt
+    }).then((buildData) => {
+        let result = buildData.body || [];
 
-    When(/^a pull request is opened to "(.*)" branch$/, (branch, callback) => {
-        // Write code here that turns the phrase above into concrete actions
-        callback(null, 'pending');
-    });
+        result = result.filter(item => item.sha === this.sha);
 
-    Then(/^the "(.*)" job is triggered$/, {
-        timeout: TIMEOUT
-    }, function step(jobName) {
-        return sdapi.searchForBuild({
+        Assert.equal(result.length, 0, 'Unexpected job was triggered.');
+    });
+});
+
+Then(/^that "(.*)" build uses the same SHA as the "(.*)" build$/, {
+    timeout: TIMEOUT
+}, function step(jobName1, jobName2) {
+    return Promise.all([
+        sdapi.searchForBuild({
             instance: this.instance,
             pipelineId: this.pipelineId,
             desiredSha: this.sha,
             desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
-            jobName,
+            jobName: jobName1,
             jwt: this.jwt
-        })
-            .then((build) => {
-                this.eventId = build.eventId;
-                const job = this.jobs.find(j => j.name === jobName);
-
-                Assert.equal(build.jobId, job.id);
-
-                this.buildId = build.id;
-            });
-    });
-
-    Then(/^the "(.*)" job is triggered from "([^"]*)"$/, {
-        timeout: TIMEOUT
-    }, function step(triggeredJobName, parentJobName) {
-        return sdapi.findEventBuilds({
-            instance: this.instance,
-            eventId: this.eventId,
-            jwt: this.jwt,
-            jobs: this.jobs,
-            jobName: triggeredJobName
-        })
-            .then((builds) => {
-                this.builds = builds;
-                const parentJob = this.jobs.find(j => j.name === parentJobName);
-                const parentBuild = this.builds.find(b => b.jobId === parentJob.id);
-                const triggeredJob = this.jobs.find(j => j.name === triggeredJobName);
-                const triggeredBuild = this.builds.find(b => b.jobId === triggeredJob.id);
-
-                Assert.equal(parentBuild.id, triggeredBuild.parentBuildId);
-
-                this.buildId = triggeredBuild.id;
-            });
-    });
-
-    Then(/^the "(.*)" job is triggered from "([^"]*)" and "([^"]*)"$/, {
-        timeout: TIMEOUT
-    }, function step(joinJobName, parentJobName1, parentJobName2) {
-        return sdapi.findEventBuilds({
-            instance: this.instance,
-            eventId: this.eventId,
-            jwt: this.jwt,
-            jobs: this.jobs,
-            jobName: joinJobName
-        })
-            .then((builds) => {
-                this.builds = builds;
-                const joinJob = this.jobs.find(j => j.name === joinJobName);
-                const joinBuild = this.builds.find(b => b.jobId === joinJob.id);
-
-                [parentJobName1, parentJobName2].forEach((jobName) => {
-                    const parentJob = this.jobs.find(j => j.name === jobName);
-                    const parentBuild = this.builds.find(b => b.jobId === parentJob.id);
-
-                    Assert.oneOf(parentBuild.id, joinBuild.parentBuildId);
-                });
-            });
-    });
-
-    Then(/^the "(.*)" job is not triggered$/, {
-        timeout: TIMEOUT
-    }, function step(jobName) {
-        return sdapi.findBuilds({
+        }),
+        sdapi.searchForBuild({
             instance: this.instance,
             pipelineId: this.pipelineId,
-            jobName,
+            desiredSha: this.sha,
+            desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+            jobName: jobName2,
             jwt: this.jwt
-        }).then((buildData) => {
-            let result = buildData.body || [];
+        })
+    ])
+        .then(([build1, build2]) => Assert.equal(build1.sha, build2.sha));
+});
 
-            result = result.filter(item => item.sha === this.sha);
-
-            Assert.equal(result.length, 0, 'Unexpected job was triggered.');
-        });
+Then(/^the "(.*)" build succeeded$/, {
+    timeout: TIMEOUT
+}, function step(jobName) {
+    return this.waitForBuild(this.buildId).then((resp) => {
+        Assert.equal(resp.statusCode, 200);
+        Assert.equal(resp.body.status, 'SUCCESS', `Unexpected build status: ${jobName}`);
     });
+});
 
-    Then(/^that "(.*)" build uses the same SHA as the "(.*)" build$/, {
-        timeout: TIMEOUT
-    }, function step(jobName1, jobName2) {
-        return Promise.all([
-            sdapi.searchForBuild({
-                instance: this.instance,
-                pipelineId: this.pipelineId,
-                desiredSha: this.sha,
-                desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
-                jobName: jobName1,
-                jwt: this.jwt
-            }),
-            sdapi.searchForBuild({
-                instance: this.instance,
-                pipelineId: this.pipelineId,
-                desiredSha: this.sha,
-                desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
-                jobName: jobName2,
-                jwt: this.jwt
-            })
-        ])
-            .then(([build1, build2]) => Assert.equal(build1.sha, build2.sha));
-    });
-
-    Then(/^the "(.*)" build succeeded$/, {
-        timeout: TIMEOUT
-    }, function step(jobName) {
-        return this.waitForBuild(this.buildId).then((resp) => {
-            Assert.equal(resp.statusCode, 200);
-            Assert.equal(resp.body.status, 'SUCCESS', `Unexpected build status: ${jobName}`);
-        });
-    });
-
-    Then(/^the "(.*)" build failed$/, {
-        timeout: TIMEOUT
-    }, function step(jobName) {
-        return this.waitForBuild(this.buildId).then((resp) => {
-            Assert.equal(resp.statusCode, 200);
-            Assert.equal(resp.body.status, 'FAILURE', `Unexpected build status: ${jobName}`);
-        });
+Then(/^the "(.*)" build failed$/, {
+    timeout: TIMEOUT
+}, function step(jobName) {
+    return this.waitForBuild(this.buildId).then((resp) => {
+        Assert.equal(resp.statusCode, 200);
+        Assert.equal(resp.body.status, 'FAILURE', `Unexpected build status: ${jobName}`);
     });
 });

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -119,7 +119,8 @@ function createBranch(branch, repoOwner, repoName) {
  * @return {Promise}
  */
 function createFile(branch, repoOwner, repoName) {
-    const content = new Buffer(randomString(MAX_CONTENT_LENGTH));
+    // eslint-disable-next-line new-cap
+    const content = new Buffer.alloc(MAX_CONTENT_LENGTH, randomString(MAX_CONTENT_LENGTH));
     const filename = randomString(MAX_FILENAME_LENGTH);
     const owner = repoOwner || 'screwdriver-cd-test';
     const repo = repoName || 'functional-git';

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -5,7 +5,7 @@ const path = require('path');
 const env = require('node-env-file');
 const requestretry = require('requestretry');
 const request = require('../support/request');
-const { defineSupportCode } = require('cucumber');
+const { setWorldConstructor } = require('cucumber');
 
 /**
  * Retry until the build has finished
@@ -181,5 +181,4 @@ function CustomWorld({ attach, parameters }) {
     this.ensurePipelineExists = ensurePipelineExists;
 }
 
-defineSupportCode(({ setWorldConstructor }) =>
-    setWorldConstructor(CustomWorld));
+setWorldConstructor(CustomWorld);

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "screwdriver-api",
   "version": "0.5.0",
-  "description": "API server for the Screwdriver CD service",
+  "description": "API server for the Screwdriver.cd service",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
     "test": "jenkins-mocha --recursive --timeout 4000 --exit",
     "start": "./bin/server",
-    "functional": "cucumber-js --format=pretty --tags 'not @ignore'",
+    "functional": "cucumber-js --format=progress --tags 'not @ignore' --retry 2 --fail-fast",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png"
   },
@@ -120,7 +120,7 @@
     "chai-as-promised": "^6.0.0",
     "chai-jwt": "^2.0.0",
     "coveralls": "^3.0.7",
-    "cucumber": "2.3.1",
+    "cucumber": "6.0.4",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "form-data": "^2.5.1",


### PR DESCRIPTION
## Context
Current cucumber.js version is very old (2!) and some feature tests are flakey.

## Objective
- Use the latest cucumber.js 6 to use `--retry` option
- Fix deprecation of cucumber,js 

## References
- [cucumber-js/cli.md at master · cucumber/cucumber-js](https://github.com/cucumber/cucumber-js/blob/9518f1c46de28767d4e19f2faf5c3b5c29936c97/docs/cli.md#parallel-experimental)
- [cucumber-js/CHANGELOG.md at master · cucumber/cucumber-js](https://github.com/cucumber/cucumber-js/blob/master/CHANGELOG.md)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
