### PR TITLE
design(1314): Update sd-local design about env options

### DIFF
--- a/design/sd-local.md
+++ b/design/sd-local.md
@@ -12,6 +12,7 @@ As a result, User cannot confirm whether the result obtained on CI is the expect
 - December 3rd, 2019: Proposal submitted
 - December 6th, 2019: Added `SD_META_DIR`
 - December 18th, 2019: Updated `launcher` / `log-service`
+- March 4th, 2020: Updated env options
 
 ## Proposal
 
@@ -131,7 +132,8 @@ $ sdlocal build [job-name] [options]
 - `--meta-file [path]` Path to config file of `meta` (JSON)
 - `-e, --env [key=value]` Set `key` and `value` relationship which is set as environment variables of Build Container.
   - `secrets` is also set as environment variables.
-- `--env-file [path]` Path to config file of environment variables. (`.env`)
+  - When both `--env` and `--env-file` options are used, `--env` has priority about environment variables used in both options.
+- `--env-file [path]` Path to config file of environment variables. (`.env` format file can be used.)
 - `--artifacts-dir [path]` Path to the host side directory which is mounted into `$SD_ARTIFACTS_DIR`. (default: `./sd-artifacts`)
 - `-m, --memory [size]` Set memory size which Build Container can use. Either b, k, m, g can be used as a size unit. (default: ?)
 - `--src-url [repository url]` Set repository URL which is to build when user use the remote repository without local files.


### PR DESCRIPTION
## Context
We implemented the `--env` and `--env-file` options in screwdriver-cd/sd-local#15.
But the behavior when both `--env` and `--env-file` options are used at the same time is not mentioned by the design doc.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR adds the details of env options.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
screwdriver-cd/sd-local#15
#1314
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
