### PR TITLE
fix(1937): fix error message when SCM is different

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -124,6 +124,11 @@ module.exports = () => ({
                     let scmConfig;
                     let permissions;
 
+                    if (scmContext !== pipeline.scmContext) {
+                        // eslint-disable-next-line max-len
+                        throw boom.forbidden('This checkoutUrl is not supported for your current login host.');
+                    }
+
                     // Check if user has push access
                     return user.getPermissions(pipeline.scmUri)
                         .then((userPermissions) => {

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -236,6 +236,7 @@ describe('event plugin test', () => {
         const pipelineMock = {
             id: pipelineId,
             checkoutUrl,
+            scmContext: 'github:github.com',
             update: sinon.stub().resolves(),
             admins: { foo: true, bar: true },
             admin: Promise.resolve({
@@ -258,7 +259,7 @@ describe('event plugin test', () => {
             };
             scmConfig = {
                 prNum: null,
-                scmContext,
+                scmContext: 'github:github.com',
                 scmUri,
                 token: 'iamtoken'
             };
@@ -788,6 +789,15 @@ describe('event plugin test', () => {
                 assert.notCalled(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
+            });
+        });
+
+        it('returns 403 forbidden error when user\'s scm' +
+            ' and pipeline\'s scm are different', () => {
+            options.credentials.scmContext = 'mygit:mygit.com';
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 403);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix https://github.com/screwdriver-cd/screwdriver/issues/1937

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR makes the error message easy to understand. This message is used UI to show SCM action link. I will make another PR to UI.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/ui/pull/530

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
