### PR TITLE
fix(2152): Support PR analysis for coverage info [3]

### DIFF
--- a/plugins/coverage/README.md
+++ b/plugins/coverage/README.md
@@ -27,11 +27,11 @@ server.register({
 ### Routes
 
 #### Returns an access token to talk to coverage server
-`GET /coverage/token?scope=job`
+`GET /coverage/token?scope=job&projectKey=job:123&username=user-job-123`
 
 #### Get an object with coverage info
 
-`GET /coverage/info?pipelineId=1&jobId=123&startTime=2017-10-19T13%3A00%3A00%2B0200&endTime=2017-10-19T15%3A00%3A00%2B0200&jobName=main&pipelineName=d2lam%2Fmytest&scope=pipeline`
+`GET /coverage/info?pipelineId=1&jobId=123&startTime=2017-10-19T13%3A00%3A00%2B0200&endTime=2017-10-19T15%3A00%3A00%2B0200&jobName=main&pipelineName=d2lam%2Fmytest&scope=pipeline&prNum=555&prParentJobId=456`
 
 Should resolve with something like
 ```javascript

--- a/plugins/coverage/index.js
+++ b/plugins/coverage/index.js
@@ -4,6 +4,7 @@ const boom = require('boom');
 const infoRoute = require('./info');
 const tokenRoute = require('./token');
 const COVERAGE_SCOPE_ANNOTATION = 'screwdriver.cd/coverageScope';
+const PR_REGEX = /^PR-(\d+)(?::([\w-]+))?$/;
 
 /**
  * Coverage API Plugin
@@ -33,7 +34,6 @@ exports.register = (server, options, next) => {
             annotations: scope ? { [COVERAGE_SCOPE_ANNOTATION]: scope || null } : {},
             prNum
         };
-        const prRegex = /^PR-(\d+)(?::([\w-]+))?$/;
 
         if (jobId) {
             // Get job, scope, and PR info
@@ -51,15 +51,15 @@ exports.register = (server, options, next) => {
 
                 // If scope is job and job is pull request, set jobId and jobName
                 if (coverageConfig.annotations[COVERAGE_SCOPE_ANNOTATION] === 'job' && isPR) {
-                    const prNameMatch = job.name.match(prRegex);
+                    const prNameMatch = job.name.match(PR_REGEX);
 
-                    coverageConfig.jobId = job.prParentJobId;
+                    coverageConfig.prParentJobId = job.prParentJobId;
                     coverageConfig.jobName = prNameMatch && prNameMatch.length > 1 ? prNameMatch[2] : job.name;
                     coverageConfig.prNum = prNameMatch && prNameMatch.length > 1 ? prNameMatch[1] : prNum;
                 }
 
                 if (coverageConfig.annotations[COVERAGE_SCOPE_ANNOTATION] === 'pipeline' && isPR) {
-                    const prNameMatch = job.name.match(prRegex);
+                    const prNameMatch = job.name.match(PR_REGEX);
 
                     coverageConfig.prNum = prNameMatch && prNameMatch.length > 1 ? prNameMatch[1] : prNum;
                 }

--- a/plugins/coverage/index.js
+++ b/plugins/coverage/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const boom = require('boom');
 const infoRoute = require('./info');
 const tokenRoute = require('./token');
+const COVERAGE_SCOPE_ANNOTATION = 'screwdriver.cd/coverageScope';
 
 /**
  * Coverage API Plugin
@@ -12,6 +14,62 @@ const tokenRoute = require('./token');
  */
 exports.register = (server, options, next) => {
     const { coveragePlugin } = options;
+
+    /**
+     * Get extra coverage info such as:
+     * - annotations for scope
+     * - jobId and jobName for PR
+     * @method getCoverageConfig
+     * @param {Object}      config              Configuration object
+     * @param {Pipeline}    config.jobId        Screwdriver job ID
+     * @param {Job}         [config.prNum]      PR number
+     * @param {Build}       [config.scope]      Scope (pipeline or job)
+     * @return {Promise}                        Resolves to config object
+     */
+    server.expose('getCoverageConfig', ({ scope, jobId, prNum }) => {
+        const { jobFactory } = server.root.app;
+        const coverageConfig = {
+            jobId,
+            annotations: scope ? { [COVERAGE_SCOPE_ANNOTATION]: scope || null } : {},
+            prNum
+        };
+        const prRegex = /^PR-(\d+)(?::([\w-]+))?$/;
+
+        if (jobId) {
+            // Get job, scope, and PR info
+            return jobFactory.get(jobId).then(job => {
+                if (!job) {
+                    throw boom.notFound(`Job ${jobId} does not exist`);
+                }
+
+                const isPR = job.isPR();
+
+                if (!scope) {
+                    coverageConfig.annotations =
+                        job.permutations[0] && job.permutations[0].annotations ? job.permutations[0].annotations : {};
+                }
+
+                // If scope is job and job is pull request, set jobId and jobName
+                if (coverageConfig.annotations[COVERAGE_SCOPE_ANNOTATION] === 'job' && isPR) {
+                    const prNameMatch = job.name.match(prRegex);
+
+                    coverageConfig.jobId = job.prParentJobId;
+                    coverageConfig.jobName = prNameMatch && prNameMatch.length > 1 ? prNameMatch[2] : job.name;
+                    coverageConfig.prNum = prNameMatch && prNameMatch.length > 1 ? prNameMatch[1] : prNum;
+                }
+
+                if (coverageConfig.annotations[COVERAGE_SCOPE_ANNOTATION] === 'pipeline' && isPR) {
+                    const prNameMatch = job.name.match(prRegex);
+
+                    coverageConfig.prNum = prNameMatch && prNameMatch.length > 1 ? prNameMatch[1] : prNum;
+                }
+
+                return coverageConfig;
+            });
+        }
+
+        return Promise.resolve(coverageConfig);
+    });
 
     server.route([infoRoute({ coveragePlugin }), tokenRoute({ coveragePlugin })]);
 

--- a/plugins/coverage/index.js
+++ b/plugins/coverage/index.js
@@ -1,10 +1,7 @@
 'use strict';
 
-const boom = require('boom');
 const infoRoute = require('./info');
 const tokenRoute = require('./token');
-const COVERAGE_SCOPE_ANNOTATION = 'screwdriver.cd/coverageScope';
-const PR_REGEX = /^PR-(\d+)(?::([\w-]+))?$/;
 
 /**
  * Coverage API Plugin
@@ -15,61 +12,6 @@ const PR_REGEX = /^PR-(\d+)(?::([\w-]+))?$/;
  */
 exports.register = (server, options, next) => {
     const { coveragePlugin } = options;
-
-    /**
-     * Get extra coverage info such as:
-     * - annotations for scope
-     * - jobId and jobName for PR
-     * @method getCoverageConfig
-     * @param {Object}      config              Configuration object
-     * @param {Pipeline}    config.jobId        Screwdriver job ID
-     * @param {Job}         [config.prNum]      PR number
-     * @param {Build}       [config.scope]      Scope (pipeline or job)
-     * @return {Promise}                        Resolves to config object
-     */
-    server.expose('getCoverageConfig', ({ scope, jobId, prNum }) => {
-        const { jobFactory } = server.root.app;
-        const coverageConfig = {
-            jobId,
-            annotations: scope ? { [COVERAGE_SCOPE_ANNOTATION]: scope || null } : {},
-            prNum
-        };
-
-        if (jobId) {
-            // Get job, scope, and PR info
-            return jobFactory.get(jobId).then(job => {
-                if (!job) {
-                    throw boom.notFound(`Job ${jobId} does not exist`);
-                }
-
-                const isPR = job.isPR();
-
-                if (!scope) {
-                    coverageConfig.annotations =
-                        job.permutations[0] && job.permutations[0].annotations ? job.permutations[0].annotations : {};
-                }
-
-                // If scope is job and job is pull request, set jobId and jobName
-                if (coverageConfig.annotations[COVERAGE_SCOPE_ANNOTATION] === 'job' && isPR) {
-                    const prNameMatch = job.name.match(PR_REGEX);
-
-                    coverageConfig.prParentJobId = job.prParentJobId;
-                    coverageConfig.jobName = prNameMatch && prNameMatch.length > 1 ? prNameMatch[2] : job.name;
-                    coverageConfig.prNum = prNameMatch && prNameMatch.length > 1 ? prNameMatch[1] : prNum;
-                }
-
-                if (coverageConfig.annotations[COVERAGE_SCOPE_ANNOTATION] === 'pipeline' && isPR) {
-                    const prNameMatch = job.name.match(PR_REGEX);
-
-                    coverageConfig.prNum = prNameMatch && prNameMatch.length > 1 ? prNameMatch[1] : prNum;
-                }
-
-                return coverageConfig;
-            });
-        }
-
-        return Promise.resolve(coverageConfig);
-    });
 
     server.route([infoRoute({ coveragePlugin }), tokenRoute({ coveragePlugin })]);
 

--- a/plugins/coverage/info.js
+++ b/plugins/coverage/info.js
@@ -19,14 +19,24 @@ module.exports = config => ({
             }
         },
         handler: (request, reply) => {
-            const { jobId, pipelineId, startTime, endTime, jobName, pipelineName, scope, projectKey } = request.query;
+            const {
+                jobId,
+                pipelineId,
+                startTime,
+                endTime,
+                jobName,
+                pipelineName,
+                scope,
+                projectKey,
+                prNum
+            } = request.query;
             const { jobFactory } = request.server.app;
-            const infoConfig = { jobId, pipelineId, startTime, endTime, jobName, pipelineName };
+            const infoConfig = { jobId, pipelineId, startTime, endTime, jobName, pipelineName, prNum };
 
             // Short circuit to get coverage info
             if (projectKey && startTime && endTime) {
                 return config.coveragePlugin
-                    .getInfo({ startTime, endTime, coverageProjectKey: projectKey })
+                    .getInfo({ startTime, endTime, coverageProjectKey: projectKey, prNum })
                     .then(reply)
                     .catch(err => reply(boom.boomify(err)));
             }

--- a/plugins/coverage/info.js
+++ b/plugins/coverage/info.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const boom = require('boom');
-const hoek = require('hoek');
 
 module.exports = config => ({
     method: 'GET',
@@ -20,35 +19,10 @@ module.exports = config => ({
             }
         },
         handler: (request, reply) => {
-            const {
-                jobId,
-                pipelineId,
-                startTime,
-                endTime,
-                jobName,
-                pipelineName,
-                scope,
-                projectKey,
-                prNum
-            } = request.query;
-            let infoConfig = { jobId, pipelineId, startTime, endTime, jobName, pipelineName, prNum };
-
-            // Short circuit to get coverage info
-            if (projectKey && startTime && endTime) {
-                return config.coveragePlugin
-                    .getInfo({ startTime, endTime, coverageProjectKey: projectKey, prNum })
-                    .then(reply)
-                    .catch(err => reply(boom.boomify(err)));
-            }
-
-            return request.server.plugins.coverage.getCoverageConfig({ jobId, prNum, scope }).then(coverageConfig => {
-                infoConfig = hoek.merge(infoConfig, coverageConfig, { nullOverride: false });
-
-                return config.coveragePlugin
-                    .getInfo(infoConfig)
-                    .then(reply)
-                    .catch(err => reply(boom.boomify(err)));
-            });
+            return config.coveragePlugin
+                .getInfo(request.query)
+                .then(reply)
+                .catch(err => reply(boom.boomify(err)));
         }
     }
 });

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -23,11 +23,19 @@ module.exports = config => ({
             const { jobFactory } = request.server.app;
             const buildCredentials = request.auth.credentials;
             const { jobId } = buildCredentials;
-            const { scope } = request.query;
+            const { scope, projectKey, username } = request.query;
             const tokenConfig = {
                 buildCredentials,
                 scope
             };
+
+            if (projectKey) {
+                tokenConfig.projectKey = projectKey;
+            }
+
+            if (username) {
+                tokenConfig.username = username;
+            }
 
             // Get job scope
             if (jobId && !scope) {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -26,22 +26,20 @@ module.exports = config => ({
             const { scope } = request.query;
             const tokenConfig = {
                 buildCredentials,
-                annotations: scope ? { [COVERAGE_SCOPE_ANNOTATION]: scope || null } : {}
+                scope
             };
 
+            // Get job scope
             if (jobId && !scope) {
-                // Get job scope
                 return jobFactory.get(jobId).then(job => {
                     if (!job) {
                         throw boom.notFound(`Job ${jobId} does not exist`);
                     }
 
-                    if (!scope) {
-                        tokenConfig.annotations =
-                            job.permutations[0] && job.permutations[0].annotations
-                                ? job.permutations[0].annotations
-                                : {};
-                    }
+                    tokenConfig.scope =
+                        job.permutations[0] && job.permutations[0].annotations
+                            ? job.permutations[0].annotations[COVERAGE_SCOPE_ANNOTATION]
+                            : null;
 
                     return config.coveragePlugin
                         .getAccessToken(tokenConfig)

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -116,6 +116,24 @@ describe.only('coverage plugin test', () => {
             });
         });
 
+        it('returns 200 with projectKey and username', () => {
+            options.url = '/coverage/token?projectKey=job:123&username=user-job-123&scope=job';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, 'faketoken');
+                assert.calledWith(coveragePlugin.getAccessToken, {
+                    scope: 'job',
+                    buildCredentials: {
+                        jobId: 123,
+                        scope: ['build']
+                    },
+                    projectKey: 'job:123',
+                    username: 'user-job-123'
+                });
+            });
+        });
+
         it('returns 200 with default scope', () => {
             jobFactoryMock.get.resolves({
                 permutations: [{}],

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -7,7 +7,7 @@ const mockery = require('mockery');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe.only('coverage plugin test', () => {
+describe('coverage plugin test', () => {
     let plugin;
     let server;
     let coveragePlugin;

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -7,7 +7,7 @@ const mockery = require('mockery');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('coverage plugin test', () => {
+describe.only('coverage plugin test', () => {
     let plugin;
     let server;
     let coveragePlugin;
@@ -228,7 +228,8 @@ describe('coverage plugin test', () => {
                 endTime: '2017-10-19T15:00:00+0200',
                 jobName: 'main',
                 pipelineName: 'd2lam/mytest',
-                annotations: { 'screwdriver.cd/coverageScope': 'pipeline' }
+                annotations: { 'screwdriver.cd/coverageScope': 'pipeline' },
+                prNum: undefined
             };
             options = {
                 // eslint-disable-next-line
@@ -259,7 +260,8 @@ describe('coverage plugin test', () => {
                 assert.calledWith(coveragePlugin.getInfo, {
                     startTime: args.startTime,
                     endTime: args.endTime,
-                    coverageProjectKey: `pipeline:${pipelineId}`
+                    coverageProjectKey: `pipeline:${pipelineId}`,
+                    prNum: undefined
                 });
             });
         });


### PR DESCRIPTION
## Context

When users open PRs, we should take advantage of Sonar PR analysis so new projects are not created.

## Objective

This PR adds logic to get scope, jobId, and jobName for PRs for Sonar coverage plugin.

## References

Related to #2152 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
