### PR TITLE
fix(1339): parent event parameters not passed on restart

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -196,6 +196,11 @@ module.exports = () => ({
                                 return eventFactory.get(parentEventId)
                                     .then((parentEvent) => {
                                         payload.baseBranch = parentEvent.baseBranch || null;
+
+                                        if (parentEvent.meta && parentEvent.meta.parameters) {
+                                            payload.meta.parameters = parentEvent.meta.parameters;
+                                        }
+
                                         if (!prNum) {
                                             payload.workflowGraph = parentEvent.workflowGraph;
                                             payload.sha = parentEvent.sha;

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -428,7 +428,15 @@ describe('event plugin test', () => {
             eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.baseBranch = 'master';
             testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                }
+            };
             eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta.parameters = {
+                user: { value: 'adong' }
+            };
             options.payload.parentEventId = parentEventId;
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 
@@ -566,6 +574,9 @@ describe('event plugin test', () => {
             };
             eventConfig.changedFiles = ['screwdriver.yaml'];
             eventConfig.baseBranch = 'master';
+            eventConfig.meta.parameters = {
+                user: { value: 'adong' }
+            };
 
             return server.inject(options).then((reply) => {
                 expectedLocation = {


### PR DESCRIPTION
## Context

currently on build restart, default parameters were used because parent event parameters were not passed on build restart.

## Objective

pass parent event parameters on build restart

## References

https://github.com/screwdriver-cd/screwdriver/issues/1339

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
