### PR TITLE
fix: get cluster names from list

### DIFF
--- a/plugins/pipelines/caches/request.js
+++ b/plugins/pipelines/caches/request.js
@@ -42,7 +42,14 @@ async function invoke(request) {
     };
 
     if (cache.strategy === 'disk') {
-        const buildClusters = await request.server.app.buildClusterFactory.list();
+        const clusters = await request.server.app.buildClusterFactory.list();
+
+        if (!clusters || clusters.length === 0) {
+            logger.warn('No buildclusters found');
+        }
+        const buildClusters = clusters.map(cluster => cluster.name);
+
+        logger.info(`Processing invalidation request with buildClusters: ${buildClusters}`);
 
         Object.assign(options, {
             method: 'POST',

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -257,7 +257,7 @@ describe('DELETE /pipelines/1234/caches', () => {
             };
         });
         it('successfully push cache delete message to queue', () => {
-            buildClusterFactoryMock.list.resolves(['q1', 'q2']);
+            buildClusterFactoryMock.list.resolves([{ name: 'q1' }, { name: 'q2' }]);
             mockRequestRetry.yieldsAsync(null, { statusCode: 200 });
 
             return server.inject(options).then(reply => {
@@ -267,6 +267,7 @@ describe('DELETE /pipelines/1234/caches', () => {
         });
 
         it('returns err when push message fails', () => {
+            buildClusterFactoryMock.list.resolves([{ name: 'q1' }, { name: 'q2' }]);
             mockRequestRetry.yieldsAsync(null, { statusCode: 500 });
 
             return server.inject(options).then(reply => {


### PR DESCRIPTION
## Context

BuildCluster names are needed to push to rabbit queues

## Objective

This PR fixes an issue with fetching the cluster names

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
