### PR TITLE
fix!: restrict list pipelines size

### DIFF
--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -50,13 +50,22 @@ module.exports = () => ({
                         // See https://www.w3schools.com/sql/sql_like.asp for syntax
                         keyword: `%${request.query.search}%`
                     };
+                } else {
+                    // default list all to 50 max count, according to schema.api.pagination
+                    config.paginate = {
+                        page: 1,
+                        count: 50
+                    };
                 }
 
-                if (request.query.page || request.query.count) {
-                    config.paginate = {
-                        page: request.query.page,
-                        count: request.query.count
-                    };
+                if (request.query.page) {
+                    config.paginate = config.paginate || {};
+                    config.paginate.page = request.query.page;
+                }
+
+                if (request.query.count) {
+                    config.paginate = config.paginate || {};
+                    config.paginate.count = request.query.count;
                 }
 
                 const pipelines = factory.list(config);

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -347,12 +347,16 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 200 and all pipelines with no pagination', () => {
+        it('returns 200 and pipelines with pagination if no search parameter specified', () => {
             options.url = '/pipelines';
             pipelineFactoryMock.list
                 .withArgs({
                     params: {
                         scmContext: 'github:github.com'
+                    },
+                    paginate: {
+                        page: 1,
+                        count: 50
                     },
                     sort: 'descending'
                 })
@@ -361,6 +365,10 @@ describe('pipeline plugin test', () => {
                 .withArgs({
                     params: {
                         scmContext: 'gitlab:mygitlab'
+                    },
+                    paginate: {
+                        page: 1,
+                        count: 50
                     },
                     sort: 'descending'
                 })
@@ -379,6 +387,10 @@ describe('pipeline plugin test', () => {
                     params: {
                         scmContext: 'github:github.com'
                     },
+                    paginate: {
+                        page: 1,
+                        count: 50
+                    },
                     sort: 'ascending'
                 })
                 .resolves(getPipelineMocks(testPipelines));
@@ -386,6 +398,10 @@ describe('pipeline plugin test', () => {
                 .withArgs({
                     params: {
                         scmContext: 'gitlab:mygitlab'
+                    },
+                    paginate: {
+                        page: 1,
+                        count: 50
                     },
                     sort: 'ascending'
                 })
@@ -404,6 +420,10 @@ describe('pipeline plugin test', () => {
                     params: {
                         scmContext: 'github:github.com'
                     },
+                    paginate: {
+                        page: 1,
+                        count: 50
+                    },
                     sort: 'ascending',
                     sortBy: 'name'
                 })
@@ -412,6 +432,10 @@ describe('pipeline plugin test', () => {
                 .withArgs({
                     params: {
                         scmContext: 'gitlab:mygitlab'
+                    },
+                    paginate: {
+                        page: 1,
+                        count: 50
                     },
                     sort: 'ascending',
                     sortBy: 'name'


### PR DESCRIPTION
## Context

list pipelines may return enormous data given large enough cluster, and it's better to put default size limiting in place

## Objective

default pagination for list pipelines without search query

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
