### PR TITLE
feat(1958): Correct major version. BREAKING CHANGE: hapi v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-api",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "description": "API server for the Screwdriver.cd service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Context

SD API version needs a major version upgrade after Hapi upgrade

## Objective

This PR upgrades to version 4.0.0 as API already published till version 3.4.71.

## References

https://www.npmjs.com/package/screwdriver-api
https://github.com/screwdriver-cd/screwdriver/issues/1958

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
