### PR TITLE
fix: Add semantic release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
-    "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png"
+    "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "bin": {
     "screwdriver-api": "./bin/server"
@@ -123,6 +124,12 @@
     "tinytim": "^0.1.1",
     "uuid": "^8.3.0",
     "verror": "^1.6.1"
+  },
+  "release": {
+    "debug": false,
+    "verifyConditions": {
+      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
+    }
   },
   "devDependencies": {
     "@octokit/rest": "~18.0.3",


### PR DESCRIPTION
## Context

Missing semantic release script in package.json.

## Objective

This PR adds semantic release script in package.json.

## References

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
