### PR TITLE
fix: Revert to older version of executor-queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "screwdriver-executor-docker": "^4.2.3",
     "screwdriver-executor-k8s": "^13.6.1",
     "screwdriver-executor-k8s-vm": "^3.2.2",
-    "screwdriver-executor-queue": "^2.9.2",
+    "screwdriver-executor-queue": "2.9.2",
     "screwdriver-executor-router": "^1.0.11",
     "screwdriver-logger": "^1.0.1",
     "screwdriver-models": "^27.43.3",


### PR DESCRIPTION
## Context

Revert executor-queue to older version 

## Objective

Revert executor-queue to older version

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
