### PR TITLE
fix: allow Swagger to add Bear Token field

### DIFF
--- a/plugins/swagger.js
+++ b/plugins/swagger.js
@@ -13,10 +13,10 @@ const swaggerPlugin = {
                     version: '3'
                 },
                 securityDefinitions: {
-                    token: {
-                        type: 'bearer',
-                        name: 'X-Token',
-                        in: 'header'
+                    'jwt': {
+                        'type': 'apiKey',
+                        'name': 'Authorization',
+                        'in': 'header'
                     }
                 },
                 // see https://github.com/glennjones/hapi-swagger/blob/master/optionsreference.md#json-json-endpoint-needed-to-create-ui
@@ -24,9 +24,9 @@ const swaggerPlugin = {
                     'hapi-rate-limit': {
                         enabled: false
                     }
-                }
-            },
-            security: [{ token: [] }]
+                },
+                security: [{ jwt: [] }]
+            }
         });
     }
 };

--- a/plugins/swagger.js
+++ b/plugins/swagger.js
@@ -13,10 +13,10 @@ const swaggerPlugin = {
                     version: '3'
                 },
                 securityDefinitions: {
-                    'jwt': {
-                        'type': 'apiKey',
-                        'name': 'Authorization',
-                        'in': 'header'
+                    jwt: {
+                        type: 'apiKey',
+                        name: 'Authorization',
+                        in: 'header'
                     }
                 },
                 // see https://github.com/glennjones/hapi-swagger/blob/master/optionsreference.md#json-json-endpoint-needed-to-create-ui


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Allow user to add bear token on `http://localhost:9001/v4/documentation` or `https://api.screwdriver.cd/v4/documentation`

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Before:
![image](https://user-images.githubusercontent.com/15989893/96390805-2bdcde00-116b-11eb-84fe-fe382992a552.png)

After:
![image](https://user-images.githubusercontent.com/15989893/96390893-8d04b180-116b-11eb-954b-096a4f8902c1.png)

![image](https://user-images.githubusercontent.com/15989893/96390785-14055a00-116b-11eb-9d64-6b2cdbf98175.png)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/glennjones/hapi-swagger/issues/602
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
