### PR TITLE
fix: openPR return object instead of plain string

### DIFF
--- a/plugins/pipelines/openPr.js
+++ b/plugins/pipelines/openPr.js
@@ -72,7 +72,7 @@ module.exports = () => ({
                                 throw boom.notImplemented('openPr not implemented for gitlab');
                             }
 
-                            return reply(pullRequest.data.url).code(201);
+                            return reply({ prUrl: pullRequest.data.url }).code(201);
                         });
                 })
                 .catch(err => reply(boom.boomify(err)));

--- a/plugins/pipelines/openPr.js
+++ b/plugins/pipelines/openPr.js
@@ -72,7 +72,7 @@ module.exports = () => ({
                                 throw boom.notImplemented('openPr not implemented for gitlab');
                             }
 
-                            return reply({ prUrl: pullRequest.data.url }).code(201);
+                            return reply({ prUrl: pullRequest.data.html_url }).code(201);
                         });
                 })
                 .catch(err => reply(boom.boomify(err)));

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2840,11 +2840,13 @@ describe('pipeline plugin test', () => {
         it('returns 201 and correct pipeline data', () =>
             server.inject(options).then(reply => {
                 const { prUrl } = reply.result;
+
                 assert.equal(prUrl, pullRequest.data.url);
                 assert.equal(reply.statusCode, 201);
             }));
 
-        it('formats the checkout url correctly', () => {https://github.com/screwdriver-cd/screwdriver/blob/b97c9123868a0f8c6985de43320d1efd7c2cd818/plugins/pipelines/latestBuild.js
+        it('formats the checkout url correctly', () => {
+            // github.com/screwdriver-cd/screwdriver/blob/b97c9123868a0f8c6985de43320d1efd7c2cd818/plugins/pipelines/latestBuild.js
             userMock.getPermissions.withArgs(scmUri).resolves({ push: false });
 
             return server.inject(options).then(() => {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2839,11 +2839,12 @@ describe('pipeline plugin test', () => {
 
         it('returns 201 and correct pipeline data', () =>
             server.inject(options).then(reply => {
-                assert.equal(reply.result, pullRequest.data.url);
+                const { prUrl } = reply.result;
+                assert.equal(prUrl, pullRequest.data.url);
                 assert.equal(reply.statusCode, 201);
             }));
 
-        it('formats the checkout url correctly', () => {
+        it('formats the checkout url correctly', () => {https://github.com/screwdriver-cd/screwdriver/blob/b97c9123868a0f8c6985de43320d1efd7c2cd818/plugins/pipelines/latestBuild.js
             userMock.getPermissions.withArgs(scmUri).resolves({ push: false });
 
             return server.inject(options).then(() => {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2846,7 +2846,6 @@ describe('pipeline plugin test', () => {
             }));
 
         it('formats the checkout url correctly', () => {
-            // github.com/screwdriver-cd/screwdriver/blob/b97c9123868a0f8c6985de43320d1efd7c2cd818/plugins/pipelines/latestBuild.js
             userMock.getPermissions.withArgs(scmUri).resolves({ push: false });
 
             return server.inject(options).then(() => {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2809,7 +2809,7 @@ describe('pipeline plugin test', () => {
         let userMock;
         const pullRequest = {
             data: {
-                url: 'pullRequestUrl'
+                html_url: 'pullRequestUrl'
             }
         };
 
@@ -2841,7 +2841,7 @@ describe('pipeline plugin test', () => {
             server.inject(options).then(reply => {
                 const { prUrl } = reply.result;
 
-                assert.equal(prUrl, pullRequest.data.url);
+                assert.equal(prUrl, pullRequest.data.html_url);
                 assert.equal(reply.statusCode, 201);
             }));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

UI expects return value to be a String that can be parsed via `JSON.parse`, if it is plain String like `thisisaStingValue`, then it will throw errors.

## Objective
Change return value from `String` to `Object`, so can be parsed by `JSON.parse`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
