### PR TITLE
feat(2319): [3] Support template composition

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -116,7 +116,7 @@ module.exports = async config => {
             }
         });
 
-        // Set the factorys within server.app
+        // Set the factories within server.app
         // Instantiating the server with the factories will apply a shallow copy
         server.app = {
             commandFactory: config.commandFactory,

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "screwdriver-scm-github": "^11.1.0",
     "screwdriver-scm-gitlab": "^2.1.0",
     "screwdriver-scm-router": "^6.1.0",
-    "screwdriver-template-validator": "^4.0.0",
+    "screwdriver-template-validator": "^5.0.0",
     "screwdriver-workflow-parser": "^3.1.1",
     "sqlite3": "^5.0.0",
     "tinytim": "^0.1.1",

--- a/plugins/template-validator.js
+++ b/plugins/template-validator.js
@@ -30,9 +30,10 @@ const templateValidatorPlugin = {
                 },
                 handler: async (request, h) => {
                     try {
-                        const templateString = request.payload.yaml;
+                        const { templateFactory } = request.server.app;
+                        const { yaml: templateString } = request.payload;
 
-                        const result = await validator(templateString);
+                        const result = await validator(templateString, templateFactory);
 
                         return h.response(result);
                     } catch (err) {

--- a/plugins/templates/create.js
+++ b/plugins/templates/create.js
@@ -19,8 +19,10 @@ module.exports = () => ({
             scope: ['build']
         },
 
-        handler: (request, h) =>
-            validator(request.payload.yaml)
+        handler: (request, h) => {
+            const { pipelineFactory, templateFactory } = request.server.app;
+
+            return validator(request.payload.yaml, templateFactory)
                 .then(config => {
                     if (config.errors.length > 0) {
                         throw boom.badRequest(
@@ -29,10 +31,7 @@ module.exports = () => ({
                         );
                     }
 
-                    const { pipelineFactory } = request.server.app;
-                    const { templateFactory } = request.server.app;
-                    const { pipelineId } = request.auth.credentials;
-                    const { isPR } = request.auth.credentials;
+                    const { isPR, pipelineId } = request.auth.credentials;
                     // Search using namespace if it is passed in
                     const listOptions = config.template.namespace
                         ? {
@@ -77,7 +76,8 @@ module.exports = () => ({
                 })
                 .catch(err => {
                     throw err;
-                }),
+                });
+        },
         validate: {
             payload: templateSchema.input
         }

--- a/plugins/templates/createTag.js
+++ b/plugins/templates/createTag.js
@@ -22,13 +22,9 @@ module.exports = () => ({
         },
 
         handler: async (request, h) => {
-            const { pipelineFactory } = request.server.app;
-            const { templateFactory } = request.server.app;
-            const { templateTagFactory } = request.server.app;
-            const { pipelineId } = request.auth.credentials;
-            const { isPR } = request.auth.credentials;
-            const name = request.params.templateName;
-            const tag = request.params.tagName;
+            const { pipelineFactory, templateFactory, templateTagFactory } = request.server.app;
+            const { isPR, pipelineId } = request.auth.credentials;
+            const { templateName: name, tagName: tag } = request.params;
             const { version } = request.payload;
 
             return Promise.all([


### PR DESCRIPTION
## Context

Would be nice if template owners could base their templates on other templates.

## Objective

This PR passes in the template factory to the template validator so the template can be fetched and flattened.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319
Blocked by https://github.com/screwdriver-cd/template-validator/pull/23

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
