### PR TITLE
fix: fix command functional tests

### DIFF
--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -16,6 +16,7 @@ Feature: Commands
         Then the job is completed successfully
         And the command is published with <format> format
         And "exec" step executes the command with arguments: <arguments>
+        And the command is deleted
 
         Examples:
             | command      | job     | format  | arguments |
@@ -31,6 +32,7 @@ Feature: Commands
         And "1.0.1" is tagged with "stable"
         And "1.0.1" is tagged with "GA"
         And "stable" tag is removed from "1.0.0"
+        And the command is deleted
 
     @ignore
     Scenario: Get list of explicit command versions

--- a/features/step_definitions/sd-cmd.js
+++ b/features/step_definitions/sd-cmd.js
@@ -222,3 +222,20 @@ Then(/^"([^"]+)" tag is removed from "([^"]+)"$/, {
         Assert.notEqual(response.body.version, version);
     });
 });
+
+Then(/^the command is deleted$/, {
+    timeout: TIMEOUT
+}, function step() {
+    /* eslint-disable-next-line consistent-return */
+    return request({
+        uri: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}`
+        + `/${this.command}`,
+        method: 'DELETE',
+        json: true,
+        auth: {
+            bearer: this.jwt
+        }
+    }).then((resp) => {
+        Assert.equal(resp.statusCode, 204);
+    });
+});

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -204,6 +204,7 @@ Then(/^the "(.*)" build failed$/, {
 });
 
 After({
+    tags: '@workflow',
     timeout: TIMEOUT
 }, function hook() {
     if (this.pipelineId) {


### PR DESCRIPTION
## Context

Shared command functional tests is broken. This happens when pipeline associated with the shared command is is deleted. When pipeline is deleted then test user is unable to delete the shared command. 

## Objective

Delete shared command as part of functional test. This way future tests are not dependent on old data. 

## References

https://cd.screwdriver.cd/pipelines/1/builds/167904/steps/test

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
