### PR TITLE
fix(2312): add latest to template and command

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "screwdriver-config-parser": "^6.3.0",
     "screwdriver-coverage-bookend": "^1.0.3",
     "screwdriver-coverage-sonar": "^3.0.0",
-    "screwdriver-data-schema": "^20.8.0",
+    "screwdriver-data-schema": "^21.0.0",
     "screwdriver-datastore-sequelize": "^7.1.0",
     "screwdriver-executor-base": "^8.1.0",
     "screwdriver-executor-docker": "^5.0.0",

--- a/plugins/commands/list.js
+++ b/plugins/commands/list.js
@@ -72,7 +72,11 @@ module.exports = () => ({
             if (compact === 'true') {
                 // removing `config` trims most of the bytes
                 config.exclude = ['usage', 'docker', 'habitat', 'binary'];
-                config.groupBy = ['namespace', 'name'];
+                if (config.params) {
+                    config.params.latestVersion = true;
+                } else {
+                    config.params = { latestVersion: true };
+                }
             }
 
             return factory

--- a/plugins/commands/list.js
+++ b/plugins/commands/list.js
@@ -72,11 +72,11 @@ module.exports = () => ({
             if (compact === 'true') {
                 // removing `config` trims most of the bytes
                 config.exclude = ['usage', 'docker', 'habitat', 'binary'];
-                if (config.params) {
-                    config.params.latestVersion = true;
-                } else {
-                    config.params = { latestVersion: true };
-                }
+                // using spread operator because params could be null
+                config.params = {
+                    ...config.params,
+                    latest: true
+                };
             }
 
             return factory

--- a/plugins/templates/list.js
+++ b/plugins/templates/list.js
@@ -68,7 +68,11 @@ module.exports = () => ({
             if (compact === 'true') {
                 // removing `config` trims most of the bytes
                 config.exclude = ['config'];
-                config.groupBy = ['namespace', 'name'];
+                if (config.params) {
+                    config.params.latestVersion = true;
+                } else {
+                    config.params = { latestVersion: true };
+                }
             }
 
             if (page || count) {

--- a/plugins/templates/list.js
+++ b/plugins/templates/list.js
@@ -68,11 +68,11 @@ module.exports = () => ({
             if (compact === 'true') {
                 // removing `config` trims most of the bytes
                 config.exclude = ['config'];
-                if (config.params) {
-                    config.params.latestVersion = true;
-                } else {
-                    config.params = { latestVersion: true };
-                }
+                // using spread operator because params could be null
+                config.params = {
+                    ...config.params,
+                    latest: true
+                };
             }
 
             if (page || count) {

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -240,7 +240,7 @@ describe('command plugin test', () => {
                 assert.deepEqual(reply.result, testcommands);
                 assert.calledWith(commandFactoryMock.list, {
                     exclude: ['usage', 'docker', 'habitat', 'binary'],
-                    params: { latestVersion: true },
+                    params: { latest: true },
                     sort: 'descending'
                 });
             });

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -240,7 +240,7 @@ describe('command plugin test', () => {
                 assert.deepEqual(reply.result, testcommands);
                 assert.calledWith(commandFactoryMock.list, {
                     exclude: ['usage', 'docker', 'habitat', 'binary'],
-                    groupBy: ['namespace', 'name'],
+                    params: { latestVersion: true },
                     sort: 'descending'
                 });
             });

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -235,7 +235,7 @@ describe('template plugin test', () => {
                 assert.deepEqual(reply.result, testtemplates);
                 assert.calledWith(templateFactoryMock.list, {
                     exclude: ['config'],
-                    groupBy: ['namespace', 'name'],
+                    params: { latestVersion: true }, 
                     sort: 'descending'
                 });
             });

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -235,7 +235,7 @@ describe('template plugin test', () => {
                 assert.deepEqual(reply.result, testtemplates);
                 assert.calledWith(templateFactoryMock.list, {
                     exclude: ['config'],
-                    params: { latestVersion: true }, 
+                    params: { latest: true },
                     sort: 'descending'
                 });
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
adding a new field `latest` to template and command
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
use `latest` to query compact mode instead of groupby
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2312

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
