### PR TITLE
fix(1847): allow pipeline token to create secret and change job state

### DIFF
--- a/plugins/secrets/create.js
+++ b/plugins/secrets/create.js
@@ -13,7 +13,7 @@ module.exports = () => ({
         tags: ['api', 'secrets'],
         auth: {
             strategies: ['token'],
-            scope: ['user', '!guest']
+            scope: ['user', '!guest', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {
@@ -26,6 +26,7 @@ module.exports = () => ({
             const secretFactory = request.server.app.secretFactory;
             const username = request.auth.credentials.username;
             const scmContext = request.auth.credentials.scmContext;
+            const isValidToken = request.server.plugins.pipelines.isValidToken;
 
             return Promise.all([
                 pipelineFactory.get(request.payload.pipelineId),
@@ -37,6 +38,11 @@ module.exports = () => ({
 
                 if (!user) {
                     throw boom.notFound(`User ${username} does not exist`);
+                }
+
+                // In pipeline scope, check if the token is allowed to the pipeline
+                if (!isValidToken(pipeline.id, request.auth.credentials)) {
+                    throw boom.unauthorized('Token does not have permission to this pipeline');
                 }
 
                 return user.getPermissions(pipeline.scmUri)

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -113,6 +113,10 @@ describe('job plugin test', () => {
 
         server.register([{
             register: plugin
+        }, {
+            /* eslint-disable global-require */
+            register: require('../../plugins/pipelines')
+            /* eslint-enable global-require */
         }], (err) => {
             done(err);
         });

--- a/test/plugins/secrets.test.js
+++ b/test/plugins/secrets.test.js
@@ -95,6 +95,10 @@ describe('secret plugin test', () => {
             options: {
                 password
             }
+        }, {
+            /* eslint-disable global-require */
+            register: require('../../plugins/pipelines')
+            /* eslint-enable global-require */
         }], done);
     });
 


### PR DESCRIPTION
## Context

Currently only user token can change job state and create secrets. We should also allow pipeline token for more flexibility/
## Objective

Allow pipeline token to create secrets and change job state.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1847

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
