### PR TITLE
fix(): Fix missing token error in create endpoint

### DIFF
--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -23,7 +23,6 @@ module.exports = () => ({
             const { autoKeysGeneration } = request.payload;
             const { pipelineFactory, userFactory, collectionFactory, secretFactory } = request.server.app;
             const { username, scmContext } = request.auth.credentials;
-            const pipelineToken = '';
             const deployKeySecret = 'SD_SCM_DEPLOY_KEY';
 
             // fetch the user
@@ -97,7 +96,7 @@ module.exports = () => ({
                 const privateDeployKey = await pipelineFactory.scm.addDeployKey({
                     scmContext,
                     checkoutUrl,
-                    token: pipelineToken
+                    token
                 });
                 const privateDeployKeyB64 = Buffer.from(privateDeployKey).toString('base64');
 


### PR DESCRIPTION
## Context

## Objective

This PR fixes the missing token error in the create pipeline endpoint of the API

## References

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
