### PR TITLE
fix(2026): Check for startFrom for event create [2]

### DIFF
--- a/features/support/world.js
+++ b/features/support/world.js
@@ -5,7 +5,7 @@ const path = require('path');
 const env = require('node-env-file');
 const requestretry = require('requestretry');
 const { setWorldConstructor } = require('cucumber');
-const request = require('../support/request');
+const request = require('./request');
 
 /**
  * Retry until the build has finished

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -94,6 +94,11 @@ module.exports = () => ({
                         payload.creator = creator;
                     }
 
+                    // Check for startFrom
+                    if (!startFrom) {
+                        throw boom.badRequest('Missing "startFrom" trigger');
+                    }
+
                     // Trigger "~pr" needs to have PR number given
                     // Note: To kick start builds for all jobs under a PR,
                     // you need both the prNum and the trigger "~pr" as startFrom

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -747,6 +747,14 @@ describe('event plugin test', () => {
             });
         });
 
+        it('returns 400 bad request error when missing startFrom', () => {
+            delete options.payload.startFrom;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 400);
+            });
+        });
+
         it('returns 400 bad request error missing prNum for "~pr"', () => {
             eventConfig.prRef = 'prref';
             eventConfig.type = 'pr';


### PR DESCRIPTION
## Context

Should throw a more specific error when `startFrom` is missing.
`startFrom` is not required when `buildId` is passed in.

## Objective

This PR adds a check for `startFrom`.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2026

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
