### PR TITLE
feat: update fn name for oktokit v18

### DIFF
--- a/features/support/github.js
+++ b/features/support/github.js
@@ -124,7 +124,7 @@ function createFile(branch, repoOwner, repoName) {
     const owner = repoOwner || 'screwdriver-cd-test';
     const repo = repoName || 'functional-git';
 
-    return octokit.repos.createOrUpdateFile({
+    return octokit.repos.createOrUpdateFileContents({
         owner,
         repo,
         path: `testfiles/${filename}`,


### PR DESCRIPTION
## Context

Oktokit version has been upgraded to v18, so we need to update the apis being used

## Objective

This PR fixes the oktokit api

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
