### PR TITLE
feat(1079): integrate deploy keys features with auth and pipeline routes [5]

### DIFF
--- a/plugins/auth/contexts.js
+++ b/plugins/auth/contexts.js
@@ -17,15 +17,15 @@ module.exports = config => ({
         notes: 'Get all auth contexts',
         tags: ['api', 'auth', 'context'],
         handler: (request, reply) => {
-            const { pipelineFactory, userFactory } = request.server.app;
-            const scmContexts = userFactory.scm.getScmContexts();
+            const { scm } = request.server.app.userFactory;
+            const scmContexts = scm.getScmContexts();
             const contexts = [];
 
             scmContexts.forEach(scmContext => {
                 const context = {
                     context: scmContext,
-                    displayName: userFactory.scm.getDisplayName({ scmContext }),
-                    autoDeployKeyGeneration: pipelineFactory.scm.autoDeployKeyGenerationEnabled({
+                    displayName: scm.getDisplayName({ scmContext }),
+                    autoDeployKeyGeneration: scm.autoDeployKeyGenerationEnabled({
                         scmContext
                     })
                 };

--- a/plugins/auth/contexts.js
+++ b/plugins/auth/contexts.js
@@ -24,7 +24,7 @@ module.exports = config => ({
             const promises = [];
 
             scmContexts.forEach(scmContext => {
-                const promise = pipelineFactory.scm.checkAutoDeployKeyGeneration({
+                const promise = pipelineFactory.scm.autoDeployKeyGenerationEnabled({
                     scmContext
                 });
 

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -155,6 +155,8 @@ module.exports = () => ({
                                                                 });
                                                         });
                                                 }
+
+                                                return null;
                                             })
                                             .then(() => {
                                                 // TODO: decide to put this outside or inside

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -25,10 +25,8 @@ module.exports = () => ({
             const checkoutUrl = helper.formatCheckoutUrl(request.payload.checkoutUrl);
             const rootDir = helper.sanitizeRootDir(request.payload.rootDir);
             const { autoKeysGeneration } = request.payload;
-            const { secretFactory } = request.server.app;
-            const { pipelineFactory, userFactory, collectionFactory } = request.server.app;
-            const { username } = request.auth.credentials;
-            const { scmContext } = request.auth.credentials;
+            const { pipelineFactory, userFactory, collectionFactory, secretFactory } = request.server.app;
+            const { username, scmContext } = request.auth.credentials;
             let pipelineToken = '';
             const depKeySecret = 'SD_SCM_DEPLOY_KEY';
 

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -139,8 +139,7 @@ module.exports = () => ({
                                                                 value: privateDeployKeyB64,
                                                                 allowInPR: false
                                                             });
-                                                        })
-                                                        .catch(err => reply(boom.boomify(err)));
+                                                        });
                                                 }
 
                                                 return null;

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -87,7 +87,7 @@ module.exports = () => ({
                                     })
                                     // get the default collection for current user
                                     .then(pipeline => {
-                                        collectionFactory
+                                        return collectionFactory
                                             .list({
                                                 params: {
                                                     userId: user.id,
@@ -123,14 +123,14 @@ module.exports = () => ({
                                             })
                                             .then(() => {
                                                 if (autoKeysGeneration) {
-                                                    pipelineFactory.scm
+                                                    return pipelineFactory.scm
                                                         .addDeployKey({
                                                             scmContext,
                                                             checkoutUrl,
                                                             token: pipelineToken
                                                         })
                                                         .then(privateDepKey => {
-                                                            secretFactory
+                                                            return secretFactory
                                                                 .get({
                                                                     pipelineId: pipeline.id,
                                                                     name: depKeySecret

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -129,12 +129,6 @@ module.exports = () => ({
                                                             token: pipelineToken
                                                         })
                                                         .then(privateDeployKey => {
-                                                            if (!privateDeployKey) {
-                                                                throw boom.notImplemented(
-                                                                    'addDeployKey not implemented for gitlab and bitbucket'
-                                                                );
-                                                            }
-
                                                             const privateDeployKeyB64 = Buffer.from(
                                                                 privateDeployKey
                                                             ).toString('base64');
@@ -145,7 +139,8 @@ module.exports = () => ({
                                                                 value: privateDeployKeyB64,
                                                                 allowInPR: false
                                                             });
-                                                        });
+                                                        })
+                                                        .catch(err => reply(boom.boomify(err)));
                                                 }
 
                                                 return null;

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -82,7 +82,8 @@ describe('auth plugin test', () => {
                     provider: 'github',
                     scope: ['admin:repo_hook', 'read:org', 'repo:status']
                 }
-            })
+            }),
+            checkAutoDeployKeyGeneration: sinon.stub().resolves(true)
         };
         userFactoryMock = {
             get: sinon.stub(),
@@ -1049,6 +1050,7 @@ describe('auth plugin test', () => {
             scm.getScmContexts.returns(['github:github.com', 'github:mygithub.com']);
             scm.getDisplayName.withArgs({ scmContext: 'github:github.com' }).returns('github');
             scm.getDisplayName.withArgs({ scmContext: 'github:mygithub.com' }).returns('mygithub');
+            scm.checkAutoDeployKeyGeneration.resolves(true);
         });
 
         it('lists the contexts', () =>
@@ -1058,13 +1060,14 @@ describe('auth plugin test', () => {
                     url: '/auth/contexts'
                 })
                 .then(reply => {
+                    console.log(reply.result[0]);
                     assert.equal(reply.statusCode, 200, 'Contexts should be available');
                     assert.deepEqual(
                         reply.result,
                         [
-                            { context: 'github:github.com', displayName: 'github' },
-                            { context: 'github:mygithub.com', displayName: 'mygithub' },
-                            { context: 'guest', displayName: 'Guest Access' }
+                            { context: 'github:github.com', displayName: 'github', autoDeployKeyGeneration: true },
+                            { context: 'github:mygithub.com', displayName: 'mygithub', autoDeployKeyGeneration: true },
+                            { context: 'guest', displayName: 'Guest Access', autoDeployKeyGeneration: false }
                         ],
                         'Contexts returns data'
                     );
@@ -1074,6 +1077,8 @@ describe('auth plugin test', () => {
             scm.getScmContexts.returns(['github:github.com']);
             server = new hapi.Server();
             server.app.userFactory = userFactoryMock;
+            server.app.pipelineFactory = pipelineFactoryMock;
+            scm.checkAutoDeployKeyGeneration.resolves(true);
 
             server.connection({
                 port: 1234
@@ -1101,10 +1106,17 @@ describe('auth plugin test', () => {
                             url: '/auth/contexts'
                         })
                         .then(reply => {
+                            console.log(reply.result[0]);
                             assert.equal(reply.statusCode, 200, 'Contexts should be available');
                             assert.deepEqual(
                                 reply.result,
-                                [{ context: 'github:github.com', displayName: 'github' }],
+                                [
+                                    {
+                                        context: 'github:github.com',
+                                        displayName: 'github',
+                                        autoDeployKeyGeneration: true
+                                    }
+                                ],
                                 'Contexts returns data'
                             );
                         })

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -83,7 +83,7 @@ describe('auth plugin test', () => {
                     scope: ['admin:repo_hook', 'read:org', 'repo:status']
                 }
             }),
-            autoDeployKeyGenerationEnabled: sinon.stub().resolves(true)
+            autoDeployKeyGenerationEnabled: sinon.stub().returns(true)
         };
         userFactoryMock = {
             get: sinon.stub(),
@@ -1050,7 +1050,7 @@ describe('auth plugin test', () => {
             scm.getScmContexts.returns(['github:github.com', 'github:mygithub.com']);
             scm.getDisplayName.withArgs({ scmContext: 'github:github.com' }).returns('github');
             scm.getDisplayName.withArgs({ scmContext: 'github:mygithub.com' }).returns('mygithub');
-            scm.autoDeployKeyGenerationEnabled.resolves(true);
+            scm.autoDeployKeyGenerationEnabled.withArgs({ scmContext: 'github:mygithub.com' }).returns(true);
         });
 
         it('lists the contexts', () =>
@@ -1078,7 +1078,7 @@ describe('auth plugin test', () => {
             server = new hapi.Server();
             server.app.userFactory = userFactoryMock;
             server.app.pipelineFactory = pipelineFactoryMock;
-            scm.autoDeployKeyGenerationEnabled.resolves(true);
+            scm.autoDeployKeyGenerationEnabled.withArgs({ scmContext: 'github:mygithub.com' }).returns(true);
 
             server.connection({
                 port: 1234

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -1060,7 +1060,6 @@ describe('auth plugin test', () => {
                     url: '/auth/contexts'
                 })
                 .then(reply => {
-                    console.log(reply.result[0]);
                     assert.equal(reply.statusCode, 200, 'Contexts should be available');
                     assert.deepEqual(
                         reply.result,

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -83,7 +83,7 @@ describe('auth plugin test', () => {
                     scope: ['admin:repo_hook', 'read:org', 'repo:status']
                 }
             }),
-            checkAutoDeployKeyGeneration: sinon.stub().resolves(true)
+            autoDeployKeyGenerationEnabled: sinon.stub().resolves(true)
         };
         userFactoryMock = {
             get: sinon.stub(),
@@ -1050,7 +1050,7 @@ describe('auth plugin test', () => {
             scm.getScmContexts.returns(['github:github.com', 'github:mygithub.com']);
             scm.getDisplayName.withArgs({ scmContext: 'github:github.com' }).returns('github');
             scm.getDisplayName.withArgs({ scmContext: 'github:mygithub.com' }).returns('mygithub');
-            scm.checkAutoDeployKeyGeneration.resolves(true);
+            scm.autoDeployKeyGenerationEnabled.resolves(true);
         });
 
         it('lists the contexts', () =>
@@ -1078,7 +1078,7 @@ describe('auth plugin test', () => {
             server = new hapi.Server();
             server.app.userFactory = userFactoryMock;
             server.app.pipelineFactory = pipelineFactoryMock;
-            scm.checkAutoDeployKeyGeneration.resolves(true);
+            scm.autoDeployKeyGenerationEnabled.resolves(true);
 
             server.connection({
                 port: 1234

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1436,7 +1436,7 @@ describe('pipeline plugin test', () => {
             pipelineFactoryMock.scm.parseUrl.resolves(scmUri);
             pipelineFactoryMock.scm.addDeployKey.resolves(privateKey);
 
-            secretFactoryMock.get.withArgs({ pipelineId: 123, name: 'DEPLOY_KEY' }).resolves(null);
+            secretFactoryMock.get.withArgs({ pipelineId: 123, name: 'SD_SCM_DEPLOY_KEY' }).resolves(null);
         });
 
         it('returns 201 and correct pipeline data', () => {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1465,10 +1465,10 @@ describe('pipeline plugin test', () => {
                         type: 'default'
                     }
                 });
-                assert.calledWith(secretFactoryMock.get, { pipelineId: 123, name: 'DEPLOY_KEY' });
+                assert.calledWith(secretFactoryMock.get, { pipelineId: 123, name: 'SD_SCM_DEPLOY_KEY' });
                 assert.calledWith(secretFactoryMock.create, {
                     pipelineId: 123,
-                    name: 'DEPLOY_KEY',
+                    name: 'SD_SCM_DEPLOY_KEY',
                     value: privateKeyB64,
                     allowInPR: false
                 });

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1465,7 +1465,6 @@ describe('pipeline plugin test', () => {
                         type: 'default'
                     }
                 });
-                assert.calledWith(secretFactoryMock.get, { pipelineId: 123, name: 'SD_SCM_DEPLOY_KEY' });
                 assert.calledWith(secretFactoryMock.create, {
                     pipelineId: 123,
                     name: 'SD_SCM_DEPLOY_KEY',

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -137,16 +137,6 @@ const getSecretsMocks = secrets => {
     return decorateJobMock(secrets);
 };
 
-// const getSecretMock = secret => {
-//     const mock = hoek.clone(secret);
-
-//     mock.toJson = sinon.stub().returns(secret);
-//     mock.remove = sinon.stub();
-//     mock.update = sinon.stub();
-
-//     return mock;
-// };
-
 const getUserMock = user => {
     const mock = hoek.clone(user);
 


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1079

## Objective

This PR adds functionality of handling of autoKeysGeneration visibility in the UI and its response to trigger it in the scm-github module. 

## References

screwdriver-cd/screwdriver#1079

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
