### PR TITLE
Allow log access for build scope

### DIFF
--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -152,7 +152,7 @@ module.exports = config => ({
         tags: ['api', 'builds', 'steps', 'log'],
         auth: {
             strategies: ['token'],
-            scope: ['user', 'pipeline']
+            scope: ['user', 'pipeline', 'build']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
## Context
We'd like to process logs using a teardown step in the build that created the logs.

## Objective
This will permit a build to use the SD_TOKEN to read logs from any build, including itself.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
