### PR TITLE
fix(1830): add cache2disk md5, compress, maxsize env var

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -378,6 +378,9 @@ ecosystem:
   cache:
     strategy: CACHE_STRATEGY
     path: CACHE_PATH
+    compress: CACHE_COMPRESS
+    md5check: CACHE_MD5CHECK
+    max_size_mb: CACHE_MAX_SIZE_MB
 
 build:
   environment:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -285,6 +285,9 @@ ecosystem:
   cache:
     strategy: "s3"
     path: "/"
+    compress: false
+    md5check: false
+    max_size_mb: 0
 
 # default cluster environment variables to inject into builds
 build:

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "screwdriver-datastore-sequelize": "^5.8.1",
     "screwdriver-executor-docker": "^4.2.0",
     "screwdriver-executor-k8s": "^13.6.1",
-    "screwdriver-executor-k8s-vm": "^3.1.2",
+    "screwdriver-executor-k8s-vm": "^3.1.3",
     "screwdriver-executor-queue": "^2.4.28",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Objective

add md5 check, compress, max limit environment variables for local cache

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
