### PR TITLE
fix: Use template

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,3 +1,6 @@
+cache:
+  event: [ $SD_SOURCE_DIR/node_modules ]
+
 shared:
     image: node:12
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -26,14 +26,14 @@ jobs:
 
     publish:
         requires: [main]
+        template: screwdriver-cd/semantic-release
         steps:
-            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
-            - install-ci: npm install npm-auto-version
-            - publish-npm-and-git-tag: ./ci/publish.sh
-            - publish-docker: |
-                export DOCKER_TAG=`cat VERSION`
+          - postpublish: |
+                git clone https://github.com/screwdriver-cd/toolbox.git ci
+                git fetch
+                export DOCKER_TAG=`git describe --tags`
                 ./ci/docker-trigger.sh
-            - save-tag-to-meta: meta set docker_tag $DOCKER_TAG && meta get docker_tag
+                meta set docker_tag $DOCKER_TAG && meta get docker_tag
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
         secrets:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -31,12 +31,7 @@ jobs:
         requires: [main]
         template: screwdriver-cd/semantic-release
         steps:
-          - postpublish: |
-                git clone https://github.com/screwdriver-cd/toolbox.git ci
-                git fetch
-                export DOCKER_TAG=`git describe --tags`
-                ./ci/docker-trigger.sh
-                meta set docker_tag $DOCKER_TAG && meta get docker_tag
+          - postpublish: sd-cmd exec screwdriver/docker-trigger
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
         secrets:


### PR DESCRIPTION
## Context

Now that we have bumped Screwdriver to a major version, we can use semantic release template to publish new versions.

## Objective

This PR switches to using semantic-release template.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
