### PR TITLE
fix: Add expected GH_TOKEN key

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -38,7 +38,7 @@ jobs:
             # Publishing to NPM
             - NPM_TOKEN
             # Pushing tags to Git
-            - GIT_KEY
+            - GH_TOKEN
             # Trigger a Docker Hub build
             - DOCKER_TRIGGER
 


### PR DESCRIPTION
## Context

Build expects GH_TOKEN. 

## Objective

This PR adds GH_TOKEN.

## References


## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
