### PR TITLE
fix: use a different git user for prod functional tests

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -77,7 +77,9 @@ jobs:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
-            - test: npm install && npm run functional
+            - test: |
+                export GIT_TOKEN=$GIT_TOKEN_PROD
+                npm install && npm run functional
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
             K8S_CONTAINER: screwdriver-api
@@ -93,6 +95,6 @@ jobs:
             # Access key for functional tests
             - SD_API_TOKEN
             # Git access token
-            - GIT_TOKEN
+            - GIT_TOKEN_PROD
             # Talking to Kubernetes
             - K8S_TOKEN


### PR DESCRIPTION
## Context

Same git user is used for both prod and beta functional tests. This is causing rate limiting problems when running tests back to back.

## Objective

Use a separate user for prod functional tests.

## References

https://cd.screwdriver.cd/pipelines/1/builds/167329/steps/test

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
