### PR TITLE
design(1314): add `--disable-image-pull` option

### DIFF
--- a/design/sd-local.md
+++ b/design/sd-local.md
@@ -135,7 +135,7 @@ $ sdlocal build [job-name] [options]
 - `--artifacts-dir [path]` Path to the host side directory which is mounted into `$SD_ARTIFACTS_DIR`. (default: `./sd-artifacts`)
 - `-m, --memory [size]` Set memory size which Build Container can use. Either b, k, m, g can be used as a size unit. (default: ?)
 - `--src-url [repository url]` Set repository URL which is to build when user use the remote repository without local files.
-- `--always-pull-disable` Disable `sd-local` from always pulling build image.
+- `--disable-image-pull` Disable `sd-local` from always pulling build image.
 
 #### Output
 

--- a/design/sd-local.md
+++ b/design/sd-local.md
@@ -135,6 +135,7 @@ $ sdlocal build [job-name] [options]
 - `--artifacts-dir [path]` Path to the host side directory which is mounted into `$SD_ARTIFACTS_DIR`. (default: `./sd-artifacts`)
 - `-m, --memory [size]` Set memory size which Build Container can use. Either b, k, m, g can be used as a size unit. (default: ?)
 - `--src-url [repository url]` Set repository URL which is to build when user use the remote repository without local files.
+- `--always-pull-disable` Disable `sd-local` from always pulling build image.
 
 #### Output
 


### PR DESCRIPTION
## Context

We are now developing `sd-local` and it always pulls build image each execution.
Therefore this PR suggests adding the option to disable that behaviour to make users run jobs on docker images in local machine.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- add `--always-pull-disable` option.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
- #1314 
- screwdriver-cd/sd-local/pull/11
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
