### PR TITLE
fix: bump up scm-base dependency to force new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "screwdriver-models": "^28.3.0",
     "screwdriver-notifications-email": "^2.0.0",
     "screwdriver-notifications-slack": "^3.0.0",
-    "screwdriver-scm-base": "^7.0.0",
+    "screwdriver-scm-base": "^7.1.1",
     "screwdriver-scm-github": "^11.0.1",
     "screwdriver-scm-gitlab": "^2.0.0",
     "screwdriver-scm-router": "^6.0.0",


### PR DESCRIPTION


## Context

When API docker image is being built it's not pulling latest scm-base https://beta.api.screwdriver.cd/v4/versions

My guess is it's because upstream packages like scm-router were built with 7.1.0

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
