### PR TITLE
fix: revert change to parent event id

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -993,9 +993,12 @@ exports.register = (server, options, next) => {
                     externalJobName,
                     parentBuildId: build.id,
                     parentBuilds,
-                    causeMessage: `Triggered by sd@${pipelineId}:${currentJobName}`,
-                    parentEventId: event.id
+                    causeMessage: `Triggered by sd@${pipelineId}:${currentJobName}`
                 };
+
+                if (!event.parentEventId) {
+                    externalBuildConfig.parentEventId = event.id;
+                }
 
                 return createExternalBuild(externalBuildConfig);
             }


### PR DESCRIPTION
##  Context

Previous change to pass in `parentEventId` breaks some regular start cases and restarts cases

## Objective

revert the changes

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/1964
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
