### PR TITLE
feat(1830): add multibuildclusterenabled flag to pipeline factory init

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -92,7 +92,8 @@ bookends.teardown || [] // plugins required for the teardown-steps
 const Models = require('screwdriver-models');
 const pipelineFactory = Models.PipelineFactory.getInstance({
     datastore,
-    scm
+    scm,
+    multiBuildClusterEnabled
 });
 
 // Setup Executor


### PR DESCRIPTION
## Context

Pipeline level build cluster assignment not working as expected, the reason being multiBuildClusterEnabled flag not available in pipelineFactory

## Objective

add multiBuildClusterEnabled flag to pipelineFactory

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
