### PR TITLE
fix(1710): Fix sha for internal build

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -304,12 +304,13 @@ async function createExternalBuild(config) {
  * @param  {Number}   [config.parentBuildId]    Parent build ID
  * @param  {Number}   [config.eventId]          Event ID for build
  * @param  {Boolean}  [config.start]            Whether to start the build or not
+ * @param  {String}   [config.sha]              Build sha
  * @return {Promise}
  */
 async function createInternalBuild(config) {
     const { jobFactory, buildFactory, eventFactory, pipelineId, jobName,
         username, scmContext, build, parentBuilds, start, baseBranch, parentBuildId,
-        eventId } = config;
+        eventId, sha } = config;
     const event = await eventFactory.get(build.eventId);
     const job = await jobFactory.get({
         name: jobName,
@@ -318,7 +319,7 @@ async function createInternalBuild(config) {
     const prRef = event.pr.ref ? event.pr.ref : '';
     const internalBuildConfig = {
         jobId: job.id,
-        sha: build.sha,
+        sha: sha || build.sha,
         parentBuildId: parentBuildId || build.id,
         parentBuilds: parentBuilds || {},
         eventId: eventId || build.eventId,
@@ -1169,7 +1170,8 @@ exports.register = (server, options, next) => {
                                 parentBuilds,
                                 parentBuildId: build.id,
                                 start: false,
-                                eventId: externalEventId
+                                eventId: externalEventId,
+                                sha: externalEvent.sha
                             });
                         }
                     // If next build exists, update next build with parentBuilds info


### PR DESCRIPTION
## Context

Sometimes when the workflow continues in the original event, the sha is incorrect for the internal build.
It tries to use the SHA from the triggering pipeline.

Something like the following:
A:JobA > B:jobA> C:jobA-> B:JobB

b:jobB fails at SCM step because it uses wrong SHA from C:jobA

## Objective

This PR passes in the event's original sha to the internal build config.

Before:
<img width="590" alt="Screen Shot 2020-03-10 at 5 28 23 PM" src="https://user-images.githubusercontent.com/3230529/76371251-f16ab300-62f6-11ea-8ff8-31764ea19dad.png">

After:
<img width="582" alt="Screen Shot 2020-03-10 at 5 28 08 PM" src="https://user-images.githubusercontent.com/3230529/76371255-f3cd0d00-62f6-11ea-9fa2-150ca26fbc83.png">

## References

Related to #1710 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
