### PR TITLE
fix: add null check to trigger next build

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -1289,24 +1289,28 @@ exports.register = (server, options, next) => {
 
                         Object.keys(parentBuilds).forEach(pid => {
                             Object.keys(parentBuilds[pid].jobs).forEach(jName => {
-                                let joinJobId;
+                                let joinJob;
 
                                 if (parentBuilds[pid].jobs[jName] === null) {
                                     if (parseInt(pid, 10) === pipelineId) {
-                                        joinJobId = workflowGraph.nodes.find(node => node.name === trimJobName(jName))
-                                            .id;
+                                        joinJob = workflowGraph.nodes.find(node => node.name === trimJobName(jName));
                                     } else {
-                                        joinJobId = workflowGraph.nodes.find(node =>
+                                        joinJob = workflowGraph.nodes.find(node =>
                                             node.name.includes(`sd@${pid}:${jName}`)
-                                        ).id;
+                                        );
                                     }
-                                    const targetBuild = finishedInternalBuilds.find(b => b.jobId === joinJobId);
 
-                                    if (targetBuild) {
-                                        parentBuilds[pid].jobs[jName] = targetBuild.id;
-                                        parentBuilds[pid].eventId = targetBuild.eventId;
+                                    if (!joinJob) {
+                                        logger.warn(`Job ${jName}:${pid} not found in workflowGraph`);
                                     } else {
-                                        logger.warn(`Job ${jName}:${pid} not found in finishedInternalBuilds`);
+                                        const targetBuild = finishedInternalBuilds.find(b => b.jobId === joinJob.id);
+
+                                        if (targetBuild) {
+                                            parentBuilds[pid].jobs[jName] = targetBuild.id;
+                                            parentBuilds[pid].eventId = targetBuild.eventId;
+                                        } else {
+                                            logger.warn(`Job ${jName}:${pid} not found in finishedInternalBuilds`);
+                                        }
                                     }
                                 }
                             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
triggerNextBuild function could throw error because job was not found in workflowgraph

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add null check and logging for further investigation

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
