### PR TITLE
fix(1922): nil token

### DIFF
--- a/plugins/pipelines/openPr.js
+++ b/plugins/pipelines/openPr.js
@@ -40,30 +40,33 @@ module.exports = () => ({
 
                     return user
                         .unsealToken()
-                        .then(token =>
-                            userFactory.scm.parseUrl({
-                                scmContext,
-                                rootDir,
-                                checkoutUrl,
-                                token
-                            })
-                        )
-                        .then(scmUri => user.getPermissions(scmUri))
-                        .then(permissions => {
-                            if (!permissions.push) {
-                                throw boom.forbidden(`User ${username} does not have push access for this repo`);
-                            }
+                        .then(token => {
+                            return userFactory.scm
+                                .parseUrl({
+                                    scmContext,
+                                    rootDir,
+                                    checkoutUrl,
+                                    token
+                                })
+                                .then(scmUri => user.getPermissions(scmUri))
+                                .then(permissions => {
+                                    if (!permissions.push) {
+                                        throw boom.forbidden(
+                                            `User ${username} does not have push access for this repo`
+                                        );
+                                    }
+                                })
+                                .then(() =>
+                                    userFactory.scm.openPr({
+                                        checkoutUrl,
+                                        files,
+                                        token,
+                                        scmContext,
+                                        title,
+                                        message
+                                    })
+                                );
                         })
-                        .then(token =>
-                            userFactory.scm.openPr({
-                                checkoutUrl,
-                                files,
-                                token,
-                                scmContext,
-                                title,
-                                message
-                            })
-                        )
                         .then(pullRequest => {
                             if (!pullRequest) {
                                 throw boom.notImplemented('openPr not implemented for gitlab');


### PR DESCRIPTION
## Context

currently openPr returns 500 because it passed null token to scm-base
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

pass real token instead
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/issues/1922
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
