### PR TITLE
fix: allow pipeline token to disable and enable jobs

### DIFF
--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'tokens'],
         auth: {
             strategies: ['token'],
-            scope: ['user', '!guest']
+            scope: ['user', '!guest', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

to enable automated disable and enable of jobs via pipeline is not working as the token is enabled for only user.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This will enable pipeline token to enable or disable the job

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
