### PR TITLE
fix: delete test pipeline after workflow tests

### DIFF
--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -3,7 +3,7 @@
 const Assert = require('chai').assert;
 const github = require('../support/github');
 const sdapi = require('../support/sdapi');
-const { Before, Given, When, Then } = require('cucumber');
+const { Before, Given, When, Then, After } = require('cucumber');
 
 const TIMEOUT = 240 * 1000;
 const WAIT_TIME = 3;
@@ -201,4 +201,12 @@ Then(/^the "(.*)" build failed$/, {
         Assert.equal(resp.statusCode, 200);
         Assert.equal(resp.body.status, 'FAILURE', `Unexpected build status: ${jobName}`);
     });
+});
+
+After({
+    timeout: TIMEOUT
+}, function hook() {
+    if (this.pipelineId) {
+        return this.deletePipeline(this.pipelineId);
+    }
 });

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -209,4 +209,6 @@ After({
     if (this.pipelineId) {
         return this.deletePipeline(this.pipelineId);
     }
+
+    return false;
 });


### PR DESCRIPTION
## Context

Workflow feature test does not cleanup created test pipelines. This results in re-using git user credentials from the already existing pipeline and can cause rate limiting errors. Rest of the feature tests uses a different approach to create the test pipeline, it deletes the pipeline if it exists. https://github.com/screwdriver-cd/screwdriver/blob/master/features/support/world.js#L42-L66

## Objective

Delete workflow test pipelines after end of feature tests.

## References

https://cd.screwdriver.cd/pipelines/1/builds/167762/steps/test

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
