### PR TITLE
fix: extend token expiration time

### DIFF
--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -184,7 +184,7 @@ module.exports = config => ({
                         config.authConfig.jwtPrivateKey,
                         {
                             algorithm: 'RS256',
-                            expiresIn: '45s',
+                            expiresIn: '300s',
                             jwtid: uuid.v4()
                         }
                     );

--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -184,7 +184,7 @@ module.exports = config => ({
                         config.authConfig.jwtPrivateKey,
                         {
                             algorithm: 'RS256',
-                            expiresIn: '5s',
+                            expiresIn: '45s',
                             jwtid: uuid.v4()
                         }
                     );


### PR DESCRIPTION
## Context
token expires before api fetch all logs from store, leading to incomplete log file
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
extend token expiration time
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2068
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
