### PR TITLE
fix: add debug and profile options to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "pretest": "eslint .",
     "test": "jenkins-mocha --recursive --timeout 4000 --exit",
     "start": "./bin/server",
+    "debug": "node --nolazy --inspect-brk=9229 ./bin/server",
+    "profile": "node --prof ./bin/server",
     "functional": "cucumber-js --format=progress --tags 'not @ignore' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently there's no options in `package.json` to run `debug` and `profile`

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR add `npm run debug` and `npm run profile` to `package.json`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
