### PR TITLE
fix: support only beta jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 docker-compose.yml
 mw-data
 .vscode
+.envrc

--- a/features/step_definitions/trigger.js
+++ b/features/step_definitions/trigger.js
@@ -2,6 +2,7 @@
 
 const Assert = require('chai').assert;
 const { Before, Given, When, Then } = require('cucumber');
+const github = require('../support/github');
 const sdapi = require('../support/sdapi');
 const request = require('../support/request');
 
@@ -14,8 +15,6 @@ Before(
     function hook() {
         this.repoOrg = this.testOrg;
         this.repoName = 'functional-trigger';
-        this.pipelineIdA = null;
-        this.pipelineIdB = null;
         this.success_AJobId = null;
         this.fail_AJobId = null;
         this.success_BJobId = null;
@@ -23,139 +22,217 @@ Before(
         this.parallel_AJobId = null;
         this.parallel_B1JobId = null;
         this.parallel_B2JobId = null;
-        this.builds = null;
+        this.buildId = null;
+        this.pipelines = {};
     }
 );
 
 Given(
-    /^an existing pipeline on branch "(.*)" with the workflow jobs:$/,
+    /^an existing pipeline on branch "([^"]*)" with the workflow jobs:$/,
     {
         timeout: TIMEOUT
     },
