### PR TITLE
fix: Bump up API npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-api",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "API server for the Screwdriver.cd service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
API npm package version is updated by [npm-auto-version](https://www.npmjs.com/package/npm-auto-version).
This package updates tag based on version in package.json.
So new tag is `v4.0.X`.
https://github.com/screwdriver-cd/screwdriver/tags
However, we had already tagged `v4.1.0` by template in [this build](https://cd.screwdriver.cd/pipelines/1/builds/578833).
Therefore, we use `v4.1.0` as latest tag instead of `4.0.X`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
