### PR TITLE
fix(2312): allow fetching total count of template/command

### DIFF
--- a/plugins/commands/README.md
+++ b/plugins/commands/README.md
@@ -42,8 +42,8 @@ Can search by keyword in command name, namespace, and description:
 Can list all distinct command namespaces:
 `GET /commands?distinct=namespace`
 
-Can use additional options for sorting and pagination:
-`GET /commands?sort=ascending&sortBy=name&page=1&count=50`
+Can use additional options for sorting, pagination and return total count:
+`GET /commands?sort=ascending&sortBy=name&page=1&count=50&getCount=true`
 
 ##### Get all command versions
 

--- a/plugins/templates/README.md
+++ b/plugins/templates/README.md
@@ -41,8 +41,8 @@ Can search by keyword in template name, namespace, and description:
 Can list all distinct template namespaces:
 `GET /templates?distinct=namespace`
 
-Can use additional options for sorting and pagination:
-`GET /templates?sort=ascending&sortBy=name&page=1&count=50`
+Can use additional options for sorting, pagination and get toal count:
+`GET /templates?sort=ascending&sortBy=name&page=1&count=50&getCount=true`
 
 ##### Get a single template
 

--- a/plugins/templates/README.md
+++ b/plugins/templates/README.md
@@ -41,7 +41,7 @@ Can search by keyword in template name, namespace, and description:
 Can list all distinct template namespaces:
 `GET /templates?distinct=namespace`
 
-Can use additional options for sorting, pagination and get toal count:
+Can use additional options for sorting, pagination and get total count:
 `GET /templates?sort=ascending&sortBy=name&page=1&count=50&getCount=true`
 
 ##### Get a single template

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -281,6 +281,29 @@ describe('command plugin test', () => {
             });
         });
 
+        it('returns 200 and all commands with count', () => {
+            const commandMocks = getCommandMocks(testcommands);
+            const resultMock = {
+                count: 123,
+                rows: commandMocks
+            };
+
+            commandFactoryMock.list.resolves(resultMock);
+            options.url = '/commands?getCount=true';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, '200');
+                assert.deepEqual(reply.result, {
+                    count: 123,
+                    rows: testcommands
+                });
+                assert.calledWith(commandFactoryMock.list, {
+                    getCount: true,
+                    sort: 'descending'
+                });
+            });
+        });
+
         it('returns 500 when datastore fails', () => {
             commandFactoryMock.list.rejects(new Error('fittoburst'));
 

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -276,6 +276,29 @@ describe('template plugin test', () => {
             });
         });
 
+        it('returns 200 and all templates with count', () => {
+            const templateMocks = getTemplateMocks(testtemplates);
+            const resultMock = {
+                count: 123,
+                rows: templateMocks
+            };
+
+            templateFactoryMock.list.resolves(resultMock);
+            options.url = '/templates?getCount=true';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, {
+                    count: 123,
+                    rows: testtemplates
+                });
+                assert.calledWith(templateFactoryMock.list, {
+                    getCount: true,
+                    sort: 'descending'
+                });
+            });
+        });
+
         it('returns 500 when datastore fails', () => {
             templateFactoryMock.list.rejects(new Error('fittoburst'));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
It would be nice if we can get total count when paginating template/commands
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add support to return count in addition to template/commands

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2312
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
