### PR TITLE
docs: [skip ci] update plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,24 @@ For more information about Screwdriver, check out our [homepage](http://screwdri
 
 ### Plugins
 
-This API comes preloaded with 11 (eleven) resources:
+This API comes preloaded with 16 (sixteen) resources:
 
  - [auth](plugins/auth/README.md)
  - [banners](plugins/banners/README.md)
  - [builds](plugins/builds/README.md)
+ - [buildClusters](plugins/buildClusters/README.md)
  - [collections](plugins/collections/README.md)
+ - [commands](plugins/commands/README.md)
  - [coverage](plugins/coverage/README.md) - optional
  - [events](plugins/events/README.md)
  - [jobs](plugins/jobs/README.md)
  - [pipelines](plugins/pipelines/README.md)
  - [secrets](plugins/secrets/README.md)
+ - [templates](plugins/templates/README.md)
  - [tokens](plugins/tokens/README.md)
  - [webhooks](plugins/webhooks/README.md)
+ - [stats](plugins/stats.js)
+ - [isAdmin](plugins/isAdmin.js)
 
 Three (3) option for datastores:
  - Postgres, MySQL, and Sqlite (`sequelize`)


### PR DESCRIPTION
## Context
Some plugins are not in the docs,  so add them to the docs.

## Objective
update the docs

## References
https://github.com/screwdriver-cd/screwdriver/blob/master/lib/registerPlugins.js

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