-    function step(branch, table) {
-        let pipelineVarName = 'pipelineIdA';
-
-        if (branch === 'pipelineB') {
-            pipelineVarName = 'pipelineIdB';
-        }
-
-        return this.ensurePipelineExists({
+    async function step(branchName, table) {
+        await this.ensurePipelineExists({
             repoName: this.repoName,
-            branch,
-            pipelineVarName,
+            branch: branchName,
             table,
             shouldNotDeletePipeline: true
         });
+
+        this.pipelines[branchName] = {
+            pipelineId: this.pipelineId,
+            jobs: this.jobs
+        };
     }
 );
 
 Given(
-    /^an existing pipeline on branch "(.*)" with job "(.*)"$/,
+    /^an existing pipeline on branch "([^"]*)" with job "([^"]*)"$/,
     {
         timeout: TIMEOUT
     },
-    function step(branch, jobName) {
-        let pipelineVarName = 'pipelineIdA';
-
-        if (branch === 'pipelineB') {
-            pipelineVarName = 'pipelineIdB';
-        }
-
-        return this.ensurePipelineExists({
+    async function step(branchName, jobName) {
+        await this.ensurePipelineExists({
             repoName: this.repoName,
-            branch,
-            pipelineVarName,
+            branch: branchName,
             jobName,
             shouldNotDeletePipeline: true
         });
+
+        this.pipelines[branchName] = {
+            pipelineId: this.pipelineId,
+            jobs: this.jobs
+        };
     }
 );
 
-When(/^the "(fail_A|success_A|parallel_A)" job on branch "(?:.*)" is started$/, { timeout: TIMEOUT }, function step(
-    jobName
-) {
-    const jobId = jobName ? this[`${jobName}JobId`] : this.jobId;
-    const buildVarName = jobName ? `${jobName}BuildId` : 'buildId';
-
-    return request({
-        uri: `${this.instance}/${this.namespace}/builds`,
-        method: 'POST',
-        body: {
-            jobId
-        },
-        auth: {
-            bearer: this.jwt
-        },
-        json: true
-    }).then(resp => {
-        Assert.equal(resp.statusCode, 201);
-
-        this[buildVarName] = resp.body.id;
-        this.buildId = resp.body.id;
-    });
-});
-
-// no-op since the next test handles this case
-Then(
-    /^the "(?:success_B|parallel_B1|parallel_B2)" job on branch "(?:.*)" is started$/,
+When(
+    /^a new commit is pushed to "([^"]*)" branch with the trigger jobs$/,
     {
         timeout: TIMEOUT
     },
-    () => null
-);
-
-Then(
-    /^the "(.*)" build's parentBuildId is that "(.*)" build's buildId$/,
-    {
-        timeout: TIMEOUT
-    },
-    function step(jobName1, jobName2) {
-        const buildVarName = jobName2 ? `${jobName2}BuildId` : 'buildId';
-
-        return sdapi
-            .searchForBuild({
-                instance: this.instance,
-                pipelineId: this.pipelineIdB,
-                desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
-                jobName: jobName1,
-                jwt: this.jwt,
-                parentBuildId: this[buildVarName]
-            })
-            .then(resultBuild => Assert.ok(resultBuild));
-    }
-);
-
-Then(
-    /^the "(.*)" job on branch "(.*)" is not triggered$/,
-    {
-        timeout: TIMEOUT
-    },
-    function step(jobName, branch) {
-        let pipelineId = this.pipelineIdA;
-
-        if (branch === 'pipelineB') {
-            pipelineId = this.pipelineIdB;
-        }
-
-        return sdapi
-            .findBuilds({
-                instance: this.instance,
-                pipelineId,
-                jobName,
-                jwt: this.jwt
-            })
-            .then(buildData => {
-                let result = buildData.body || [];
-
-                result = result.filter(item => item.sha === this.sha);
-
-                Assert.equal(result.length, 0, 'Unexpected job was triggered.');
+    function step(branchName) {
+        return github
+            .createBranch(branchName, this.repoOrg, this.repoName)
+            .then(() => github.createFile(branchName, this.repoOrg, this.repoName))
+            .then(({ data }) => {
+                this.pipelines[branchName].sha = data.commit.sha;
             });
     }
 );
 
+When(
+    /^the "(fail_A|success_A|parallel_A)" job on branch "(?:.*)" is started$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(jobName) {
+        const jobId = jobName ? this[`${jobName}JobId`] : this.jobId;
+        const buildVarName = jobName ? `${jobName}BuildId` : 'buildId';
+
+        return request({
+            uri: `${this.instance}/${this.namespace}/builds`,
+            method: 'POST',
+            body: {
+                jobId
+            },
+            auth: {
+                bearer: this.jwt
+            },
+            json: true
+        }).then(resp => {
+            Assert.equal(resp.statusCode, 201);
+
+            this[buildVarName] = resp.body.id;
+            this.buildId = resp.body.id;
+        });
+    }
+);
+
+// no-op since the next test handles this case
 Then(
-    /^builds for "(.*)" and "(.*)" jobs are part of a single event$/,
+    /^the "(?:success_B|parallel_B1|parallel_B2)" job on branch "(?:.*)" is started$/,
+    { timeout: TIMEOUT },
+    () => null
+);
+
+Then(
+    /^the "([^"]*)" build's parentBuildId on branch "([^"]*)" is that "([^"]*)" build's buildId$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(jobName1, branchName, jobName2) {
+        const { pipelineId } = this.pipelines[branchName];
+        const buildVarName = jobName2 ? `${jobName2}BuildId` : 'buildId';
+
+        const build = await sdapi.searchForBuild({
+            instance: this.instance,
+            pipelineId,
+            desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+            jobName: jobName1,
+            jwt: this.jwt,
+            parentBuildId: this[buildVarName]
+        });
+
+        this.buildId = build.id;
+        this.pipelines[branchName].eventId = build.eventId;
+        this.pipelines[branchName].sha = build.sha;
+
+        Assert.ok(build);
+    }
+);
+
+When(
+    /^the "([^"]*)" job is triggered on branch "([^"]*)"$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(jobName, branchName) {
+        const { pipelineId, jobs, sha } = this.pipelines[branchName];
+
+        const build = await sdapi.searchForBuild({
+            instance: this.instance,
+            pipelineId,
+            desiredSha: sha,
+            desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+            jobName,
+            jwt: this.jwt
+        });
+
+        const job = jobs.find(j => j.name === jobName);
+
+        this.buildId = build.id;
+        this.pipelines[branchName].eventId = build.eventId;
+
+        Assert.equal(build.jobId, job.id);
+    }
+);
+
+Then(
+    /^the "([^"]*)" job on branch "([^"]*)" is not triggered$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(jobName, branchName) {
+        const { pipelineId } = this.pipelines[branchName];
+
+        const build = await sdapi.findBuilds({
+            instance: this.instance,
+            pipelineId,
+            jobName,
+            jwt: this.jwt
+        });
+
+        let result = build.body || [];
+
+        result = result.filter(item => item.sha === this.sha);
+
+        Assert.equal(result.length, 0, 'Unexpected job was triggered.');
+    }
+);
+
+Then(
+    /^the "([^"]*)" job is triggered from "([^"]*)" on branch "([^"]*)" and "([^"]*)" on branch "([^"]*)"$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(joinJobName, parentJobName, parentBranchName, externalJobName, externalBranchName) {
+        const parentPipeline = this.pipelines[parentBranchName];
+        const parentBuilds = await sdapi.findEventBuilds({
+            instance: this.instance,
+            eventId: parentPipeline.eventId,
+            jwt: this.jwt,
+            jobs: parentPipeline.jobs,
+            jobName: joinJobName
+        });
+
+        const joinJob = parentPipeline.jobs.find(j => j.name === joinJobName);
+        const joinBuild = parentBuilds.find(b => b.jobId === joinJob.id);
+
+        const parentJob = parentPipeline.jobs.find(j => j.name === parentJobName);
+        const parentBuild = parentBuilds.find(b => b.jobId === parentJob.id);
+
+        Assert.oneOf(parentBuild.id, joinBuild.parentBuildId);
+
+        const externalPipeline = this.pipelines[externalBranchName];
+        const externalBuilds = await sdapi.findEventBuilds({
+            instance: this.instance,
+            eventId: externalPipeline.eventId,
+            jwt: this.jwt,
+            jobs: externalPipeline.jobs,
+            jobName: externalJobName
+        });
+
+        const externalJob = externalPipeline.jobs.find(j => j.name === externalJobName);
+        const externalBuild = externalBuilds.find(b => b.jobId === externalJob.id);
+
+        Assert.oneOf(externalBuild.id, joinBuild.parentBuildId);
+    }
+);
+
+Then(
+    /^builds for "([^"]*)" and "([^"]*)" jobs are part of a single event$/,
     {
         timeout: TIMEOUT
     },
@@ -171,5 +248,62 @@ Then(
                 Assert.deepEqual(result1.eventId, result2.eventId, 'Jobs triggered in separate events.');
             }
         );
+    }
+);
+
+Then(
+    /^that "([^"]*)" build uses the same SHA as the "([^"]*)" build on branch "([^"]*)"$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(jobName1, jobName2, branchName) {
+        const { pipelineId, sha } = this.pipelines[branchName];
+
+        return Promise.all([
+            sdapi.searchForBuild({
+                instance: this.instance,
+                pipelineId,
+                desiredSha: sha,
+                desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+                jobName: jobName1,
+                jwt: this.jwt
+            }),
+            sdapi.searchForBuild({
+                instance: this.instance,
+                pipelineId,
+                desiredSha: sha,
+                desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+                jobName: jobName2,
+                jwt: this.jwt
+            })
+        ]).then(([build1, build2]) => Assert.equal(build1.sha, build2.sha));
+    }
+);
+
+Then(
+    /^the "([^"]*)" job is triggered from "([^"]*)" and "([^"]*)" on branch "([^"]*)"$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(joinJobName, parentJobName1, parentJobName2, branchName) {
+        const { eventId, jobs } = this.pipelines[branchName];
+
+        const builds = await sdapi.findEventBuilds({
+            instance: this.instance,
+            eventId,
+            jwt: this.jwt,
+            jobs,
+            jobName: joinJobName
+        });
+
+        const joinJob = jobs.find(j => j.name === joinJobName);
+        const joinBuild = builds.find(b => b.jobId === joinJob.id);
+
+        [parentJobName1, parentJobName2].forEach(jobName => {
+            const parentJob = jobs.find(j => j.name === jobName);
+            const parentBuild = builds.find(b => b.jobId === parentJob.id);
+
+            Assert.oneOf(parentBuild.id, joinBuild.parentBuildId);
+        });
     }
 );

--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -59,43 +59,64 @@ Feature: Remote Trigger
         And the "parallel_B2" build's parentBuildId on branch "pipelineB" is that "parallel_A" build's buildId
         And builds for "parallel_B1" and "parallel_B2" jobs are part of a single event
 
+    @beta
     Scenario: Remote Join
-        Given an existing pipeline on branch "remote1" with the workflow jobs:
+        Given an existing pipeline on branch "beta-remote_join1" with the workflow jobs:
             | job       | requires                  |
             | simple    | ~commit                   |
             | parallel  | simple                    |
             | join      | parallel, sd@?:external   |
-        And an existing pipeline on branch "remote2" with the workflow jobs:
+        And an existing pipeline on branch "beta-remote_join2" with the workflow jobs:
             | job       | requires      |
             | external  | ~sd@?:simple  |
-        When a new commit is pushed to "remote1" branch with the trigger jobs
-        And the "simple" job is triggered on branch "remote1"
+        When a new commit is pushed to "beta-remote_join1" branch with the trigger jobs
+        And the "simple" job is triggered on branch "beta-remote_join1"
         And the "simple" build succeeded
-        And the "parallel" job is triggered on branch "remote1"
+        And the "parallel" job is triggered on branch "beta-remote_join1"
         And the "parallel" build succeeded
-        And the "external" build's parentBuildId on branch "remote2" is that "simple" build's buildId
+        And the "external" build's parentBuildId on branch "beta-remote_join2" is that "simple" build's buildId
         And the "external" build succeeded
-        Then the "join" job is triggered from "parallel" on branch "remote1" and "external" on branch "remote2"
-        And that "join" build uses the same SHA as the "simple" build on branch "remote1"
+        Then the "join" job is triggered from "parallel" on branch "beta-remote_join1" and "external" on branch "beta-remote_join2"
+        And that "join" build uses the same SHA as the "simple" build on branch "beta-remote_join1"
+
+    @prod
+    Scenario: Remote Join
+        Given an existing pipeline on branch "remote_join1" with the workflow jobs:
+            | job       | requires                  |
+            | simple    | ~commit                   |
+            | parallel  | simple                    |
+            | join      | parallel, sd@?:external   |
+        And an existing pipeline on branch "remote_join2" with the workflow jobs:
+            | job       | requires      |
+            | external  | ~sd@?:simple  |
+        When a new commit is pushed to "remote_join1" branch with the trigger jobs
+        And the "simple" job is triggered on branch "remote_join1"
+        And the "simple" build succeeded
+        And the "parallel" job is triggered on branch "remote_join1"
+        And the "parallel" build succeeded
+        And the "external" build's parentBuildId on branch "remote_join2" is that "simple" build's buildId
+        And the "external" build succeeded
+        Then the "join" job is triggered from "parallel" on branch "remote_join1" and "external" on branch "remote_join2"
+        And that "join" build uses the same SHA as the "simple" build on branch "remote_join1"
 
     Scenario: Join Job from External Trigger
-        Given an existing pipeline on branch "remoteA" with the workflow jobs:
+        Given an existing pipeline on branch "external_trigger1" with the workflow jobs:
             | job       | requires  |
             | trigger   | ~commit   |
-        And an existing pipeline on branch "remoteB" with the workflow jobs:
+        And an existing pipeline on branch "external_trigger2" with the workflow jobs:
             | job       | requires              |
             | main      | ~sd@?:trigger         |
             | parallel1 | main                  |
             | parallel2 | main                  |
             | join      | parallel1, parallel2  |
-        When a new commit is pushed to "remoteA" branch with the trigger jobs
-        And the "trigger" job is triggered on branch "remoteA"
+        When a new commit is pushed to "external_trigger1" branch with the trigger jobs
+        And the "trigger" job is triggered on branch "external_trigger1"
         And the "trigger" build succeeded
-        And the "main" build's parentBuildId on branch "remoteB" is that "trigger" build's buildId
+        And the "main" build's parentBuildId on branch "external_trigger2" is that "trigger" build's buildId
         And the "main" build succeeded
-        And the "parallel1" build's parentBuildId on branch "remoteB" is that "main" build's buildId
+        And the "parallel1" build's parentBuildId on branch "external_trigger2" is that "main" build's buildId
         And the "parallel1" build succeeded
-        And the "parallel2" build's parentBuildId on branch "remoteB" is that "main" build's buildId
+        And the "parallel2" build's parentBuildId on branch "external_trigger2" is that "main" build's buildId
         And the "parallel2" build succeeded
-        Then the "join" job is triggered from "parallel1" and "parallel2" on branch "remoteB"
-        And that "join" build uses the same SHA as the "main" build on branch "remoteB"
+        Then the "join" job is triggered from "parallel1" and "parallel2" on branch "external_trigger2"
+        And that "join" build uses the same SHA as the "main" build on branch "external_trigger2"

--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -26,35 +26,76 @@ Feature: Remote Trigger
         - If multiple jobs in a pipeline requires the same external pipeline's Job as trigger, then
           builds for these jobs should be part of same pipeline event
 
-      Scenario: External builds are not triggered if required build is not successful.
-          Given an existing pipeline on branch "pipelineA" with job "fail_A"
-          And an existing pipeline on branch "pipelineB" with the workflow jobs:
-              | job           | requires      |
-              | fail_B | ~sd@?:fail_A |
-          When the "fail_A" job on branch "pipelineA" is started
-          And the "fail_A" build failed
-          Then the "fail_B" job on branch "pipelineB" is not triggered
+    Scenario: External builds are not triggered if required build is not successful.
+        Given an existing pipeline on branch "pipelineA" with job "fail_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job       | requires      |
+            | fail_B    | ~sd@?:fail_A  |
+        When the "fail_A" job on branch "pipelineA" is started
+        And the "fail_A" build failed
+        Then the "fail_B" job on branch "pipelineB" is not triggered
 
-      Scenario: External build is triggered after another build is successful.
-          Given an existing pipeline on branch "pipelineA" with job "success_A"
-          And an existing pipeline on branch "pipelineB" with the workflow jobs:
-              | job           | requires      |
-              | success_B | ~sd@?:success_A |
-          When the "success_A" job on branch "pipelineA" is started
-          And the "success_A" build succeeded
-          Then the "success_B" job on branch "pipelineB" is started
-          And the "success_B" build's parentBuildId is that "success_A" build's buildId
+    Scenario: External build is triggered after another build is successful.
+        Given an existing pipeline on branch "pipelineA" with job "success_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job       | requires          |
+            | success_B | ~sd@?:success_A   |
+        When the "success_A" job on branch "pipelineA" is started
+        And the "success_A" build succeeded
+        Then the "success_B" job on branch "pipelineB" is started
+        And the "success_B" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
 
-      Scenario: Fan-out. Multiple external builds are triggered in parallel as a result of a build's success.
-          Given an existing pipeline on branch "pipelineA" with job "parallel_A"
-          And an existing pipeline on branch "pipelineB" with the workflow jobs:
-              | job             | requires      |
-              | parallel_B1 | ~sd@?:parallel_A |
-              | parallel_B2 | ~sd@?:parallel_A |
-          When the "parallel_A" job on branch "pipelineA" is started
-          And the "parallel_A" build succeeded
-          Then the "parallel_B1" job on branch "pipelineB" is started
-          And the "parallel_B1" build's parentBuildId is that "parallel_A" build's buildId
-          And the "parallel_B2" job on branch "pipelineB" is started
-          And the "parallel_B2" build's parentBuildId is that "parallel_A" build's buildId
-          And builds for "parallel_B1" and "parallel_B2" jobs are part of a single event
+    Scenario: Fan-out. Multiple external builds are triggered in parallel as a result of a build's success.
+        Given an existing pipeline on branch "pipelineA" with job "parallel_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job           | requires          |
+            | parallel_B1   | ~sd@?:parallel_A  |
+            | parallel_B2   | ~sd@?:parallel_A  |
+        When the "parallel_A" job on branch "pipelineA" is started
+        And the "parallel_A" build succeeded
+        Then the "parallel_B1" job on branch "pipelineB" is started
+        And the "parallel_B1" build's parentBuildId on branch "pipelineB" is that "parallel_A" build's buildId
+        And the "parallel_B2" job on branch "pipelineB" is started
+        And the "parallel_B2" build's parentBuildId on branch "pipelineB" is that "parallel_A" build's buildId
+        And builds for "parallel_B1" and "parallel_B2" jobs are part of a single event
+
+    Scenario: Remote Join
+        Given an existing pipeline on branch "remote1" with the workflow jobs:
+            | job       | requires                  |
+            | simple    | ~commit                   |
+            | parallel  | simple                    |
+            | join      | parallel, sd@?:external   |
+        And an existing pipeline on branch "remote2" with the workflow jobs:
+            | job       | requires      |
+            | external  | ~sd@?:simple  |
+        When a new commit is pushed to "remote1" branch with the trigger jobs
+        And the "simple" job is triggered on branch "remote1"
+        And the "simple" build succeeded
+        And the "parallel" job is triggered on branch "remote1"
+        And the "parallel" build succeeded
+        And the "external" build's parentBuildId on branch "remote2" is that "simple" build's buildId
+        And the "external" build succeeded
+        Then the "join" job is triggered from "parallel" on branch "remote1" and "external" on branch "remote2"
+        And that "join" build uses the same SHA as the "simple" build on branch "remote1"
+
+    Scenario: Join Job from External Trigger
+        Given an existing pipeline on branch "remoteA" with the workflow jobs:
+            | job       | requires  |
+            | trigger   | ~commit   |
+        And an existing pipeline on branch "remoteB" with the workflow jobs:
+            | job       | requires              |
+            | main      | ~sd@?:trigger         |
+            | parallel1 | main                  |
+            | parallel2 | main                  |
+            | join      | parallel1, parallel2  |
+        When a new commit is pushed to "remoteA" branch with the trigger jobs
+        And the "trigger" job is triggered on branch "remoteA"
+        And the "trigger" build succeeded
+        And the "main" build's parentBuildId on branch "remoteB" is that "trigger" build's buildId
+        And the "main" build succeeded
+        And the "parallel1" build's parentBuildId on branch "remoteB" is that "main" build's buildId
+        And the "parallel1" build succeeded
+        And the "parallel2" build's parentBuildId on branch "remoteB" is that "main" build's buildId
+        And the "parallel2" build succeeded
+        Then the "join" job is triggered from "parallel1" and "parallel2" on branch "remoteB"
+        And that "join" build uses the same SHA as the "main" build on branch "remoteB"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "./bin/server",
     "debug": "node --nolazy --inspect-brk=9229 ./bin/server",
     "profile": "node --prof ./bin/server",
-    "functional": "cucumber-js --format=progress --tags 'not @ignore' --retry 2 --fail-fast --exit",
+    "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
+    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png"
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -10,7 +10,7 @@ jobs:
             - ~pr
             - ~commit
             - ~sd@73:publish #artifact-bookend https://cd.screwdriver.cd/pipelines/73
-            - ~sd@9:publish  #models https://cd.screwdriver.cd/pipelines/9         
+            - ~sd@9:publish  #models https://cd.screwdriver.cd/pipelines/9
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - install: npm install
@@ -51,7 +51,7 @@ jobs:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
-            - test: npm install && npm run functional
+            - test: npm install && npm run functional-beta
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
             K8S_CONTAINER: screwdriver-api


### PR DESCRIPTION
## Context
(#2159) caused failure of beta functional test.
The reason was that functional test didn't work on beta.
So, I solved this problem.

this PR diff
https://github.com/screwdriver-cd/screwdriver/pull/2166/commits/969592a3f9529d826372cf928cb6a6396c5416de


## Objective
- Remote join acceptance test enable work on beta
- Add required jobs in beta
- change test pipeline name (to clearly separate by beta functional test)
  - remote1 -> remote_join1, beta-remote_join1
  - remote2 -> remote_join2, beta-remote_join2
  - remoteA -> external_trigger1
  - remoteB -> external_trigger2
- Add remote join & external join accesptance test (#2159)
- Refactor trigger.js, world.js (#2159)

## References
- functional-trigger test branch (example)
  - https://github.com/screwdriver-cd-test/functional-trigger/tree/beta-remote_join1

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
