### PR TITLE
fix(1415): add subscribe

### DIFF
--- a/test/plugins/data/validator.output.json
+++ b/test/plugins/data/validator.output.json
@@ -79,6 +79,7 @@
         ]
     },
     "parameters": {},
+    "subscribe": {},
     "workflowGraph": {
         "nodes": [
             { "name": "~pr" },


### PR DESCRIPTION
## Context
[The test is failing](https://cd.screwdriver.cd/pipelines/1/builds/577299/steps/test) with the following error.
<img width="703" src="https://user-images.githubusercontent.com/24538326/95810068-17ec4300-0d4b-11eb-8ac7-3e1c594db156.png">

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The following PR adds `subscribe` field.
https://github.com/screwdriver-cd/config-parser/pull/109

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1415
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
