### PR TITLE
fix(1710): add error handling

### DIFF
--- a/plugins/shutdown.js
+++ b/plugins/shutdown.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Joi = require('joi');
-
 const logger = require('screwdriver-logger');
 
 const tasks = {};


### PR DESCRIPTION
## Context

We are noticing POST "/build/BUILD_ID" end point failing due to lack of proper error handling. 

## Objective

While underlying issue is not fixed, this put's a band aid of API processing and causes it to complete without erroring out.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1710

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
