### PR TITLE
fix(1785): Fix to get parent event builds recursively

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -607,6 +607,8 @@ async function getFinishedBuilds(event, eventFactory) {
         return event.getBuilds();
     }
 
+    // If parent event id, merge parent build status data recurively and
+    // rerun all builds in the path of the startFrom
     const parentEvent = await eventFactory.get({ id: event.parentEventId });
     const parents = await getFinishedBuilds(parentEvent, eventFactory);
     const upstreamBuilds = await removeDownstreamBuilds({

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -597,6 +597,29 @@ async function handleNewBuild({ done, hasFailure, newBuild }) {
 }
 
 /**
+ * Get finished builds in the all parent events
+ * @param  {Event}      event           Current event
+ * @param  {Factory}    eventFactory    Event Factory
+ * @return {Promise}                    All finished builds
+ */
+async function getFinishedBuilds(event, eventFactory) {
+    if (!event.parentEventId) {
+        return event.getBuilds();
+    }
+
+    const parentEvent = await eventFactory.get({ id: event.parentEventId });
+    const parents = await getFinishedBuilds(parentEvent, eventFactory);
+    const upstreamBuilds = await removeDownstreamBuilds({
+        builds: parents,
+        startFrom: event.startFrom,
+        parentEvent
+    });
+    const builds = await event.getBuilds();
+
+    return builds.concat(upstreamBuilds);
+}
+
+/**
  * Create next build or check if current build can be started
  * @param  {Factory}    buildFactory        Build factory
  * @param  {Factory}    jobFactory          Job factory
@@ -784,30 +807,14 @@ exports.register = (server, options, next) => {
                     return createBuild(buildConfig);
                 }
 
-                return Promise.resolve().then(() => {
-                    if (!event.parentEventId) {
-                        return event.getBuilds();
-                    }
-
-                    // If parent event id, merge parent build status data and
-                    // rerun all builds in the path of the startFrom
-                    return eventFactory.get({ id: event.parentEventId })
-                        .then(parentEvent => parentEvent.getBuilds()
-                            .then(parentBuilds => removeDownstreamBuilds({
-                                builds: parentBuilds,
-                                startFrom: event.startFrom,
-                                parentEvent
-                            }))
-                        )
-                        .then(upstreamBuilds => event.getBuilds()
-                            .then(builds => builds.concat(upstreamBuilds)));
-                }).then(finishedBuilds => handleNextBuild({
-                    buildConfig,
-                    joinList,
-                    finishedBuilds,
-                    jobId: workflowGraph.nodes
-                        .find(node => node.name === trimJobName(nextJobName)).id
-                }));
+                return Promise.resolve().then(() => getFinishedBuilds(event, eventFactory))
+                    .then(finishedBuilds => handleNextBuild({
+                        buildConfig,
+                        joinList,
+                        finishedBuilds,
+                        jobId: workflowGraph.nodes
+                            .find(node => node.name === trimJobName(nextJobName)).id
+                    }));
             }));
         }
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1658,14 +1658,14 @@ describe('build plugin test', () => {
                     });
                 });
 
-                it('triggers if all jobs in join are done with parent event', () => {
+                it('triggers if all jobs in join are done with all parent event', () => {
                     // For a pipeline like this:
                     //   -> b
                     // a
                     //   ->
                     //      c
                     // d ->
-                    // If user restarts `a`, it should get `d`'s parent event status and trigger `c`
+                    // If user restarts `a`, it should get `d`'s all parent event status and trigger `c`
                     eventMock.parentEventId = 456;
                     eventMock.startFrom = 'a';
                     eventMock.workflowGraph.edges = [
@@ -1676,6 +1676,8 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
                     parentEventMock.workflowGraph.edges = eventMock.workflowGraph.edges;
+                    parentEventMock.parentEventId = 789;
+                    parentEventMock.startFrom = 'a';
                     eventMock.getBuilds.resolves([{
                         id: 5,
                         jobId: 1,
@@ -1683,17 +1685,48 @@ describe('build plugin test', () => {
                     }]);
                     parentEventMock.getBuilds.resolves([
                         {
-                            id: 1,
+                            id: 6,
                             jobId: 1,
                             status: 'FAILURE'
-                        },
-                        {
-                            id: 4,
-                            jobId: 4,
-                            status: 'SUCCESS'
                         }
                     ]);
                     jobCconfig.start = false;
+
+                    const parentEventMock2 = {
+                        id: 789,
+                        pipelineId,
+                        workflowGraph: {
+                            nodes: [
+                                { name: '~pr' },
+                                { name: '~commit' },
+                                { name: 'a', id: 1 },
+                                { name: 'b', id: 2 },
+                                { name: 'c', id: 3 },
+                                { name: 'd', id: 4 }
+                            ],
+                            edges: [
+                                { src: '~pr', dest: 'a' },
+                                { src: '~commit', dest: 'a' },
+                                { src: 'a', dest: 'b' },
+                                { src: 'a', dest: 'c', join: true },
+                                { src: 'd', dest: 'c', join: true }
+                            ]
+                        },
+                        getBuilds: sinon.stub().resolves([
+                            {
+                                id: 1,
+                                jobId: 1,
+                                status: 'FAILURE'
+                            },
+                            {
+                                id: 4,
+                                jobId: 4,
+                                status: 'SUCCESS'
+                            }
+                        ])
+                    };
+
+                    eventFactoryMock.get.withArgs({ id: 789 }).resolves(parentEventMock2);
 
                     return server.inject(options).then(() => {
                         assert.calledTwice(buildFactoryMock.create);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix #1785 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In getFinishedBuilds, it gets all parent event and merges parent build status data recursively.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

#1785 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
