### PR TITLE
fix(2198): Add support for automated Sonar Git App PR decoration [2]

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -362,6 +362,9 @@ coverage:
     sdUiUrl: ECOSYSTEM_UI
     # Enterprise edition (true) or open source edition (false)
     sonarEnterprise: COVERAGE_SONAR_ENTERPRISE
+    # Github app name for Sonar PR decoration (default to 'Screwdriver Sonar PR Checks')
+    # https://docs.sonarqube.org/latest/analysis/pr-decoration/
+    sonarGitAppName: COVERAGE_SONAR_GIT_APP_NAME
 
 multiBuildCluster:
   # Enabled multi build cluster feature or not

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -252,6 +252,7 @@ coverage:
   #   adminToken: your-sonar-admin-token
   #   sdUiUrl: https://cd.screwdriver.cd
   #   sonarEnterprise: false
+  #   sonarGitAppName: "Screwdriver Sonar PR Checks"
 
 multiBuildCluster:
   # Enabled multi build cluster feature or not

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Assert = require('chai').assert;
-const octokitRest = require('@octokit/rest');
-const octokit = octokitRest({
+const { Octokit } = require('@octokit/rest');
+const octokit = new Octokit({
     baseUrl: [
         `https://${process.env.TEST_SCM_HOSTNAME || 'api.github.com'}`,
         `${process.env.TEST_SCM_HOSTNAME ? '/api/v3' : ''}`

--- a/plugins/coverage/README.md
+++ b/plugins/coverage/README.md
@@ -27,7 +27,7 @@ server.register({
 ### Routes
 
 #### Returns an access token to talk to coverage server
-`GET /coverage/token?scope=job&projectKey=job:123&username=user-job-123`
+`GET /coverage/token?scope=job&projectKey=job:123&projectName=d2lam/mytest&username=user-job-123`
 
 #### Get an object with coverage info
 

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -23,7 +23,7 @@ module.exports = config => ({
             const { jobFactory } = request.server.app;
             const buildCredentials = request.auth.credentials;
             const { jobId } = buildCredentials;
-            const { scope, projectKey, username } = request.query;
+            const { scope, projectKey, projectName, username } = request.query;
             const tokenConfig = {
                 buildCredentials,
                 scope
@@ -31,6 +31,10 @@ module.exports = config => ({
 
             if (projectKey) {
                 tokenConfig.projectKey = projectKey;
+            }
+
+            if (projectName) {
+                tokenConfig.projectName = projectName;
             }
 
             if (username) {


### PR DESCRIPTION
## Context

Users should be able to configure the name for their Github App for PR decoration with Sonar.

## Objective

This PR
- adds configuration options and passes in projectName as param for getting Sonar token
- updates how we're calling Octokit in functional tests (related to https://github.com/screwdriver-cd/screwdriver/issues/2173)

## References

Related to #2198 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
