### PR TITLE
feat(1826):Clickable URLs in console output

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "sqlite3": "^5.0.0",
     "tinytim": "^0.1.1",
     "uuid": "^8.3.1",
+    "validator": "^13.5.1",
     "verror": "^1.6.1"
   },
   "release": {

--- a/test/plugins/data/step.html.log.ndjson
+++ b/test/plugins/data/step.html.log.ndjson
@@ -1,0 +1,4 @@
+{"t":1472236246000,"m":"<script> alert('xss&doom'); </script>","n":0}
+{"t":1472236247000,"m":"<script> alert(\"xss&doom\"); </script>","n":1}
+{"t":1472236248000,"m":"Backtick: `","n":2}
+{"t":1472236249000,"m":"Backslash: \\","n":3}

--- a/test/plugins/data/step.url.log.ndjson
+++ b/test/plugins/data/step.url.log.ndjson
@@ -1,0 +1,2 @@
+{"t":1472236240000,"m":"http:// link http://github.com","n":0}
+{"t":1472236241000,"m":"https:// link https://github.com","n":1}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When the build console log for a job contains URLs, it is rendered as plain text
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Replace urls in with anchor link and escape rest of log message.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1826
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
