### PR TITLE
fix(2094): [2] workaround for NULL value in `pipeline.annotations`

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -330,7 +330,8 @@ async function createPREvents(options, request) {
                 }
             }
             const { skipMessage, resolvedChainPR } = getSkipMessageAndChainPR({
-                pipeline: p,
+                // Workaround for pipelines which has NULL value in `pipeline.annotations`
+                pipeline: !p.annotations ? { annotations: {}, ...p } : p,
                 prSource,
                 restrictPR,
                 chainPR


### PR DESCRIPTION
## Context
Before this PR, screwdriver.cd makes incomplete pipelines for the repository which has no `screwdriver.yaml` because `pipeline.sync` failed when no `screwdriver.yaml` is found and `pipeline.annotation` in DB become `NULL` value.
Therefore this PR makes it possible to handle the `NULL` value in `pipelines.annotations` and create PR events that add `screwdriver.yaml` at first time.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Assign empty objects to `pipelines.annotations` when it is undefined.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
#2094 
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
