### PR TITLE
fix(1710): Fix parentBuildId and tests

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -501,7 +501,7 @@ async function updateParentBuilds({
             nextBuild.parentBuilds, currentBuildInfo]);
 
     nextBuild.parentBuilds = newParentBuilds;
-    nextBuild.parentBuildIds = [build.id].concat(nextBuild.parentBuildId || []);
+    nextBuild.parentBuildId = [build.id].concat(nextBuild.parentBuildId || []);
 
     return nextBuild.update();
 }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -61,7 +61,7 @@ const jwtMock = {
     sign: () => 'sign'
 };
 
-describe.only('build plugin test', () => {
+describe('build plugin test', () => {
     let buildFactoryMock;
     let stepFactoryMock;
     let userFactoryMock;


### PR DESCRIPTION
## Context

Typo in code: `parentBuildIds` => `parentBuildId`.

## Objective

This PR fixes a typo and removes `.only` on build unit tests.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
