### PR TITLE
fix: Add pipeline scope for build update

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -44,7 +44,7 @@ module.exports = config => ({
         tags: ['api', 'builds'],
         auth: {
             strategies: ['token'],
-            scope: ['build', 'user', '!guest', 'temporal']
+            scope: ['build', 'pipeline', 'user', '!guest', 'temporal']
         },
         plugins: {
             'hapi-swagger': {


### PR DESCRIPTION
## Context

Sometimes users might want to abort a build using a pipeline token.

## Objective

This PR adds pipeline scope to the build update endpoint.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
