### PR TITLE
feat(2267): use list instead calling get individually

### DIFF
--- a/plugins/collections/get.js
+++ b/plugins/collections/get.js
@@ -38,15 +38,16 @@ module.exports = () => ({
                         result.type = 'normal';
                     }
 
-                    // Store promises from pipelineFactory fetch operations
-                    const collectionPipelines = [];
-
-                    result.pipelineIds.forEach(id => {
-                        collectionPipelines.push(pipelineFactory.get(id));
-                    });
+                    const listConfig = {
+                        search: {
+                            field: 'id',
+                            keyword: collection.pipelineIds
+                        }
+                    };
 
                     return (
-                        Promise.all(collectionPipelines)
+                        pipelineFactory
+                            .list(listConfig)
                             // to filter out null
                             .then(pipelines => pipelines.filter(pipeline => pipeline))
                             .then(pipelines => {

--- a/test/plugins/collections.test.js
+++ b/test/plugins/collections.test.js
@@ -46,6 +46,23 @@ const getPipelineMockFromId = id => {
     return Promise.resolve(result);
 };
 
+const listPipelines = config => {
+    const result = [];
+
+    config.search.keyword.forEach(id => {
+        let pipelineMock = null;
+
+        testPipelines.forEach(pipeline => {
+            if (pipeline.id === id) {
+                pipelineMock = hoek.clone(pipeline);
+            }
+        });
+        result.push(pipelineMock);
+    });
+
+    return Promise.resolve(result);
+};
+
 const getUserMock = user => {
     const mock = hoek.clone(user);
 
@@ -84,7 +101,8 @@ describe('collection plugin test', () => {
             get: sinon.stub().resolves(null)
         };
         pipelineFactoryMock = {
-            get: sinon.stub()
+            get: sinon.stub(),
+            list: sinon.stub()
         };
         userFactoryMock = {
             get: sinon.stub()
@@ -105,6 +123,7 @@ describe('collection plugin test', () => {
         });
         userFactoryMock.get.withArgs({ username, scmContext }).resolves(userMock);
         pipelineFactoryMock.get.callsFake(getPipelineMockFromId);
+        pipelineFactoryMock.list.callsFake(listPipelines);
 
         mockery.registerMock('screwdriver-logger', loggerMock);
 


### PR DESCRIPTION
## Context
Currently we call pipelineFactory.get() multiple time to get all pipeline under a collection, it's time to move to one single call to pipelineFactory.list()
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
move to pipelineFactory.list()
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2267
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
