### PR TITLE
fix: use for..for instead of reduce

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -810,7 +810,9 @@ async function createOrRunNextBuild({ buildFactory, jobFactory, eventFactory, pi
     }
 
     if (!newBuild) {
-        throw new Error(`No build found for ${pipelineId}:${jobName}`);
+        logger.error(`No build found for ${pipelineId}:${jobName}`);
+
+        return null;
     }
 
     /* CHECK IF ALL PARENTBUILDS OF NEW BUILD ARE DONE */
@@ -1256,18 +1258,17 @@ exports.register = (server, options, next) => {
         const nextJobNames = Object.keys(joinObj);
 
         // Start each build sequentially
-        await nextJobNames.reduce(async (jobRunPromise, nextJobName) => {
+        // FIXME:: Remove eslint disable after upgrading eslint rules
+        /* eslint-disable */
+        for (const nextJobName of nextJobNames) {
             try {
-                await jobRunPromise;
-
-                return processNextJob(nextJobName);
+                await processNextJob(nextJobName);
             } catch (err) {
                 logger.error(`Error in processNextJob - pipeline:${pipelineId}-${nextJobName}` +
-                    ` event:${event.id}`, err);
-
-                return Promise.resolve();
+                    ` event:${event.id} `, err);
             }
-        }, Promise.resolve());
+        }
+        /* eslint-enable */
 
         return null;
     });


### PR DESCRIPTION
## Context

Previous logic using `reduce` is about creating a `Promise` chain to process promises sequentially. But error handling is a bit tricky, since on each loop we are processing previous `Promise`.



## Objective

`for..of` is much more readable and easy to capture context on errors.  

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/pull/1999/files#diff-7a514e440aa937beee722c7ac84dfb93R1243-R1249

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
