### PR TITLE
fix(2148): Add configPipelineSha when create childpipeline event

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -270,6 +270,20 @@ async function createEvent(config) {
 
     payload.sha = sha;
 
+    // Set configPipelineSha for child pipeline
+    if (pipeline.configPipelineId) {
+        const configPipeline = await pipelineFactory.get(pipeline.configPipelineId);
+        const configAdmin = await configPipeline.admin;
+        const configToken = await configAdmin.unsealToken();
+        const configScmConfig = {
+            scmContext: configPipeline.scmContext,
+            scmUri: configPipeline.scmUri,
+            token: configToken
+        };
+
+        payload.configPipelineSha = await scm.getCommitSha(configScmConfig);
+    }
+
     return eventFactory.create(payload);
 }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When creating externalBuild in childpipeline,  `configPipelineSha` is not set in the event.
However, `configPipelineSha` is needed to create child pipeline's event.
https://github.com/screwdriver-cd/models/blob/4f0d1f9b54927222f47840ae8ede18d815c4b66b/lib/eventFactory.js#L614-L626

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add configPipelineSha when creating childpipeline event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
screwdriver-cd/screwdriver#2148

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
