### PR TITLE
feat(1830): pull in latest executor-k8s-vm

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "screwdriver-datastore-sequelize": "^5.8.1",
     "screwdriver-executor-docker": "^4.2.0",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^2.10.0",
+    "screwdriver-executor-k8s-vm": "^3.1.0",
     "screwdriver-executor-queue": "^2.4.28",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Context

Pull in latest executor-k8s-vm

## Objective

Update executor-k8s-vm version to 3.1.0

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
