### PR TITLE
feat: remove describe() on schema and use available fields

### DIFF
--- a/plugins/commands/list.js
+++ b/plugins/commands/list.js
@@ -8,7 +8,7 @@ const listSchema = joi
     .label('List of commands');
 const distinctSchema = joi
     .string()
-    .valid(...Object.keys(schema.models.command.base.describe().keys))
+    .valid(...Object.keys(schema.models.command.fields))
     .label('Field to return unique results by');
 const compactSchema = joi
     .string()

--- a/plugins/templates/list.js
+++ b/plugins/templates/list.js
@@ -8,7 +8,7 @@ const listSchema = joi
     .label('List of templates');
 const distinctSchema = joi
     .string()
-    .valid(...Object.keys(schema.models.template.base.describe().keys))
+    .valid(...Object.keys(schema.models.template.fields))
     .label('Field to return unique results by');
 const compactSchema = joi
     .string()


### PR DESCRIPTION
## Context

any.describe() fn on the models is scanning the entire model and returning a nested object while we are only interested in the keys in the object and don't need this processing.

## Objective

This pr removes the unnecessary describe on schema and instead used fields which gives the keys

## References

https://github.com/screwdriver-cd/screwdriver/issues/2216

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
