### PR TITLE
fix(2115): add metrics plugins

### DIFF
--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -20,7 +20,9 @@ function registerDefaultPlugins(server, callback) {
         '../plugins/swagger',
         '../plugins/validator',
         '../plugins/template-validator',
-        '../plugins/command-validator'
+        '../plugins/command-validator',
+        '../plugins/promster',
+        '../plugins/metrics'
     ].map(plugin => require(plugin));
 
     async.eachSeries(

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "dependencies": {
+    "@promster/hapi": "^4.1.11",
     "async": "^2.6.3",
     "bell": "^8.0.0",
     "boom": "^7.3.0",
@@ -87,6 +88,7 @@
     "license-checker": "^17.0.0",
     "ndjson": "^1.4.3",
     "node-env-file": "^0.1.8",
+    "prom-client": "^12.0.0",
     "request": "^2.88.2",
     "requestretry": "^1.12.0",
     "screwdriver-artifact-bookend": "^1.1.25",

--- a/plugins/metrics.js
+++ b/plugins/metrics.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { getSummary } = require('@promster/hapi');
+
+/**
+ * Hapi interface for plugin to set up metrics endpoint
+ * @method register
+ * @param  {Hapi.Server}    server
+ * @param  {Object}         options
+ * @param  {Function} next
+ */
+exports.register = (server, options, next) => {
+    // Add the status route
+    server.route({
+        method: 'GET',
+        path: '/metrics',
+        handler: (request, reply) => reply(getSummary()),
+        config: {
+            description: 'application metrics',
+            notes: 'Expose application metrics',
+            tags: ['api']
+        }
+    });
+    next();
+};
+
+exports.register.attributes = {
+    name: 'application metrics',
+    version: '1.0.0'
+};

--- a/plugins/promster.js
+++ b/plugins/promster.js
@@ -10,6 +10,6 @@ const { createPlugin } = require('@promster/hapi');
  * @param  {Function} next
  */
 module.exports = {
-    register: createPlugin({}),
+    register: createPlugin({ options: { metricPrefix: 'sd_' } }),
     options: {}
 };

--- a/plugins/promster.js
+++ b/plugins/promster.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { createPlugin } = require('@promster/hapi');
+
+/**
+ * Hapi interface for plugin to collect the metrics in the hapi-server
+ * @method register
+ * @param  {Hapi.Server}    server
+ * @param  {Object}         options
+ * @param  {Function} next
+ */
+module.exports = {
+    register: createPlugin({}),
+    options: {}
+};

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -16,7 +16,9 @@ describe('Register Unit Test Case', () => {
         '../plugins/swagger',
         '../plugins/validator',
         '../plugins/template-validator',
-        '../plugins/command-validator'
+        '../plugins/command-validator',
+        '../plugins/promster',
+        '../plugins/metrics'
     ];
     const resourcePlugins = [
         '../plugins/auth',


### PR DESCRIPTION
## Context
Screwdriver.cd has no application metrics, except build metrics, and cluster admins are hard to find what problems is happend on the application, for example, 500 error is happend or performances are degraded.

## Objective
To detect these problems, This PR adds the [promster](https://github.com/tdeekens/promster) plugins to collect the metrics about nodejs and http.
- `plugins/promster.js` to collect http and nodejs metrics
- `plugins/metrics.js` to expose the collected metrics

It can collect the metrics like following
![image](https://user-images.githubusercontent.com/5774825/87750506-9d3c8600-c836-11ea-967d-333c64d6c8ab.png)

Please refer the documents for more details
https://github.com/tdeekens/promster#-documentation

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2115
https://github.com/tdeekens/promster

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
