### PR TITLE
[3] fix: noisy logs, no commit found for sha

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -858,7 +858,7 @@ async function pushEvent(request, h, parsed, skipMessage, token) {
     const { eventFactory } = request.server.app;
     const { pipelineFactory } = request.server.app;
     const { userFactory } = request.server.app;
-    const { hookId, checkoutUrl, branch, scmContext, type, action, changedFiles, releaseName, ref } = parsed;
+    const { hookId, checkoutUrl, branch, scmContext, type, action, changedFiles, releaseName, ref, deleted } = parsed;
     const fullCheckoutUrl = `${checkoutUrl}#${branch}`;
     const scmConfig = {
         scmUri: '',
@@ -888,7 +888,7 @@ async function pushEvent(request, h, parsed, skipMessage, token) {
         );
         let events = [];
 
-        if (!pipelines || pipelines.length === 0) {
+        if (deleted || !pipelines || pipelines.length === 0) {
             request.log(['webhook', hookId], `Skipping since Pipeline ${fullCheckoutUrl} does not exist`);
         } else {
             events = await createEvents(eventFactory, userFactory, pipelineFactory, pipelines, parsed, skipMessage);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Such errors occurs in a situation, and it is noisy in any investigation or analysis.
```
Getting errors with [{"action":"getCommit","token":"248ec46cbf868bfe999bf6590c0ba42ee8cd90a2","params":{"owner":"yoshwata-test","repo":"branch-filter-test","ref":"0000000000000000000000000000000000000000"}}]: HttpError: No commit found for SHA: 0000000000000000000000000000000000000000
```

The situation is
- When a branch is deleted
- the branch is match with the branch filter regex.

`00000` means that deleted branch is not exist anymore.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

API does not emit `No commit found for SHA: 0000~` error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/data-schema/pull/410
https://github.com/screwdriver-cd/scm-github/pull/179
https://github.com/screwdriver-cd/screwdriver/pull/2213

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
