### PR TITLE
fix(1847): Allow pipeline token to remove and update secret

### DIFF
--- a/plugins/secrets/index.js
+++ b/plugins/secrets/index.js
@@ -58,6 +58,10 @@ exports.register = (server, options, next) => {
                 });
             }
 
+            if (scope.includes('pipeline') && secret.pipelineId !== credentials.pipelineId) {
+                throw boom.forbidden('Token does not have permission to this secret');
+            }
+
             if (secret.pipelineId !== credentials.pipelineId && secret.pipelineId !== credentials.configPipelineId) {
                 throw boom.forbidden(`${username} is not allowed to access this secret`);
             }

--- a/plugins/secrets/remove.js
+++ b/plugins/secrets/remove.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'secrets'],
         auth: {
             strategies: ['token'],
-            scope: ['user', '!guest']
+            scope: ['user', '!guest', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {

--- a/plugins/secrets/update.js
+++ b/plugins/secrets/update.js
@@ -14,7 +14,7 @@ module.exports = () => ({
         tags: ['api', 'secrets'],
         auth: {
             strategies: ['token'],
-            scope: ['user', '!guest']
+            scope: ['user', '!guest', 'pipeline']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently only user token can delete and update secrets. We should also allow pipeline token for more flexibility.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Allow pipeline token to delete and update secrets.

## References

#1847 

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
