### PR TITLE
fix: disable one more test in beta

### DIFF
--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -99,6 +99,7 @@ Feature: Remote Trigger
         Then the "join" job is triggered from "parallel" on branch "remote_join1" and "external" on branch "remote_join2"
         And that "join" build uses the same SHA as the "simple" build on branch "remote_join1"
 
+    @prod
     Scenario: Join Job from External Trigger
         Given an existing pipeline on branch "external_trigger1" with the workflow jobs:
             | job       | requires  |


### PR DESCRIPTION
## Context

Disable another flaky test in beta

## Objective

Tests are flaky and pipeline needs to be unblocked.

## References

https://cd.screwdriver.cd/pipelines/1/builds/437199/steps/test

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
