### PR TITLE
fix(1954): add webhook sync

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -135,10 +135,12 @@ module.exports = () => ({
                                             oldPipeline.name = scmRepo.name;
 
                                             // update pipeline with new scmRepo and branch
-                                            return oldPipeline
-                                                .update()
-                                                .then(updatedPipeline => updatedPipeline.sync())
-                                                .then(syncedPipeline => reply(syncedPipeline.toJson()).code(200));
+                                            return oldPipeline.update().then(updatedPipeline => {
+                                                return Promise.all([
+                                                    updatedPipeline.sync(),
+                                                    updatedPipeline.addWebhook(`${request.server.info.uri}/v4/webhooks`)
+                                                ]).then(results => reply(results[0].toJson()).code(200));
+                                            });
                                         })
                                 )
                         );


### PR DESCRIPTION
## Context
Fix for issue of https://github.com/screwdriver-cd/screwdriver/issues/1954.

## Objective
When you change the repository from the options page, add a webhook to the new github repository.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1954

I fixed it in the same way as create.
https://github.com/screwdriver-cd/screwdriver/blob/9625f1477dd2402b03a901c6c42f25765d08afca/plugins/pipelines/create.js#L149-L163

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
