### PR TITLE
fix(1710): Parallel trigger

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -841,9 +841,9 @@ async function handleDuplicatePipelines(config) {
         [currentJobParentBuilds, currentBuildInfo]);
 
     // Handle external events
-    // if no join array and external and pipeline the same, should be same event
+    // If no join array and external and pipeline the same, should be same event
     if (duplicatePipelineIds.length) {
-        return Promise.all(duplicatePipelineIds.forEach((pid) => {
+        await Promise.all(duplicatePipelineIds.map(async (pid) => {
             const externalJobNamesWithMatchingPipelineId =
                 externalJobNamesWithNoJoinArr.filter(jName =>
                     EXTERNAL_TRIGGER_ALL.exec(jName)[1] === pid);
@@ -854,7 +854,7 @@ async function handleDuplicatePipelines(config) {
             });
 
             // Start one event per duplicate pipelineId
-            return createExternalBuild({
+            await createExternalBuild({
                 pipelineFactory,
                 eventFactory,
                 externalPipelineId: pid,
@@ -863,7 +863,7 @@ async function handleDuplicatePipelines(config) {
                 parentBuilds,
                 causeMessage: `Triggered by sd@${pipelineId}:${currentJobName}`,
                 parentEventId: event.id
-            }).then(() => newJoinObj);
+            });
         }));
     }
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2384,14 +2384,15 @@ describe('build plugin test', () => {
 
                 it('creates a single event for downstream triggers in the same pipeline', () => {
                     // For a pipeline like this:
-                    //      -> sd@2:a
+                    //      -> b
                     //    a
-                    //      -> sd@2:b
+                    //      -> sd@2:b, sd@2:a
                     // If user is at `a`, it should trigger both `sd@2:a` and `sd@2:b` in one event
                     eventMock.workflowGraph = { nodes: [
                         { name: '~pr' },
                         { name: '~commit' },
                         { name: 'a', id: 1 },
+                        { name: 'b', id: 2 },
                         { name: 'sd@2:a', id: 4 },
                         { name: 'sd@2:c', id: 6 }
                     ],
@@ -2399,7 +2400,8 @@ describe('build plugin test', () => {
                         { src: '~pr', dest: 'a' },
                         { src: '~commit', dest: 'a' },
                         { src: 'a', dest: 'sd@2:a' },
-                        { src: 'a', dest: 'sd@2:c' }
+                        { src: 'a', dest: 'sd@2:c' },
+                        { src: 'a', dest: 'b' }
                     ] };
                     const parentBuilds = {
                         123: { eventId: '8888', jobs: { a: 12345 } }
@@ -2457,7 +2459,8 @@ describe('build plugin test', () => {
                         assert.calledOnce(eventFactoryMock.create);
                         assert.calledWith(eventFactoryMock.create, eventConfig);
                         assert.notCalled(externalEventMock.getBuilds);
-                        assert.notCalled(buildFactoryMock.create);
+                        assert.calledOnce(buildFactoryMock.create);
+                        assert.calledWith(buildFactoryMock.create, jobBconfig);
                         assert.notCalled(buildC.update);
                         assert.notCalled(updatedBuildC.start);
                     });


### PR DESCRIPTION
## Context

Parallel triggers are not working when there are duplicate pipeline external downstream triggers. This is because the `handleDuplicatePipelines` function is not returning correctly.

## Objective

This PR fixes the above issue.

## References

Related to #1710 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
