### PR TITLE
fix(1710): Allow join external trigger

### DIFF
--- a/plugins/pipelines/listTriggers.js
+++ b/plugins/pipelines/listTriggers.js
@@ -3,9 +3,9 @@
 const boom = require('boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const { EXTERNAL_TRIGGER, JOB_NAME } = schema.config.regex;
+const { JOB_NAME } = schema.config.regex;
 const pipelineIdSchema = joi.reach(schema.models.pipeline.base, 'id');
-const destSchema = joi.string().regex(EXTERNAL_TRIGGER).max(64);
+const destSchema = joi.reach(schema.models.trigger.base, 'dest');
 const triggerListSchema = joi.array().items(joi.object({
     jobName: JOB_NAME,
     triggers: joi.array().items(destSchema)

--- a/test/plugins/data/triggers.json
+++ b/test/plugins/data/triggers.json
@@ -9,6 +9,6 @@
     },
     {
         "jobName": "prod",
-        "triggers": ["~sd@345:beta", "~sd@456:deploy"]
+        "triggers": ["~sd@345:beta", "sd@456:deploy"]
     }
 ]


### PR DESCRIPTION
## Context

Should allow pipeline list triggers to return external join trigger.

## Objective

This PR updates the trigger destination regex.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
