### PR TITLE
fix(1710): Fix external check for join build

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -908,7 +908,7 @@ exports.register = (server, options, next) => {
                             externalPipelineId: pipelineAndJob.externalPipelineId,
                             externalJobName: pipelineAndJob.externalJobName,
                             parentBuildId: build.id,
-                            isExternal,
+                            isExternal: EXTERNAL_TRIGGER_AND.test(nextJobToTriggerName),
                             workflowGraph,
                             nextJobName: nextJobToTriggerName,
                             externalBuild,

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1878,6 +1878,15 @@ describe('build plugin test', () => {
                         }
                     }))
                 };
+                const externalEventBuilds = [{
+                    id: 555,
+                    jobId: 4,
+                    status: 'SUCCESS'
+                }, {
+                    id: 777,
+                    jobId: 7,
+                    status: 'ABORTED'
+                }];
                 let externalEventMock;
                 let jobBconfig;
                 let jobCconfig;
@@ -1886,15 +1895,8 @@ describe('build plugin test', () => {
                 beforeEach((done) => {
                     externalEventMock = {
                         id: 2,
-                        builds: [{
-                            id: 555,
-                            jobId: 4,
-                            status: 'SUCCESS'
-                        }, {
-                            id: 777,
-                            jobId: 7,
-                            status: 'ABORTED'
-                        }]
+                        builds: externalEventBuilds,
+                        getBuilds: sinon.stub().resolves(externalEventBuilds)
                     };
                     parentEventMock = {
                         id: 456,
@@ -2052,16 +2054,15 @@ describe('build plugin test', () => {
                             { src: '~pr', dest: 'a' },
                             { src: '~commit', dest: 'a' },
                             { src: 'a', dest: 'b' },
-                            { src: 'b', dest: 'c' },
+                            { src: 'b', dest: 'c', join: true },
                             { src: 'a', dest: 'sd@2:a' },
-                            { src: 'sd@2:a', dest: 'c' }
+                            { src: 'sd@2:a', dest: 'c', join: true }
                         ]
                     };
-                    // buildMock.update = sinon.stub().resolves(jobD);
 
                     return newServer.inject(options).then(() => {
                         assert.calledWith(buildFactoryMock.create.firstCall, jobBconfig);
-                        assert.calledOnce(buildFactoryMock.create);
+                        assert.calledTwice(buildFactoryMock.create);
                         assert.calledWith(eventFactoryMock.create.firstCall, expectedEventArgs);
                     });
                 });


### PR DESCRIPTION
## Context

The join job does not always update properly for external parallel fork join.

## Objective

This PR passes in the correct value for checking if the job is external or not when creating the join build after creating the external build.

## References

Related to #1710 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
