### PR TITLE
fix(1468): [3] Remove magic 1.8s

### DIFF
--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -169,8 +169,6 @@ describe('webhooks plugin test', () => {
         };
 
         plugin = rewire('../../plugins/webhooks');
-        // eslint-disable-next-line no-underscore-dangle
-        plugin.__set__('WAIT_FOR_CHANGEDFILES', 0);
 
         server = new hapi.Server();
         server.root.app = {


### PR DESCRIPTION
## Context
Now Screwdriver.cd wait 1.8s for getting changed files correctly.
This PR remove waiting `magic 1.8s`, and polling `mergeable` in `getChangedFiles` of `scm-github`(https://github.com/screwdriver-cd/scm-github/pull/145)
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Remove waiting `magic 1.8s`
- Use `prNum` and `scmUri` for `getChangedFiles`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1468
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
