### PR TITLE
fix: add --exit option to cucumber

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pretest": "eslint .",
     "test": "jenkins-mocha --recursive --timeout 4000 --exit",
     "start": "./bin/server",
-    "functional": "cucumber-js --format=progress --tags 'not @ignore' --retry 2 --fail-fast",
+    "functional": "cucumber-js --format=progress --tags 'not @ignore' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png"
   },


### PR DESCRIPTION
## Context
Test sometimes hang with retry

## Objective
Add `--exit` option to prevent hanging.

## References
- https://github.com/screwdriver-cd/screwdriver/pull/1852#issuecomment-557313286
- https://github.com/cucumber/cucumber-js/blob/master/docs/cli.md#exiting

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
