### PR TITLE
docs: add Gitlab option for SCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Three (3) options for executor:
  - Docker (`docker`)
  - Nomad (`nomad`)
 
-Two (2) options for SCM:
+Three (3) options for SCM:
  - Github (`github`)
+ - Gitlab (`gitlab`)
  - Bitbucket (`bitbucket`)
 
 ### Prerequisites


### PR DESCRIPTION

## Context
Screwdriver is already support Gitlab SCM now.

## Objective
update the docs

## References
none
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
