### PR TITLE
fix: When external downstream trigger is part of a join, should not be triggered by external event

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2027,7 +2027,23 @@ describe('build plugin test', () => {
                                 {
                                     id: 3
                                 }
-                            ])
+                            ]),
+                            workflowGraph: {
+                                nodes: [
+                                    { name: '~pr' },
+                                    { name: '~commit' },
+                                    { name: 'a', id: 1 },
+                                    { name: 'b', id: 2 },
+                                    { name: 'c', id: 3 },
+                                    { name: 'd', id: 4 }
+                                ],
+                                edges: [
+                                    { src: '~pr', dest: 'main' },
+                                    { src: '~commit', dest: 'main' },
+                                    { src: '~sd@123:a', dest: 'a' },
+                                    { src: '~sd@123:a', dest: 'c' }
+                                ]
+                            }
                         })
                     );
                     eventFactoryMock.get.withArgs({ id: 456 }).resolves(parentEventMock);
@@ -3197,7 +3213,7 @@ describe('build plugin test', () => {
                         pipelineId: 123,
                         scmContext: 'github:github.com',
                         sha: 'sha',
-                        startFrom: '~sd@123:a',
+                        startFrom: 'c',
                         type: 'pipeline',
                         username: 'foo'
                     };


### PR DESCRIPTION
## Context

When user has a pipeline like below, an extra event is getting triggered.
Pipeline 52:
<img width="415" alt="Screen Shot 2020-03-23 at 9 15 47 PM" src="https://user-images.githubusercontent.com/3230529/77387759-7d46fb00-6d4b-11ea-8e9c-0f3c5a87aa7c.png">
Pipeline 53:
<img width="264" alt="Screen Shot 2020-03-23 at 9 14 06 PM" src="https://user-images.githubusercontent.com/3230529/77387679-5092e380-6d4b-11ea-8220-e6b399a7cbf8.png">
Pipeline 54:
<img width="244" alt="Screen Shot 2020-03-23 at 9 14 01 PM" src="https://user-images.githubusercontent.com/3230529/77387707-5f799600-6d4b-11ea-9fba-e4d0728f59c1.png">


## Objective

This PR does a check to make sure the issue above does not happen by getting the workflowGraph and checking if the downstream external trigger has a join.

## References

Related #1710 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
