### PR TITLE
fix: Pin to executor-basev7.5.0 while we wait for hapi changes to roll out

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "screwdriver-coverage-sonar": "^2.0.0",
     "screwdriver-data-schema": "^19.12.0",
     "screwdriver-datastore-sequelize": "^6.0.1",
-    "screwdriver-executor-base": "^7.5.0",
+    "screwdriver-executor-base": "7.5.0",
     "screwdriver-executor-docker": "^4.2.3",
     "screwdriver-executor-k8s": "^13.16.5",
     "screwdriver-executor-k8s-vm": "^3.2.3",


### PR DESCRIPTION
## Context

executor-base v7.6.0 has the latest version of data-schema with all the hapi changes, which breaks the duplicate step in screwdriver: https://cd.screwdriver.cd/pipelines/1/builds/474900/steps/duplicate

## Objective

This PR temporarily pins executor-base to v7.5.0 while we wait for all the hapi changes to roll out.

## References

Related to https://github.com/screwdriver-cd/executor-base/pull/65

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
