### PR TITLE
fix(1830): update cache env var path and latest executork8svm

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -374,6 +374,10 @@ ecosystem:
   allowCors:
     __name: ECOSYSTEM_ALLOW_CORS
     __format: json
+  # build cache strategies: s3, disk, with s3 as default option to store cache
+  cache:
+    strategy: CACHE_STRATEGY
+    path: CACHE_PATH
 
 build:
   environment:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -281,6 +281,10 @@ ecosystem:
   dockerRegistry: ""
   # Extra origins allowed to do CORS to API
   allowCors: []
+  # build cache strategies: s3, disk, with s3 as default option to store cache
+  cache:
+    strategy: "s3"
+    path: "/"
 
 # default cluster environment variables to inject into builds
 build:

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "screwdriver-datastore-sequelize": "^5.8.1",
     "screwdriver-executor-docker": "^4.2.0",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^3.1.1",
+    "screwdriver-executor-k8s-vm": "^3.1.2",
     "screwdriver-executor-queue": "^2.4.28",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Context

Move cache environment variables under ecosystem and get latest executork8svm

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
