### PR TITLE
fix: Add additional logic for getting jobId for trigger

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -1059,7 +1059,7 @@ async function handleDuplicatePipelines(config) {
                         parentEventId: event.id
                     });
                 } catch (err) {
-                    logger.info(
+                    logger.error(
                         `Could not create external build - pipeline:${pid} startFrom:~sd@${pipelineId}:${currentJobName} `,
                         err
                     );
@@ -1250,7 +1250,7 @@ exports.register = (server, options, next) => {
                     const nextNode = parentWorkflowGraph.nodes.find(
                         node => node.name === trimJobName(externalJobName) || node.name.includes(nextJobName)
                     );
-                    const jobId = nextNode.id;
+                    const jobId = nextNode ? nextNode.id : null;
                     // Get next build
                     const nextBuild = finishedExternalBuilds.find(b => b.jobId === jobId && b.status === 'CREATED');
                     // The next build has been restarted and this was the original run
@@ -1285,8 +1285,12 @@ exports.register = (server, options, next) => {
                                     }
                                     const targetBuild = finishedInternalBuilds.find(b => b.jobId === joinJobId);
 
-                                    parentBuilds[pid].jobs[jName] = targetBuild.id;
-                                    parentBuilds[pid].eventId = targetBuild.eventId;
+                                    if (targetBuild) {
+                                        parentBuilds[pid].jobs[jName] = targetBuild.id;
+                                        parentBuilds[pid].eventId = targetBuild.eventId;
+                                    } else {
+                                        logger.warn(`Job ${jName}:${pid} not found in finishedInternalBuilds`);
+                                    }
                                 }
                             });
                         });

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -323,13 +323,14 @@ async function createExternalBuild(config) {
 
 /**
  * Create internal build. If config.start is false or not passed in then do not start the job
+ * Need to pass in (jobName and pipelineId) or (jobId) to get job data
  * @method createInternalBuild
  * @param  {Object}   config                    Configuration object
  * @param  {Factory}  config.jobFactory         Job Factory
  * @param  {Factory}  config.buildFactory       Build Factory
  * @param  {Factory}  config.eventFactory       Event Factory
- * @param  {Number}   config.pipelineId         Pipeline Id
- * @param  {String}   config.jobName            Job name
+ * @param  {Number}   [config.pipelineId]       Pipeline Id
+ * @param  {String}   [config.jobName]          Job name
  * @param  {String}   config.username           Username of build
  * @param  {String}   config.scmContext         SCM context
  * @param  {Build}    config.build              Build object
@@ -339,6 +340,7 @@ async function createExternalBuild(config) {
  * @param  {Number}   [config.eventId]          Event ID for build
  * @param  {Boolean}  [config.start]            Whether to start the build or not
  * @param  {String}   [config.sha]              Build sha
+ * @param  {Number}   [config.jobId]            Job ID
  * @return {Promise}
  */
 async function createInternalBuild(config) {
@@ -356,14 +358,23 @@ async function createInternalBuild(config) {
         baseBranch,
         parentBuildId,
         eventId,
-        sha
+        sha,
+        jobId
     } = config;
     const event = await eventFactory.get(build.eventId);
-    const job = await jobFactory.get({
-        name: jobName,
-        pipelineId
-    });
     const prRef = event.pr.ref ? event.pr.ref : '';
+
+    let job = {};
+
+    if (!jobId) {
+        job = await jobFactory.get({
+            name: jobName,
+            pipelineId
+        });
+    } else {
+        job = await jobFactory.get(jobId);
+    }
+
     const internalBuildConfig = {
         jobId: job.id,
         sha: sha || build.sha,
@@ -830,7 +841,6 @@ async function createOrRunNextBuild({
             finishedInternalBuilds = finishedInternalBuilds.concat(parallelBuilds);
 
             Object.keys(parentBuilds).forEach(pid => {
-                parentBuilds[pid].eventId = event.id;
                 Object.keys(parentBuilds[pid].jobs).forEach(jName => {
                     let jobId;
 
@@ -849,6 +859,7 @@ async function createOrRunNextBuild({
 
                             if (parentJobBuild) {
                                 parentBuilds[pid].jobs[jName] = parentJobBuild.id;
+                                parentBuilds[pid].eventId = parentJobBuild.eventId;
                             } else {
                                 logger.warn(`Job ${jName}:${pid} not found in finishedInternalBuilds`);
                             }
@@ -1035,17 +1046,24 @@ async function handleDuplicatePipelines(config) {
                     delete joinObj[name];
                 });
 
-                // Start one event per duplicate pipelineId
-                await createExternalBuild({
-                    pipelineFactory,
-                    eventFactory,
-                    externalPipelineId: pid,
-                    startFrom: `~sd@${pipelineId}:${currentJobName}`,
-                    parentBuildId: build.id,
-                    parentBuilds,
-                    causeMessage: `Triggered by sd@${pipelineId}:${currentJobName}`,
-                    parentEventId: event.id
-                });
+                try {
+                    // Start one event per duplicate pipelineId
+                    await createExternalBuild({
+                        pipelineFactory,
+                        eventFactory,
+                        externalPipelineId: pid,
+                        startFrom: `~sd@${pipelineId}:${currentJobName}`,
+                        parentBuildId: build.id,
+                        parentBuilds,
+                        causeMessage: `Triggered by sd@${pipelineId}:${currentJobName}`,
+                        parentEventId: event.id
+                    });
+                } catch (err) {
+                    logger.info(
+                        `Could not create external build - pipeline:${pid} startFrom:~sd@${pipelineId}:${currentJobName} `,
+                        err
+                    );
+                }
             })
         );
     }
@@ -1229,7 +1247,10 @@ exports.register = (server, options, next) => {
                     const externalPipeline = await pipelineFactory.get(externalEvent.pipelineId);
                     const parentWorkflowGraph = externalEvent.workflowGraph;
                     const finishedExternalBuilds = await externalEvent.getBuilds();
-                    const jobId = parentWorkflowGraph.nodes.find(node => node.name === trimJobName(externalJobName)).id;
+                    const nextNode = parentWorkflowGraph.nodes.find(
+                        node => node.name === trimJobName(externalJobName) || node.name.includes(nextJobName)
+                    );
+                    const jobId = nextNode.id;
                     // Get next build
                     const nextBuild = finishedExternalBuilds.find(b => b.jobId === jobId && b.status === 'CREATED');
                     // The next build has been restarted and this was the original run
@@ -1250,7 +1271,6 @@ exports.register = (server, options, next) => {
                         finishedInternalBuilds = finishedInternalBuilds.concat(parallelBuilds);
 
                         Object.keys(parentBuilds).forEach(pid => {
-                            parentBuilds[pid].eventId = event.id;
                             Object.keys(parentBuilds[pid].jobs).forEach(jName => {
                                 let joinJobId;
 
@@ -1263,9 +1283,10 @@ exports.register = (server, options, next) => {
                                             node.name.includes(`sd@${pid}:${jName}`)
                                         ).id;
                                     }
-                                    parentBuilds[pid].jobs[jName] = finishedInternalBuilds.find(
-                                        b => b.jobId === joinJobId
-                                    ).id;
+                                    const targetBuild = finishedInternalBuilds.find(b => b.jobId === joinJobId);
+
+                                    parentBuilds[pid].jobs[jName] = targetBuild.id;
+                                    parentBuilds[pid].eventId = targetBuild.eventId;
                                 }
                             });
                         });
@@ -1310,6 +1331,7 @@ exports.register = (server, options, next) => {
                                 eventFactory,
                                 pipelineId: externalEvent.pipelineId,
                                 jobName: externalJobName,
+                                jobId,
                                 username,
                                 scmContext,
                                 build: parentBuild, // this is the parentBuild for the next build

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1954,8 +1954,8 @@ describe('build plugin test', () => {
                     pipelineId,
                     state: 'ENABLED'
                 };
-                const jobC = { ...jobB, id: 3 };
-                const jobD = {
+                const jobC = {
+                    ...jobB,
                     id: 3,
                     getLatestBuild: sinon.stub().resolves(
                         getBuildMock({
@@ -2047,7 +2047,8 @@ describe('build plugin test', () => {
                         })
                     );
                     eventFactoryMock.get.withArgs({ id: 456 }).resolves(parentEventMock);
-                    jobFactoryMock.get.withArgs(3).resolves(jobD);
+                    jobFactoryMock.get.withArgs(6).resolves(jobC);
+                    jobFactoryMock.get.withArgs(3).resolves(jobC);
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'b' }).resolves(jobB);
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'c' }).resolves(jobC);
                     jobMock.name = 'a';
@@ -2456,7 +2457,7 @@ describe('build plugin test', () => {
                         parentBuildId: 12345,
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345 } },
-                            2: { eventId: '8888', jobs: { a: 12345 } }
+                            2: { eventId: '8887', jobs: { a: 12345 } }
                         },
                         prRef: '',
                         scmContext: 'github:github.com',
@@ -3214,7 +3215,7 @@ describe('build plugin test', () => {
                         parentBuildId: 12345,
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345, c: 45678 } },
-                            2: { eventId: '8888', jobs: { a: 12345 } }
+                            2: { eventId: '8887', jobs: { a: 12345 } }
                         },
                         parentEventId: '8888',
                         pipelineId: 123,


### PR DESCRIPTION
## Context

Currently, we're seeing errors in our logs trying to get jobId info from the workflowGraph during triggerNextJobs function. This is because sometimes the node name saved in the graph is the full external trigger name, not just the shortened job name.

## Objective

This PR
- adds additional logic to get the jobId information when triggering the next job; this should fix an issue where external pipelines with circular workflows don't trigger the later build
- adds try/catch logic around handling triggering external jobs with matching pipelines
- gets eventId info from the build itself for parentBuilds rather than just using the current build's event info

### Example
With three pipelines: 2, 3, and 4, imagine an overall workflow that works like this:
2 -> 3 -> 4 -> 2

Before: The workflow would work like this 2 -> 3 -> 4. The "tag" job should be triggered by pipeline 4, but is never triggered. Below is a screenshot of pipeline 2.
<img width="252" alt="Screen Shot 2020-04-23 at 8 00 04 PM" src="https://user-images.githubusercontent.com/3230529/80170612-355f0200-859d-11ea-80d7-96081af59934.png">
After: The workflow goes like this 2 -> 3 -> 4 -> 2. The "tag" job is correctly triggered by pipeline 4. Below is a screenshot of pipeline 2.
<img width="261" alt="Screen Shot 2020-04-23 at 8 00 13 PM" src="https://user-images.githubusercontent.com/3230529/80170619-3728c580-859d-11ea-88e7-1754ba7ffca2.png">



## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
