### PR TITLE
fix: enable remote join tests in beta

### DIFF
--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -59,7 +59,7 @@ Feature: Remote Trigger
         And the "parallel_B2" build's parentBuildId on branch "pipelineB" is that "parallel_A" build's buildId
         And builds for "parallel_B1" and "parallel_B2" jobs are part of a single event
 
-    @beta @ignore
+    @beta
     Scenario: Remote Join
         Given an existing pipeline on branch "beta-remote_join1" with the workflow jobs:
             | job       | requires                  |


### PR DESCRIPTION
## Context
The feature test of remote join in beta has been ignored at https://github.com/screwdriver-cd/screwdriver/pull/2171 because the test was failed in only beta.
Now I run the test locally for beta and all tests are successful. I tried it several time and no failures.
```
$ npm run functional-beta
> screwdriver-api@0.5.0 functional-beta /Users/shoyoshi/repo/github/screwdriver
> cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit
.........................................................................................................................................................................................................................................................................................................................
42 scenarios (42 passed)
261 steps (261 passed)
20m57.930s
```

## Objective
Let’s try the remote join tests.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
