### PR TITLE
fix: Add build scope to listBuilds endpoint

### DIFF
--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -18,7 +18,7 @@ module.exports = () => ({
         tags: ['api', 'jobs', 'builds'],
         auth: {
             strategies: ['token'],
-            scope: ['user', 'pipeline']
+            scope: ['user', 'pipeline', 'build']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
## Context

Some users might want to list builds using a build token.

## Objective

This PR adds build scope to listBuilds endpoint.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
