### PR TITLE
feat(1958): Update hapi-swagger to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "deepmerge": "^4.2.2",
     "hapi-auth-bearer-token": "^6.1.6",
     "hapi-auth-jwt2": "^10.1.0",
-    "hapi-swagger": "^13.0.2",
+    "hapi-swagger": "^14.0.0",
     "joi": "^17.2.0",
     "js-yaml": "^3.13.1",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
## Context

`/v4/documentation` is broken with hapi update.

## Objective

This PR updates hapi-swagger package to fix documentation.

Before:
<img width="1494" alt="Screen Shot 2020-09-04 at 2 35 32 PM" src="https://user-images.githubusercontent.com/3230529/92286515-288fda80-eebc-11ea-950a-968ec8c852ad.png">

After:
<img width="1541" alt="Screen Shot 2020-09-04 at 2 32 14 PM" src="https://user-images.githubusercontent.com/3230529/92286502-1b72eb80-eebc-11ea-8f7f-9e027721c6ec.png">

## Related links
- Related to https://github.com/screwdriver-cd/screwdriver/issues/1958
- hapi-swagger compatibility: https://www.npmjs.com/package/hapi-swagger#compatibility

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
