### PR TITLE
fix(1339): event with parameters and parent event

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -197,7 +197,8 @@ module.exports = () => ({
                                     .then((parentEvent) => {
                                         payload.baseBranch = parentEvent.baseBranch || null;
 
-                                        if (parentEvent.meta && parentEvent.meta.parameters) {
+                                        if ((!payload.meta || !payload.meta.parameters) &&
+                                            parentEvent.meta && parentEvent.meta.parameters) {
                                             payload.meta.parameters = parentEvent.meta.parameters;
                                         }
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -455,6 +455,42 @@ describe('event plugin test', () => {
             });
         });
 
+        it('returns 201 when it creates an event with custom parameters and parent event', () => {
+            eventConfig.parentEventId = parentEventId;
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                }
+            };
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta.parameters = {
+                user: { value: 'klu' }
+            };
+            options.payload.parentEventId = parentEventId;
+            options.payload.meta.parameters = {
+                user: { value: 'klu' }
+            };
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then((reply) => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
         it('returns 201 when it successfully creates a PR event', () => {
             eventConfig.startFrom = 'PR-1:main';
             eventConfig.prNum = '1';


### PR DESCRIPTION
## Context

In my previous fix for restarting event, I made all event inherit parent event's parameters. This is causing issues where user will not be able to set custom parameters for event with parent event.

## Objective

Event won't inherit parent event parameters if custom parameters are supplied

## References

https://github.com/screwdriver-cd/screwdriver/issues/1339

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
