### PR TITLE
fix: use node:12 container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 # Screwdriver Version
 ARG VERSION=latest

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true",
+    "test": "nyc --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true",
     "start": "./bin/server",
     "debug": "node --nolazy --inspect-brk=9229 ./bin/server",
     "profile": "node --prof ./bin/server",
@@ -128,13 +128,13 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "form-data": "^2.5.1",
-    "jenkins-mocha": "^8.0.0",
     "mocha": "^7.0.1",
     "mockery": "^2.0.0",
     "mz": "^2.6.0",
     "nock": "^9.6.1",
     "node-plantuml": "^0.5.0",
     "npm-auto-version": "^1.0.0",
+    "nyc": "^15.0.0",
     "rewire": "^4.0.1",
     "sinon": "^7.4.2",
     "stream-to-promise": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true",
+    "test": "jenkins-mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true",
     "start": "./bin/server",
     "debug": "node --nolazy --inspect-brk=9229 ./bin/server",
     "profile": "node --prof ./bin/server",
@@ -128,6 +128,7 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "form-data": "^2.5.1",
+    "jenkins-mocha": "^8.0.0",
     "mocha": "^7.0.1",
     "mockery": "^2.0.0",
     "mz": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true",
     "start": "./bin/server",
     "debug": "node --nolazy --inspect-brk=9229 ./bin/server",
     "profile": "node --prof ./bin/server",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "start": "./bin/server",
     "debug": "node --nolazy --inspect-brk=9229 ./bin/server",
     "profile": "node --prof ./bin/server",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver API is running on node:8 container which is no longer supported.

## Objective

Upgrade to latest LTS of node. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/1722

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
