### PR TITLE
feat(ratelimit): add rate limiting

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -399,3 +399,7 @@ build:
     __name: CLUSTER_ENVIRONMENT_VARIABLES
     __format: json
   externalJoin: EXTERNAL_JOIN
+
+rateLimit:
+  __name: RATE_LIMIT_VARIABLES
+  __format: json

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -305,3 +305,11 @@ build:
   environment:
     SD_VERSION: 4
   externalJoin: false
+
+rateLimit:
+  # set true to enable rate limiting on auth token
+  enabled: false
+  # max request limit on auth token per duration, default: 300 (1 rps)
+  limit: 300
+  # limit duration in milliseconds, default: 300000 (5 mins)
+  duration: 300000

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -21,7 +21,8 @@ async function registerDefaultPlugins(server) {
         '../plugins/template-validator',
         '../plugins/command-validator',
         '../plugins/promster',
-        '../plugins/metrics'
+        '../plugins/metrics',
+        '../plugins/ratelimit'
     ].map(plugin => require(plugin));
 
     return plugins.map(async pluginObj =>

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "deepmerge": "^4.2.2",
     "hapi-auth-bearer-token": "^6.1.6",
     "hapi-auth-jwt2": "^10.1.0",
+    "hapi-rate-limit": "^5.0.0",
     "hapi-swagger": "^14.0.0",
     "joi": "^17.2.0",
     "js-yaml": "^3.13.1",

--- a/plugins/auth/contexts.js
+++ b/plugins/auth/contexts.js
@@ -16,6 +16,11 @@ module.exports = config => ({
         description: 'Get all auth contexts',
         notes: 'Get all auth contexts',
         tags: ['api', 'auth', 'context'],
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        },
         handler: async (request, h) => {
             const { scm } = request.server.app.userFactory;
             const scmContexts = scm.getScmContexts();

--- a/plugins/auth/crumb.js
+++ b/plugins/auth/crumb.js
@@ -14,6 +14,11 @@ module.exports = () => ({
         description: 'Generate crumb',
         notes: 'Should return a crumb',
         tags: ['api', 'crumb', 'auth'],
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        },
         handler: async (request, h) =>
             h.response({
                 crumb: request.server.plugins.crumb.generate(request, h)

--- a/plugins/auth/key.js
+++ b/plugins/auth/key.js
@@ -16,6 +16,11 @@ module.exports = options => ({
         description: 'Get jwt public key',
         notes: 'Public Key for verifying JSON Web Tokens',
         tags: ['api', 'auth', 'key'],
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        },
         handler: async (request, h) =>
             h.response({
                 key: options.jwtPublicKey

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -19,6 +19,11 @@ function addGuestRoute(config) {
                 description: 'Login as an guest user',
                 notes: 'Authenticate an guest user',
                 tags: ['api', 'auth', 'login'],
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 auth: null,
                 handler: async (request, h) => {
                     // Check if guest is allowed to login

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -20,7 +20,10 @@ module.exports = () => ({
             scope: ['user', 'pipeline']
         },
         plugins: {
-            'hapi-swagger': { security: [{ token: [] }] }
+            'hapi-swagger': { security: [{ token: [] }] },
+            'hapi-rate-limit': {
+                enabled: false
+            }
         },
         handler: async (request, h) => {
             let profile = request.auth.credentials;

--- a/plugins/banners/get.js
+++ b/plugins/banners/get.js
@@ -13,6 +13,11 @@ module.exports = () => ({
         description: 'Get a single banner',
         notes: 'Return a banner record',
         tags: ['api', 'banners'],
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        },
         handler: async (request, h) => {
             const { bannerFactory } = request.server.app;
             const { id } = request.params;

--- a/plugins/banners/list.js
+++ b/plugins/banners/list.js
@@ -10,6 +10,11 @@ module.exports = () => ({
         description: 'Get banners',
         notes: 'Returns all banner records',
         tags: ['api', 'banners'],
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        },
         handler: async (request, h) => {
             const { bannerFactory } = request.server.app;
 

--- a/plugins/command-validator.js
+++ b/plugins/command-validator.js
@@ -22,6 +22,11 @@ const commandValidatorPlugin = {
                 description: 'Validate a given sd-command.yaml',
                 notes: 'returns the parsed config, validation errors, or both',
                 tags: ['api', 'validation', 'yaml'],
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 handler: async (request, h) => {
                     try {
                         const commandString = request.payload.yaml;

--- a/plugins/metrics.js
+++ b/plugins/metrics.js
@@ -18,6 +18,11 @@ module.exports = {
             path: '/metrics',
             handler: (_, h) => h.response(getSummary()),
             config: {
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 description: 'application metrics',
                 notes: 'Expose application metrics',
                 tags: ['api']

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -83,6 +83,11 @@ module.exports = config => ({
         description: 'Get a badge for the pipeline',
         notes: 'Redirects to the badge service',
         tags: ['api', 'pipelines', 'badge'],
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        },
         handler: async (request, h) => {
             const factory = request.server.app.pipelineFactory;
             const badgeService = request.server.app.ecosystem.badges;

--- a/plugins/pipelines/jobBadge.js
+++ b/plugins/pipelines/jobBadge.js
@@ -38,6 +38,11 @@ module.exports = config => ({
         description: 'Get a badge for a job',
         notes: 'Redirects to the badge service',
         tags: ['api', 'job', 'badge'],
+        plugins: {
+            'hapi-rate-limit': {
+                enabled: false
+            }
+        },
         handler: async (request, h) => {
             const { jobFactory } = request.server.app;
             const { pipelineFactory } = request.server.app;

--- a/plugins/ratelimit.js
+++ b/plugins/ratelimit.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const rateLimit = require('hapi-rate-limit');
+const config = require('config');
+const rateLimitConfig = config.get('rateLimit');
+
+module.exports = {
+    name: 'ratelimit',
+    async register(server) {
+        server.ext('onPreAuth', async (request, h) => {
+            // see https://github.com/glennjones/hapi-swagger/issues/623
+            if (request.path.startsWith('/v4/swagger')) {
+                request.route.settings.plugins['hapi-rate-limit'] = {
+                    enabled: false
+                };
+            }
+
+            return h.continue;
+        });
+
+        await server.register({
+            plugin: rateLimit,
+            options: {
+                enabled: rateLimitConfig.enabled || false,
+                userLimit: rateLimitConfig.limit,
+                userAttribute: 'jti',
+                userCache: {
+                    expiresIn: rateLimitConfig.duration
+                },
+                authLimit: false,
+                headers: false,
+                pathLimit: false,
+                userPathLimit: false,
+                trustProxy: true
+            }
+        });
+    }
+};

--- a/plugins/stats.js
+++ b/plugins/stats.js
@@ -22,6 +22,11 @@ const statsPlugin = {
                 description: 'API stats',
                 notes: 'Should return statistics for the entire system',
                 tags: ['api', 'stats'],
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 response: {
                     schema: schema.api.stats
                 }

--- a/plugins/status.js
+++ b/plugins/status.js
@@ -19,6 +19,11 @@ const statusPlugin = {
                 description: 'API status',
                 notes: 'Should respond with 200: ok',
                 tags: ['api'],
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 response: {
                     schema: schema.api.status
                 }

--- a/plugins/swagger.js
+++ b/plugins/swagger.js
@@ -18,6 +18,12 @@ const swaggerPlugin = {
                         name: 'X-Token',
                         in: 'header'
                     }
+                },
+                // see https://github.com/glennjones/hapi-swagger/blob/master/optionsreference.md#json-json-endpoint-needed-to-create-ui
+                documentationRoutePlugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
                 }
             },
             security: [{ token: [] }]

--- a/plugins/template-validator.js
+++ b/plugins/template-validator.js
@@ -23,6 +23,11 @@ const templateValidatorPlugin = {
                 description: 'Validate a given sd-template.yaml',
                 notes: 'returns the parsed config, validation errors, or both',
                 tags: ['api', 'validation', 'yaml'],
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 handler: async (request, h) => {
                     try {
                         const templateString = request.payload.yaml;

--- a/plugins/validator.js
+++ b/plugins/validator.js
@@ -22,6 +22,11 @@ const validatorTemplate = {
                 description: 'Validate a given screwdriver.yaml',
                 notes: 'Returns the parsed config or validation errors',
                 tags: ['api', 'validation', 'yaml'],
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 handler: async (request, h) =>
                     parser(
                         request.payload.yaml,

--- a/plugins/versions.js
+++ b/plugins/versions.js
@@ -58,6 +58,11 @@ const versionsTemplate = {
                         description: 'API Package Versions',
                         notes: 'Returns list of Screwdriver package versions and third-party dependencies',
                         tags: ['api'],
+                        plugins: {
+                            'hapi-rate-limit': {
+                                enabled: false
+                            }
+                        },
                         response: {
                             schema: schema.api.versions
                         }

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -983,6 +983,11 @@ const webhooksPlugin = {
                 description: 'Handle webhook events',
                 notes: 'Acts on pull request, pushes, comments, etc.',
                 tags: ['api', 'webhook'],
+                plugins: {
+                    'hapi-rate-limit': {
+                        enabled: false
+                    }
+                },
                 payload: {
                     maxBytes: parseInt(pluginOptions.maxBytes, 10) || DEFAULT_MAX_BYTES
                 },

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -18,7 +18,8 @@ describe('Register Unit Test Case', () => {
         '../plugins/template-validator',
         '../plugins/command-validator',
         '../plugins/promster',
-        '../plugins/metrics'
+        '../plugins/metrics',
+        '../plugins/ratelimit'
     ];
     const resourcePlugins = [
         '../plugins/auth',


### PR DESCRIPTION
## Context

Given large enough user base, API might be subject to unexpected intense usage pattern from users. Providing an optional protection mechanism in place to limit the number of API request from each authenticated request would be helpful to maintain a healthy API service.

## Objective

- Add a rate limiting plugin behind a feature flag 
- Exclude rate limiting for paths which do not require authentication
    - GET /v4/auth/contexts
    - GET /v4/auth/crumb
    - GET /v4/auth/key
    - GET /v4/auth/login/guest/{web?}
    - GET /v4/auth/token/{buildId?}
      - This one is special because it takes in api_token (user/pipeline’s) and generates auth token whose jti field would be cache keyed if consumed on endpoints requiring authentication
    - GET /v4/banners
    - GET /v4/banners/{id}
    - GET /v4/documentation
    - GET /v4/metrics
    - GET /v4/pipelines/{id}/{jobName}/badge
    - GET /v4/pipelines/{id}/badge
    - GET /v4/stats
    - GET /v4/status
    - GET /v4/versions
    - POST /v4/validator
    - POST /v4/validator/command
    - POST /v4/validator/template
    - POST /v4/webhooks


## References

https://github.com/screwdriver-cd/guide/pull/419

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
