### PR TITLE
fix(1710): Simple trigger should work

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2353,6 +2353,22 @@ describe('build plugin test', () => {
                         parentBuilds,
                         start: sinon.stub().resolves()
                     });
+                    const jobCConfig = {
+                        baseBranch: 'master',
+                        configPipelineSha: 'abc123',
+                        eventId: '8887',
+                        jobId: 3,
+                        parentBuildId: 12345,
+                        parentBuilds: {
+                            123: { eventId: '8888', jobs: { a: 12345 } },
+                            2: { eventId: '8888', jobs: { a: 12345 } }
+                        },
+                        prRef: '',
+                        scmContext: 'github:github.com',
+                        sha: '58393af682d61de87789fb4961645c42180cec5a',
+                        start: false,
+                        username: 12345
+                    };
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
                     const externalEventMock = {
@@ -2397,6 +2413,7 @@ describe('build plugin test', () => {
                         assert.notCalled(eventFactoryMock.create);
                         assert.calledTwice(externalEventMock.getBuilds);
                         assert.calledOnce(buildFactoryMock.create);
+                        assert.calledWith(buildFactoryMock.create, jobCConfig);
                         assert.calledOnce(buildC.update);
                         assert.calledOnce(updatedBuildC.start);
                     });
@@ -3012,6 +3029,21 @@ describe('build plugin test', () => {
                         },
                         start: sinon.stub().resolves()
                     });
+                    const createEventConfig = {
+                        causeMessage: 'Triggered by sd@123:a',
+                        parentBuildId: 12345,
+                        parentBuilds: {
+                            123: { eventId: '8888', jobs: { a: 12345, c: 45678 } },
+                            2: { eventId: '8888', jobs: { a: 12345 } }
+                        },
+                        parentEventId: '8888',
+                        pipelineId: 123,
+                        scmContext: 'github:github.com',
+                        sha: 'sha',
+                        startFrom: '~sd@123:a',
+                        type: 'pipeline',
+                        username: 'foo'
+                    };
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
                     const externalEventMock = {
@@ -3098,6 +3130,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.calledOnce(eventFactoryMock.create);
+                        assert.calledWith(eventFactoryMock.create, createEventConfig);
                         assert.calledTwice(externalEventMock.getBuilds);
                         assert.notCalled(buildFactoryMock.create);
                         assert.calledOnce(buildC.update);


### PR DESCRIPTION
## Context

When the trigger circles back to a pipeline without a join case, it should still work. The code was failing trying to get the build ID in parent builds when it doesn't exist (since it is not a join case).

Pipeline 42:
![Screen Shot 2020-03-05 at 3 52 39 PM](https://user-images.githubusercontent.com/3230529/76036597-61dd9280-5ef9-11ea-9e43-f59dd11914a4.png)

Pipeline 43:
![Screen Shot 2020-03-05 at 3 52 46 PM](https://user-images.githubusercontent.com/3230529/76036604-6609b000-5ef9-11ea-91f8-7f5b2b7c370e.png)


## Objective

This PR handles the case where the parentBuilds does not contain desired buildId information; also passes in the correct eventId when creating the new build.

## References

Related to #1710 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
