### PR TITLE
feat(1079): Set allowInPr to true in create pipeline deploy key secret

### DIFF
--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -137,7 +137,7 @@ module.exports = () => ({
                                                                 pipelineId: pipeline.id,
                                                                 name: deployKeySecret,
                                                                 value: privateDeployKeyB64,
-                                                                allowInPR: false
+                                                                allowInPR: true
                                                             });
                                                         });
                                                 }

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1425,8 +1425,6 @@ describe('pipeline plugin test', () => {
 
             pipelineFactoryMock.scm.parseUrl.resolves(scmUri);
             pipelineFactoryMock.scm.addDeployKey.resolves(privateKey);
-
-            secretFactoryMock.get.withArgs({ pipelineId: 123, name: 'SD_SCM_DEPLOY_KEY' }).resolves(null);
         });
 
         it('returns 201 and correct pipeline data', () => {
@@ -1469,7 +1467,7 @@ describe('pipeline plugin test', () => {
                     pipelineId: 123,
                     name: 'SD_SCM_DEPLOY_KEY',
                     value: privateKeyB64,
-                    allowInPR: false
+                    allowInPR: true
                 });
                 assert.equal(reply.statusCode, 201);
             });


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1079

## Objective

This PR sets the allowInPr to true in create pipeline deploy key secret creation

## References

screwdriver-cd/screwdriver#1079

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
