### PR TITLE
fix: revert template usage on publish

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -29,16 +29,21 @@ jobs:
 
     publish:
         requires: [main]
-        template: screwdriver-cd/semantic-release
         steps:
-          - postpublish: sd-cmd exec screwdriver/docker-trigger@latest
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
+            - install-ci: npm install npm-auto-version
+            - publish-npm-and-git-tag: ./ci/publish.sh
+            - publish-docker: |
+                export DOCKER_TAG=`cat VERSION`
+                ./ci/docker-trigger.sh
+            - save-tag-to-meta: meta set docker_tag $DOCKER_TAG && meta get docker_tag
         environment:
             DOCKER_REPO: screwdrivercd/screwdriver
         secrets:
             # Publishing to NPM
             - NPM_TOKEN
             # Pushing tags to Git
-            - GH_TOKEN
+            - GIT_KEY
             # Trigger a Docker Hub build
             - DOCKER_TRIGGER
 


### PR DESCRIPTION
## Context

Using the semantic template prevents us from publishing API with changes only in dependencies. 

## Objective

Revert https://github.com/screwdriver-cd/screwdriver/pull/2226

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
