### PR TITLE
fix(1710): Create join job and store external parentBuilds info [3]

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -598,26 +598,31 @@ async function handleNewBuild({ done, hasFailure, newBuild }) {
 
 /**
  * [createOrRunNextBuild description]
- * @param  {[type]}  buildFactory       [description]
- * @param  {[type]}  jobFactory         [description]
- * @param  {[type]}  eventFactory       [description]
- * @param  {[type]}  pipelineFactory    [description]
- * @param  {[type]}  pipelineId         [description]
- * @param  {[type]}  jobName            [description]
- * @param  {[type]}  start              [description]
- * @param  {[type]}  username           [description]
- * @param  {[type]}  scmContext         [description]
- * @param  {[type]}  build              [description]
- * @param  {[type]}  event              [description]
- * @param  {[type]}  parentBuilds       [description]
- * @param  {[type]}  parentEventId      [description]
- * @param  {[type]}  externalPipelineId [description]
- * @param  {[type]}  externalJobName    [description]
- * @param  {[type]}  parentBuildId      [description]
- * @param  {Boolean} isExternal         [description]
- * @param  {[type]}  workflowGraph      [description]
- * @param  {[type]}  nextJobName        [description]
- * @return {[type]}                     [description]
+ * @param  {[type]}  buildFactory           [description]
+ * @param  {[type]}  jobFactory             [description]
+ * @param  {[type]}  eventFactory           [description]
+ * @param  {[type]}  pipelineFactory        [description]
+ * @param  {[type]}  pipelineId             [description]
+ * @param  {[type]}  jobName                [description]
+ * @param  {[type]}  start                  [description]
+ * @param  {[type]}  username               [description]
+ * @param  {[type]}  scmContext             [description]
+ * @param  {[type]}  build                  [description]
+ * @param  {[type]}  event                  [description]
+ * @param  {[type]}  parentBuilds           [description]
+ * @param  {[type]}  parentEventId          [description]
+ * @param  {[type]}  externalPipelineId     [description]
+ * @param  {[type]}  externalJobName        [description]
+ * @param  {[type]}  parentBuildId          [description]
+ * @param  {Boolean} isExternal             [description]
+ * @param  {[type]}  workflowGraph          [description]
+ * @param  {[type]}  nextJobName            [description]
+ * @param  {[type]}  externalBuild          [description]
+ * @param  {[type]}  joinListNames          [description]
+ * @param  {[type]}  joinParentBuilds       [description]
+ * @param  {[type]}  currentJobParentBuilds [description]
+ * @param  {[type]}  currentBuildInfo       [description]
+ * @return {[type]}                         [description]
  */
 async function createOrRunNextBuild({ buildFactory, jobFactory, eventFactory, pipelineFactory,
     pipelineId, jobName, start, username, scmContext, build, event, parentBuilds, parentEventId,
@@ -673,7 +678,6 @@ async function createOrRunNextBuild({ buildFactory, jobFactory, eventFactory, pi
             newBuild = await createInternalBuild(internalBuildConfig1);
         }
     } else {
-        console.log('++++ NEXT BUILD EXISTS, UPDATE PARENTBUILDS INFO IN EX');
         newBuild = await updateParentBuilds({
             joinParentBuilds,
             currentJobParentBuilds,
@@ -683,8 +687,6 @@ async function createOrRunNextBuild({ buildFactory, jobFactory, eventFactory, pi
         });
     }
 
-    console.log('++++ CHECKING STATUS OF PARENTBUILDS IN EX');
-
     /* CHECK IF ALL PARENTBUILDS OF NEW BUILD ARE DONE */
     const { hasFailure, done } = await getParentBuildStatus({
         newBuild,
@@ -692,9 +694,6 @@ async function createOrRunNextBuild({ buildFactory, jobFactory, eventFactory, pi
         pipelineId,
         buildFactory
     });
-
-    console.log('hasFailure: ', hasFailure);
-    console.log('done: ', done);
 
     /*  IF NOT DONE -> DO NOTHING
         IF DONE ->
@@ -759,8 +758,6 @@ exports.register = (server, options, next) => {
 
             return obj;
         }, {});
-
-        console.log('currentJobName: ', currentJobName);
 
         // Use old flow if external join flag is off
         if (!externalJoin) {

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -598,31 +598,31 @@ async function handleNewBuild({ done, hasFailure, newBuild }) {
 
 /**
  * [createOrRunNextBuild description]
- * @param  {[type]}  buildFactory           [description]
- * @param  {[type]}  jobFactory             [description]
- * @param  {[type]}  eventFactory           [description]
- * @param  {[type]}  pipelineFactory        [description]
- * @param  {[type]}  pipelineId             [description]
- * @param  {[type]}  jobName                [description]
- * @param  {[type]}  start                  [description]
- * @param  {[type]}  username               [description]
- * @param  {[type]}  scmContext             [description]
- * @param  {[type]}  build                  [description]
- * @param  {[type]}  event                  [description]
- * @param  {[type]}  parentBuilds           [description]
- * @param  {[type]}  parentEventId          [description]
- * @param  {[type]}  externalPipelineId     [description]
- * @param  {[type]}  externalJobName        [description]
- * @param  {[type]}  parentBuildId          [description]
- * @param  {Boolean} isExternal             [description]
- * @param  {[type]}  workflowGraph          [description]
- * @param  {[type]}  nextJobName            [description]
- * @param  {[type]}  externalBuild          [description]
- * @param  {[type]}  joinListNames          [description]
- * @param  {[type]}  joinParentBuilds       [description]
- * @param  {[type]}  currentJobParentBuilds [description]
- * @param  {[type]}  currentBuildInfo       [description]
- * @return {[type]}                         [description]
+ * @param  {Factory}    buildFactory        Build factory
+ * @param  {Factory}    jobFactory          Job factory
+ * @param  {Factory}    eventFactory        Event factory
+ * @param  {Factory}    pipelineFactory     Pipeline factory
+ * @param  {Build}      build               The parentBuild for the next build
+ * @param  {Event}      event               Current event
+ * @param  {String}     jobName             Job name
+ * @param  {Number}     pipelineId          Pipeline ID
+ * @param  {String}     externalJobName     Next job name
+ * @param  {Number}     externalPipelineId  Next pipeline ID
+ * @param  {String}     nextJobName         Next job name
+ * @param  {Object}     workflowGraph       Workflow graph
+ * @param  {Boolean}    start               Start build or not
+ * @param  {String}     username            Username
+ * @param  {String}     scmContext          Scm context
+ * @param  {Object}     parentBuilds        Parent builds info
+ * @param  {Number}     parentEventId       Parent event ID
+ * @param  {Number}     parentBuildId       Parent build ID
+ * @param  {Boolean}    isExternal          Is external or not
+ * @param  {Build}      externalBuild       External build
+ * @param  {Array}      joinListNames       Join list names
+ * @param  {Object}     joinParentBuilds    Parent builds info for join
+ * @param  {Object}     currentJobParentBuilds Parent builds info for current job
+ * @param  {Object}     currentBuildInfo    Parent builds info for current build
+ * @return {Promise}                        The newly updated/created build
  */
 async function createOrRunNextBuild({ buildFactory, jobFactory, eventFactory, pipelineFactory,
     pipelineId, jobName, start, username, scmContext, build, event, parentBuilds, parentEventId,

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -467,7 +467,6 @@ async function getNextBuild({
 
         return j.getLatestBuild({ status: 'CREATED' });
     }
-
     // Get finished internal builds from event
     let finishedInternalBuilds;
 
@@ -597,7 +596,7 @@ async function handleNewBuild({ done, hasFailure, newBuild }) {
 }
 
 /**
- * [createOrRunNextBuild description]
+ * Create next build or check if current build can be started
  * @param  {Factory}    buildFactory        Build factory
  * @param  {Factory}    jobFactory          Job factory
  * @param  {Factory}    eventFactory        Event factory
@@ -828,6 +827,7 @@ exports.register = (server, options, next) => {
                 pipelineId,
                 build
             });
+
             const { externalPipelineId, externalJobName } =
                 getPipelineAndJob(nextJobName, pipelineId);
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2264,12 +2264,20 @@ describe('build plugin test', () => {
                     }]);
 
                     return newServer.inject(options).then(() => {
-                        jobCconfig.start = false;
-                        jobCconfig.parentBuilds = { 123: {
-                            jobs: { a: 12345, b: null },
-                            eventId: '8888'
-                        } };
-                        assert.calledWith(buildFactoryMock.create, jobCconfig);
+                        assert.calledWith(buildFactoryMock.create.firstCall, {
+                            baseBranch: 'master',
+                            configPipelineSha: 'abc123',
+                            eventId: '8888',
+                            jobId: 3,
+                            parentBuildId: 12345,
+                            parentBuilds: { 123: { eventId: '8888', jobs: { a: 12345, b: null } } },
+                            parentEventId: 123,
+                            prRef: '',
+                            scmContext: 'github:github.com',
+                            sha: '58393af682d61de87789fb4961645c42180cec5a',
+                            start: false,
+                            username: 12345
+                        });
                     });
                 });
 


### PR DESCRIPTION
## Context

Currently the external parallel fork join feature does not trigger the join build after both parallel builds complete. This is because the external build is not storing its information in the join build properly.

## Objective

This PR creates the join build immediately after creating the external build so that the parentBuilds field is populated correctly.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
