### PR TITLE
fix(1710): Always pass in parentEventId

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -993,12 +993,9 @@ exports.register = (server, options, next) => {
                     externalJobName,
                     parentBuildId: build.id,
                     parentBuilds,
-                    causeMessage: `Triggered by sd@${pipelineId}:${currentJobName}`
+                    causeMessage: `Triggered by sd@${pipelineId}:${currentJobName}`,
+                    parentEventId: event.id
                 };
-
-                if (!event.parentEventId) {
-                    externalBuildConfig.parentEventId = event.id;
-                }
 
                 return createExternalBuild(externalBuildConfig);
             }


### PR DESCRIPTION
## Context

Should always pass in parentEventId.

## Objective

This PR passed in parentEventId.

## References

Related to #1710 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
