### PR TITLE
fix(1710): Pass in startFrom for external triggers

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2084,7 +2084,7 @@ describe('build plugin test', () => {
                 it('triggers next next job when next job is external', () => {
                     const expectedEventArgs = {
                         pipelineId: '2',
-                        startFrom: 'a',
+                        startFrom: '~sd@123:a',
                         type: 'pipeline',
                         causeMessage: 'Triggered by sd@123:a',
                         parentBuildId: 12345,


### PR DESCRIPTION
## Context

The UI doesn't mark external triggers properly at the moment for the new remote join feature.

Before:
<img width="538" alt="Screen Shot 2020-03-03 at 4 10 01 PM" src="https://user-images.githubusercontent.com/3230529/75831845-7b4fd480-5d69-11ea-9d9d-2e900af8f917.png">

## Objective

This PR passes in the startFrom properly as external triggers.

After:
<img width="593" alt="Screen Shot 2020-03-03 at 4 10 08 PM" src="https://user-images.githubusercontent.com/3230529/75831848-80148880-5d69-11ea-81fd-9dc28f4d5fdb.png">

## References

Related to #1710 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
