### PR TITLE
feat(2152): Add enterprise config for SonarQube

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -353,8 +353,10 @@ coverage:
     sonarHost: COVERAGE_SONAR_HOST
     # Sonar admin token
     adminToken: COVERAGE_SONAR_ADMIN_TOKEN
-    # crewdriver UI url
+    # Screwdriver UI url
     sdUiUrl: ECOSYSTEM_UI
+    # Enterprise edition (true) or open source edition (false)
+    sonarEnterprise: COVERAGE_SONAR_ENTERPRISE
 
 multiBuildCluster:
   # Enabled multi build cluster feature or not

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -246,6 +246,7 @@ coverage:
   #   sonarHost: https://sonar.screwdriver.cd
   #   adminToken: your-sonar-admin-token
   #   sdUiUrl: https://cd.screwdriver.cd
+  #   sonarEnterprise: false
 
 multiBuildCluster:
   # Enabled multi build cluster feature or not


### PR DESCRIPTION
## Context

Need a feature flag to support enterprise edition of SonarQube as well as open source edition.

## Objective

This PR adds a feature flag `sonarEnterprise`.

## References

Related to #2152 

## License

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
