### PR TITLE
feat(818): add runtimeclass config for kata

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -137,7 +137,7 @@ executor:
         preferredNodeSelectors:
           __name: K8S_PREFERRED_NODE_SELECTORS
           __format: json
-        # supoprt for kata-containers-as-a-runtimeclass
+        # support for kata-containers-as-a-runtimeclass
         runtimeClass: K8S_RUNTIME_CLASS
       # Launcher container tag to use
       launchVersion: LAUNCH_VERSION

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -137,6 +137,8 @@ executor:
         preferredNodeSelectors:
           __name: K8S_PREFERRED_NODE_SELECTORS
           __format: json
+        # supoprt for kata-containers-as-a-runtimeclass
+        runtimeClass: K8S_RUNTIME_CLASS
       # Launcher container tag to use
       launchVersion: LAUNCH_VERSION
       # Launcher image to use

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -103,6 +103,8 @@ executor:
         # k8s node selectors for approprate pod scheduling
         nodeSelectors: {}
         preferredNodeSelectors: {}
+        # supoprt for kata-containers-as-a-runtimeclass
+        runtimeClass: ""
     # Launcher image to use
     launchImage: screwdrivercd/launcher
     # Container tags to use

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -103,7 +103,7 @@ executor:
         # k8s node selectors for approprate pod scheduling
         nodeSelectors: {}
         preferredNodeSelectors: {}
-        # supoprt for kata-containers-as-a-runtimeclass
+        # support for kata-containers-as-a-runtimeclass
         runtimeClass: ""
     # Launcher image to use
     launchImage: screwdrivercd/launcher


### PR DESCRIPTION
## Context

Add runtime class config to support kata for kubernetes version v1.12.0 or above [kata-containers-as-a-runtimeclass](https://github.com/kata-containers/documentation/blob/master/how-to/containerd-kata.md#kata-containers-as-a-runtimeclass).

## References

[Evaluate Kata Containers over HyperD](https://github.com/screwdriver-cd/screwdriver/issues/818)
[executor-k8s PR#121](https://github.com/screwdriver-cd/executor-k8s/pull/121)


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.