### PR TITLE
design(1314): add description of `--local` option

### DIFF
--- a/design/sd-local.md
+++ b/design/sd-local.md
@@ -141,6 +141,7 @@ $ sdlocal build [job-name] [options]
 - `--src-url [repository url]` Set repository URL which is to build when user use the remote repository without local files.
 - `--disable-image-pull` Disable `sd-local` from always pulling build image.
 - `--sudo` Use `sudo` command to execute docker runtime.
+- `--local` Use `.sdlocal/config` in current directory as a config file of sd-local.
 
 ###### src-url option
 - How to specify the URL

--- a/design/sd-local.md
+++ b/design/sd-local.md
@@ -141,7 +141,7 @@ $ sdlocal build [job-name] [options]
 - `--src-url [repository url]` Set repository URL which is to build when user use the remote repository without local files.
 - `--disable-image-pull` Disable `sd-local` from always pulling build image.
 - `--sudo` Use `sudo` command to execute docker runtime.
-- `--local` Use `.sdlocal/config` in current directory as a config file of sd-local.
+- `--local` Run command with .sdlocal/config file in current directory
 
 ###### src-url option
 - How to specify the URL

--- a/design/sd-local.md
+++ b/design/sd-local.md
@@ -14,6 +14,7 @@ As a result, User cannot confirm whether the result obtained on CI is the expect
 - December 18th, 2019: Updated `launcher` / `log-service`
 - March 4th, 2020: Added `src-url` option and updated env options
 - March 16th, 2020: Added `sudo` option
+- March 24th, 2020: Added `--local` option
 
 ## Proposal
 


### PR DESCRIPTION
## Context
Update sd-local design docs for adding `--local` option.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## References
https://github.com/screwdriver-cd/sd-local/pull/24

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
