### PR TITLE
feat(2152): Support coverage scope param [3]

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "screwdriver-command-validator": "^1.1.0",
     "screwdriver-config-parser": "^5.3.3",
     "screwdriver-coverage-bookend": "^1.0.3",
-    "screwdriver-coverage-sonar": "^1.0.29",
+    "screwdriver-coverage-sonar": "^2.0.0",
     "screwdriver-data-schema": "^19.10.0",
     "screwdriver-datastore-sequelize": "^6.0.0",
     "screwdriver-executor-base": "^7.5.0",

--- a/plugins/coverage/README.md
+++ b/plugins/coverage/README.md
@@ -27,11 +27,11 @@ server.register({
 ### Routes
 
 #### Returns an access token to talk to coverage server
-`GET /coverage/token`
+`GET /coverage/token?scope=job`
 
 #### Get an object with coverage info
 
-`GET /coverage/info?buildId=1&jobId=123&startTime=2017-10-19T13%3A00%3A00%2B0200&endTime=2017-10-19T15%3A00%3A00%2B0200`
+`GET /coverage/info?pipelineId=1&jobId=123&startTime=2017-10-19T13%3A00%3A00%2B0200&endTime=2017-10-19T15%3A00%3A00%2B0200&jobName=main&pipelineName=d2lam%2Fmytest&scope=pipeline`
 
 Should resolve with something like
 ```javascript

--- a/plugins/coverage/info.js
+++ b/plugins/coverage/info.js
@@ -19,35 +19,46 @@ module.exports = config => ({
             }
         },
         handler: (request, reply) => {
-            const { jobId, pipelineId, startTime, endTime, jobName, pipelineName, scope } = request.query;
+            const { jobId, pipelineId, startTime, endTime, jobName, pipelineName, scope, projectKey } = request.query;
             const { jobFactory } = request.server.app;
             const infoConfig = { jobId, pipelineId, startTime, endTime, jobName, pipelineName };
 
-            return Promise.resolve()
-                .then(() => {
-                    if (scope) {
-                        return { 'screwdriver.cd/coverageScope': request.query.scope };
-                    }
-                    if (!scope && jobId) {
-                        return jobFactory.get(jobId).then(job => {
-                            if (!job) {
-                                throw boom.notFound('Job does not exist');
-                            }
+            // Short circuit to get coverage info
+            if (projectKey && startTime && endTime) {
+                return config.coveragePlugin
+                    .getInfo({ startTime, endTime, coverageProjectKey: projectKey })
+                    .then(reply)
+                    .catch(err => reply(boom.boomify(err)));
+            }
 
-                            return job.permutations[0].annotations;
-                        });
-                    }
+            return (
+                Promise.resolve()
+                    // Get scope
+                    .then(() => {
+                        if (scope) {
+                            return { 'screwdriver.cd/coverageScope': request.query.scope };
+                        }
+                        if (!scope && jobId) {
+                            return jobFactory.get(jobId).then(job => {
+                                if (!job) {
+                                    throw boom.notFound('Job does not exist');
+                                }
 
-                    return {};
-                })
-                .then(annotations => {
-                    infoConfig.annotations = annotations;
+                                return job.permutations[0].annotations;
+                            });
+                        }
 
-                    return config.coveragePlugin
-                        .getInfo(infoConfig)
-                        .then(reply)
-                        .catch(err => reply(boom.boomify(err)));
-                });
+                        return {};
+                    })
+                    .then(annotations => {
+                        infoConfig.annotations = annotations;
+
+                        return config.coveragePlugin
+                            .getInfo(infoConfig)
+                            .then(reply)
+                            .catch(err => reply(boom.boomify(err)));
+                    })
+            );
         }
     }
 });

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -249,6 +249,30 @@ describe('coverage plugin test', () => {
             });
         });
 
+        it('returns 200 when projectKey is passed in', () => {
+            coveragePlugin.getInfo.resolves(result);
+            options.url = `/coverage/info?startTime=${startTime}&endTime=${endTime}&projectKey=pipeline:${pipelineId}`;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, result);
+                assert.calledWith(coveragePlugin.getInfo, {
+                    startTime: args.startTime,
+                    endTime: args.endTime,
+                    coverageProjectKey: `pipeline:${pipelineId}`
+                });
+            });
+        });
+
+        it('returns 500 if failed to get info', () => {
+            coveragePlugin.getInfo.rejects(new Error('oops!'));
+            options.url = `/coverage/info?startTime=${startTime}&endTime=${endTime}&projectKey=pipeline:${pipelineId}`;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+
         it('returns 200 when scope is passed in', () => {
             coveragePlugin.getInfo.resolves(result);
             // eslint-disable-next-line


### PR DESCRIPTION
## Context

It would be nice if users could configure projectKey/name scope based on an annotation. 

## Objective

This PR fetches job annotations in the API so it can easily be passed to the coverage sonar plugin. Alternatively, if `scope` query param is passed in, the API will skip fetching.

## References

Related to #2152 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
