### PR TITLE
feat: add cookie timeout config

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -305,6 +305,7 @@ release:
     mode: stable
     cookieName: release
     cookieValue: stable
+    cookieTimeout: 2 # in minutes
     headerName: release
     headerValue: stable
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -146,7 +146,7 @@ module.exports = async config => {
         if (config.release && config.release.cookieName) {
             server.state(config.release.cookieName, {
                 path: '/',
-                ttl: (config.auth.sessionTimeout / 60) * 60 * 1000, // setting to 2 minutes
+                ttl: config.release.cookieTimeout * 60 * 1000, // (2 mins)
                 isSecure: config.auth.https,
                 isHttpOnly: !config.auth.https
             });

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -33,7 +33,8 @@ describe('server case', () => {
         },
         release: {
             cookieName: 'test_cookie',
-            cookieValue: 'test_value'
+            cookieValue: 'test_value',
+            cookieTimeout: 2
         }
     };
 


### PR DESCRIPTION
## Context

Cookie timeout should be controlled via separate config 

## Objective

This PR adds a cookie timeout in config

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
