### PR TITLE
fix: [2] Tag/Release trigger does not depend on changedFile

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -258,7 +258,10 @@ async function triggeredPipelines(pipelineFactory, scmConfig, branch, type, acti
         }
     });
 
-    pipelinesOnCommitBranch = pipelinesOnCommitBranch.filter(p => hasChangesUnderRootDir(p, changedFiles));
+    // Build runs regardless of changedFiles when release/tag trigger
+    pipelinesOnCommitBranch = pipelinesOnCommitBranch.filter(
+        p => ['release', 'tag'].includes(action) || hasChangesUnderRootDir(p, changedFiles)
+    );
 
     pipelinesOnOtherBranch = pipelinesOnOtherBranch.filter(p =>
         hasTriggeredJob(p, determineStartFrom(action, type, branch, null))


### PR DESCRIPTION
## Context
Currently, even if we create a tag, it does not start to build unless it matches changedFiles. Tag/Release triggers need to start built without depending on the changedFiles.

## Objective
Fixed to start build regardless of changedFile for tag/release triggers.

## References
https://github.com/screwdriver-cd/models/pull/454
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
