### PR TITLE
fix: use sd api token for sd-buildbot-functional user

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -79,7 +79,7 @@ jobs:
             - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
             - test: |
                 npm install
-                GIT_TOKEN=${GIT_TOKEN_PROD} npm run functional
+                GIT_TOKEN=${GIT_TOKEN_PROD} SD_API_TOKEN=${SD_API_TOKEN_PROD} npm run functional
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
             K8S_CONTAINER: screwdriver-api
@@ -93,7 +93,7 @@ jobs:
             TEST_ORG: screwdriver-cd-test
         secrets:
             # Access key for functional tests
-            - SD_API_TOKEN
+            - SD_API_TOKEN_PROD
             # Git access token
             - GIT_TOKEN_PROD
             # Talking to Kubernetes


### PR DESCRIPTION
## Context

Functional tests needs SD API token for the running. When new Git user was added, I missed updating SD API token for same user.

## Objective

Point prod functional tests to use new SD API token.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
