### PR TITLE
Fix depercate post build endpoint

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -9,7 +9,7 @@ module.exports = () => ({
     path: '/builds',
     config: {
         description: 'Create and start a build',
-        notes: 'Create and start a specific build',
+        notes: 'This api is depercated, use POST /events instead',
         tags: ['api', 'builds'],
         auth: {
             strategies: ['token'],

--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -17,7 +17,8 @@ module.exports = () => ({
         },
         plugins: {
             'hapi-swagger': {
-                security: [{ token: [] }]
+                security: [{ token: [] }],
+                deprecated: true
             }
         },
         handler: (request, reply) => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`POST /builds` was no longer actively maintain and does not support several new features. We should mark it as deprecated in swagger

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
mark `POST /builds` as deprecated in swagger
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
