### PR TITLE
feat: fix validation message

### DIFF
--- a/features/step_definitions/templates.js
+++ b/features/step_definitions/templates.js
@@ -58,7 +58,7 @@ Then(/^they are notified it has (no|some) errors$/, function step(quantity) {
             Assert.equal(this.body.errors.length, 2);
 
             Assert.equal(this.body.errors[0].message, '"description" is required');
-            Assert.equal(this.body.errors[1].message, '"image" must be a string');
+            Assert.equal(this.body.errors[1].message, '"config.image" must be a string');
             break;
         default:
             return Promise.resolve('pending');


### PR DESCRIPTION
## Context

Functional test template validation message is incorrect

## Objective

This PR fixes the functional test template validation message

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
