### PR TITLE
fix(1844): enforce validation on parameters

### DIFF
--- a/plugins/builds/listSecrets.js
+++ b/plugins/builds/listSecrets.js
@@ -3,7 +3,9 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.secret.get).label('List of secrets');
+const buildListSchema = joi.array()
+    .items(schema.models.secret.get).label('List of secrets');
+const buildIdSchema = joi.reach(schema.models.build.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
@@ -54,7 +56,12 @@ module.exports = () => ({
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: listSchema
+            schema: buildListSchema
+        },
+        validate: {
+            params: {
+                id: buildIdSchema
+            }
         }
     }
 });

--- a/plugins/builds/metrics.js
+++ b/plugins/builds/metrics.js
@@ -2,8 +2,11 @@
 
 const boom = require('boom');
 const joi = require('joi');
+const schema = require('screwdriver-data-schema');
 const { setDefaultTimeRange, validTimeRange } = require('../helper.js');
 const MAX_DAYS = 180; // 6 months
+const buildIdSchema = joi.reach(schema.models.build.base, 'id');
+const buildMetricListSchema = joi.array().items(joi.object());
 
 module.exports = () => ({
     method: 'GET',
@@ -48,7 +51,13 @@ module.exports = () => ({
                 .then(metrics => reply(metrics))
                 .catch(err => reply(boom.boomify(err)));
         },
+        response: {
+            schema: buildMetricListSchema
+        },
         validate: {
+            params: {
+                id: buildIdSchema
+            },
             query: joi.object({
                 startTime: joi.string().isoDate(),
                 endTime: joi.string().isoDate()

--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -1,7 +1,10 @@
 'use strict';
 
 const boom = require('boom');
+const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const authTokenSchema = schema.api.auth.token;
+const buildIdSchema = joi.reach(schema.models.build.base, 'id');
 
 module.exports = () => ({
     method: 'POST',
@@ -65,7 +68,12 @@ module.exports = () => ({
             }).catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: schema.api.auth.token
+            schema: authTokenSchema
+        },
+        validate: {
+            params: {
+                id: buildIdSchema
+            }
         }
     }
 });

--- a/plugins/events/listBuilds.js
+++ b/plugins/events/listBuilds.js
@@ -3,7 +3,8 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.build.get).label('List of builds');
+const buildListSchema = joi.array().items(schema.models.build.get).label('List of builds');
+const eventIdSchema = joi.reach(schema.models.event.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
@@ -36,7 +37,12 @@ module.exports = () => ({
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: listSchema
+            schema: buildListSchema
+        },
+        validate: {
+            params: {
+                id: eventIdSchema
+            }
         }
     }
 });

--- a/plugins/events/metrics.js
+++ b/plugins/events/metrics.js
@@ -2,8 +2,11 @@
 
 const boom = require('boom');
 const joi = require('joi');
+const schema = require('screwdriver-data-schema');
 const { setDefaultTimeRange, validTimeRange } = require('../helper.js');
 const MAX_DAYS = 180; // 6 months
+const eventIdSchema = joi.reach(schema.models.event.base, 'id');
+const eventMetricListSchema = joi.array().items(joi.object());
 
 module.exports = () => ({
     method: 'GET',
@@ -48,7 +51,13 @@ module.exports = () => ({
                 .then(metrics => reply(metrics))
                 .catch(err => reply(boom.boomify(err)));
         },
+        response: {
+            schema: eventMetricListSchema
+        },
         validate: {
+            params: {
+                id: eventIdSchema
+            },
             query: joi.object({
                 startTime: joi.string().isoDate(),
                 endTime: joi.string().isoDate()

--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -3,7 +3,8 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.build.get).label('List of builds');
+const jobIdSchema = joi.reach(schema.models.job.base, 'id');
+const buildListSchema = joi.array().items(schema.models.build.get).label('List of builds');
 
 module.exports = () => ({
     method: 'GET',
@@ -52,9 +53,12 @@ module.exports = () => ({
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: listSchema
+            schema: buildListSchema
         },
         validate: {
+            params: {
+                id: jobIdSchema
+            },
             query: schema.api.pagination
         }
     }

--- a/plugins/jobs/metrics.js
+++ b/plugins/jobs/metrics.js
@@ -4,6 +4,9 @@ const boom = require('boom');
 const joi = require('joi');
 const { setDefaultTimeRange, validTimeRange } = require('../helper.js');
 const MAX_DAYS = 180; // 6 months
+const schema = require('screwdriver-data-schema');
+const jobMetricListSchema = joi.array().items(joi.object());
+const jobIdSchema = joi.reach(schema.models.job.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
@@ -52,7 +55,13 @@ module.exports = () => ({
                 .then(metrics => reply(metrics))
                 .catch(err => reply(boom.boomify(err)));
         },
+        response: {
+            schema: jobMetricListSchema
+        },
         validate: {
+            params: {
+                id: jobIdSchema
+            },
             query: joi.object({
                 startTime: joi.string().isoDate(),
                 endTime: joi.string().isoDate(),

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -3,7 +3,9 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.event.get).label('List of events');
+const eventListSchema = joi.array().items(schema.models.event.get).label('List of events');
+const prNumSchema = joi.reach(schema.models.event.base, 'prNum');
+const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
@@ -51,12 +53,15 @@ module.exports = () => ({
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: listSchema
+            schema: eventListSchema
         },
         validate: {
+            params: {
+                id: pipelineIdSchema
+            },
             query: schema.api.pagination.concat(joi.object({
                 type: joi.string(),
-                prNum: joi.reach(schema.models.event.base, 'prNum')
+                prNum: prNumSchema
             }))
         }
     }

--- a/plugins/pipelines/listJobs.js
+++ b/plugins/pipelines/listJobs.js
@@ -3,7 +3,9 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.job.get).label('List of jobs');
+const jobListSchema = joi.array().items(schema.models.job.get).label('List of jobs');
+const jobNameSchema = joi.reach(schema.models.job.base, 'name');
+const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
@@ -50,12 +52,15 @@ module.exports = () => ({
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: listSchema
+            schema: jobListSchema
         },
         validate: {
+            params: {
+                id: pipelineIdSchema
+            },
             query: schema.api.pagination.concat(joi.object({
                 archived: joi.boolean().truthy('true').falsy('false').default(false),
-                jobName: joi.reach(schema.models.job.base, 'name')
+                jobName: jobNameSchema
             }))
         }
     }

--- a/plugins/pipelines/listSecrets.js
+++ b/plugins/pipelines/listSecrets.js
@@ -3,7 +3,8 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const listSchema = joi.array().items(schema.models.secret.get).label('List of secrets');
+const secretListSchema = joi.array().items(schema.models.secret.get).label('List of secrets');
+const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
@@ -51,7 +52,12 @@ module.exports = () => ({
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: listSchema
+            schema: secretListSchema
+        },
+        validate: {
+            params: {
+                id: pipelineIdSchema
+            }
         }
     }
 });

--- a/plugins/pipelines/listTriggers.js
+++ b/plugins/pipelines/listTriggers.js
@@ -4,8 +4,9 @@ const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const { EXTERNAL_TRIGGER, JOB_NAME } = schema.config.regex;
+const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
 const destSchema = joi.string().regex(EXTERNAL_TRIGGER).max(64);
-const listSchema = joi.array().items(joi.object({
+const triggerListSchema = joi.array().items(joi.object({
     jobName: JOB_NAME,
     triggers: joi.array().items(destSchema)
 })).label('List of triggers');
@@ -42,7 +43,12 @@ module.exports = () => ({
                 .catch(err => reply(boom.boomify(err)));
         },
         response: {
-            schema: listSchema
+            schema: triggerListSchema
+        },
+        validate: {
+            params: {
+                id: pipelineIdSchema
+            }
         }
     }
 });

--- a/plugins/pipelines/metrics.js
+++ b/plugins/pipelines/metrics.js
@@ -5,6 +5,8 @@ const joi = require('joi');
 const { setDefaultTimeRange, validTimeRange } = require('../helper.js');
 const schema = require('screwdriver-data-schema');
 const MAX_DAYS = 180; // 6 months
+const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
+const pipelineMetricListSchema = joi.array().items(joi.object());
 
 module.exports = () => ({
     method: 'GET',
@@ -60,7 +62,13 @@ module.exports = () => ({
                 .then(metrics => reply(metrics))
                 .catch(err => reply(boom.boomify(err)));
         },
+        response: {
+            schema: pipelineMetricListSchema
+        },
         validate: {
+            params: {
+                id: pipelineIdSchema
+            },
             query: schema.api.pagination.concat(joi.object({
                 startTime: joi.string().isoDate(),
                 endTime: joi.string().isoDate(),

--- a/plugins/pipelines/tokens/create.js
+++ b/plugins/pipelines/tokens/create.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const joi = require('joi');
 const boom = require('boom');
 const schema = require('screwdriver-data-schema');
 const urlLib = require('url');
+const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
+const tokenCreateSchema = schema.models.token.create;
 
 module.exports = () => ({
     method: 'POST',
@@ -80,7 +83,10 @@ module.exports = () => ({
             });
         },
         validate: {
-            payload: schema.models.token.create
+            params: {
+                id: pipelineIdSchema
+            },
+            payload: tokenCreateSchema
         }
     }
 });

--- a/plugins/pipelines/tokens/list.js
+++ b/plugins/pipelines/tokens/list.js
@@ -4,6 +4,7 @@ const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const getSchema = joi.array().items(schema.models.token.get);
+const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
 
 module.exports = () => ({
     method: 'GET',
@@ -61,6 +62,11 @@ module.exports = () => ({
         },
         response: {
             schema: getSchema
+        },
+        validate: {
+            params: {
+                id: pipelineIdSchema
+            }
         }
     }
 });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2017,7 +2017,7 @@ describe('build plugin test', () => {
     });
 
     describe('GET /builds/{id}/secrets', () => {
-        const id = '12345';
+        const id = 12345;
         let options;
         let username;
 
@@ -2888,7 +2888,7 @@ describe('build plugin test', () => {
     });
 
     describe('POST /builds/{id}/token', () => {
-        const id = '12345';
+        const id = 12345;
         const scope = ['temporal'];
         const buildTimeout = 50;
         let options;

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -184,7 +184,7 @@ describe('event plugin test', () => {
     });
 
     describe('GET /events/{id}/builds', () => {
-        const id = '12345';
+        const id = 12345;
         let options;
         let event;
         let builds;

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -284,7 +284,7 @@ describe('job plugin test', () => {
     });
 
     describe('GET /jobs/{id}/builds', () => {
-        const id = '1234';
+        const id = 1234;
         let options;
         let job;
         let builds;

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -713,7 +713,7 @@ describe('pipeline plugin test', () => {
     });
 
     describe('GET /pipelines/{id}/triggers', () => {
-        const id = '123';
+        const id = 123;
         let options;
         let pipelineMock;
 
@@ -736,6 +736,16 @@ describe('pipeline plugin test', () => {
                 assert.deepEqual(reply.result, testTriggers);
             })
         );
+
+        it('returns 400 for passing in string as pipeline id', () => {
+            const stringId = 'test';
+
+            options.url = `/pipelines/${stringId}/triggers`;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 400);
+            });
+        });
 
         it('returns 404 for updating a pipeline that does not exist', () => {
             pipelineFactoryMock.get.resolves(null);


### PR DESCRIPTION
## Context

There's inconsistency on our api, where some of them are missing validation on parameter.
For example on /pipelines/{id} there's validation on id but not on /pipelines/{id}/triggers.
This leads to inconsistent behavior when user incorrectly passing invalid parameter,
/pipelines/randomString would results in code 400 but /pipelines/string/triggers results in
code 500.

## Objective

enforce validation on parameters on our api

## References

https://github.com/screwdriver-cd/screwdriver/issues/1844

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
