### PR TITLE
fix: remove eslint disable comment

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -1341,10 +1341,7 @@ exports.register = (server, options, next) => {
             try {
                 await processNextJob(nextJobName);
             } catch (err) {
-                logger.error(
-                    `Error in processNextJob - pipeline:${pipelineId}-${nextJobName}` + ` event:${event.id} `,
-                    err
-                );
+                logger.error(`Error in processNextJob - pipeline:${pipelineId}-${nextJobName} event:${event.id} `, err);
             }
         }
 

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -1337,17 +1337,16 @@ exports.register = (server, options, next) => {
         const nextJobNames = Object.keys(joinObj);
 
         // Start each build sequentially
-        // FIXME:: Remove eslint disable after upgrading eslint rules
-        /* eslint-disable */
         for (const nextJobName of nextJobNames) {
             try {
                 await processNextJob(nextJobName);
             } catch (err) {
-                logger.error(`Error in processNextJob - pipeline:${pipelineId}-${nextJobName}` +
-                    ` event:${event.id} `, err);
+                logger.error(
+                    `Error in processNextJob - pipeline:${pipelineId}-${nextJobName}` + ` event:${event.id} `,
+                    err
+                );
             }
         }
-        /* eslint-enable */
 
         return null;
     });


### PR DESCRIPTION
## Context

Eslint disable comment is not needed any more. 

## Objective

Remove eslint disable section.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
