### PR TITLE
fix: Correctly handle ignore user case

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -876,8 +876,9 @@ exports.register = (server, options, next) => {
                     }
 
                     // if skip ci then don't return
-                    if (ignoreUser && !skipMessage) {
-                        const commitAuthors = Array.isArray(parsed.commitAuthors) ?
+                    if (ignoreUser && ignoreUser.length !== 0 && !skipMessage) {
+                        const commitAuthors = (Array.isArray(parsed.commitAuthors)
+                            && parsed.commitAuthors.length !== 0) ?
                             parsed.commitAuthors : [username];
                         const validCommitAuthors = commitAuthors.filter(author =>
                             !ignoreUser.includes(author));


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
1. `ignoreUser` has a default value `[]`.
Therefore, L879 condition become true even if cluster admins don't set `IGNORE_COMMITS_BY`.
We should check `ignoreUser` has any user.

2. GitHub event push webhook sometimes returns `[]` as commits.
https://github.com/screwdriver-cd/scm-github/blob/master/index.js#L1122
In that case, `parsed.commitAuthors` is `[]`.
Array.isArray([]) returns true, L880 commitAuthors become also `[]`. 
Then, `validCommitAuthors` become also `[]`, build is skipped.
We should correctly handle case that `parsed.commitAuthors` is `[]`.
 
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
1. Check if ignoreUser.length is not 0.
2. Check if parsed.commitAuthors.length is not 0.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
