### PR TITLE
feat(2339): [3] Add feature flag for throwing notifications validation errs

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -4,7 +4,6 @@
 
 /* eslint-disable import/no-dynamic-require */
 const config = require('config');
-const server = require('../');
 const hoek = require('@hapi/hoek');
 const { Bookend } = require('screwdriver-build-bookend');
 const logger = require('screwdriver-logger');
@@ -53,19 +52,21 @@ const multiBuildClusterEnabled = convertToBool(config.get('multiBuildCluster').e
 
 // Default cluster environment variable
 const clusterEnvConfig = config.get('build').environment; // readonly
-const clusterEnv = Object.assign({}, clusterEnvConfig);
+const clusterEnv = { ...clusterEnvConfig };
 
-Object.keys(clusterEnv).forEach((k) => {
+Object.keys(clusterEnv).forEach(k => {
     clusterEnv[k] = String(clusterEnv[k]);
 });
 
-const externalJoin = config.get('build').externalJoin; // flag to allow external join
+const { externalJoin } = config.get('build'); // flag to allow external join
+
+const notificationsValidationErr = hoek.reach(config.get('notifications').options, 'throwValidationErr'); // flag to throw notifications validation err or not
 
 // Setup Datastore
 const datastoreConfig = config.get('datastore');
 const DatastorePlugin = require(`screwdriver-datastore-${datastoreConfig.plugin}`);
 
-const datastorePluginConfig = Object.assign({}, datastoreConfig[datastoreConfig.plugin]);
+const datastorePluginConfig = { ...datastoreConfig[datastoreConfig.plugin] };
 
 // Readonly Datastore
 const datastoreROConfig = datastorePluginConfig.readOnly;
@@ -77,8 +78,7 @@ if (datastoreROConfig && Object.keys(datastoreROConfig).length > 0) {
 delete datastorePluginConfig.readOnly;
 
 // Default datastore
-const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem },
-    (datastorePluginConfig || {})));
+const datastore = new DatastorePlugin(hoek.applyToDefaults({ ecosystem }, datastorePluginConfig || {}));
 
 // Source Code Plugin
 const scmConfig = { scms: config.get('scms') };
@@ -102,22 +102,25 @@ const coverage = new CoveragePlugin(coverageConfig);
 
 // Plugins to run before/after a build
 const bookends = config.get('bookends');
-const bookend = new Bookend({
-    scm,
-    'screwdriver-artifact-bookend': artifact,
-    'screwdriver-coverage-bookend': coverage,
-    'screwdriver-cache-bookend': cache
-},
+const bookend = new Bookend(
+    {
+        scm,
+        'screwdriver-artifact-bookend': artifact,
+        'screwdriver-coverage-bookend': coverage,
+        'screwdriver-cache-bookend': cache
+    },
     bookends.setup || [], // plugins required for the setup- steps
     bookends.teardown || [] // plugins required for the teardown-steps
 );
 
 // Setup Pipeline Factory for Executor
 const Models = require('screwdriver-models');
+const server = require('..');
 const pipelineFactory = Models.PipelineFactory.getInstance({
     datastore,
     scm,
     externalJoin,
+    notificationsValidationErr,
     multiBuildClusterEnabled
 });
 
@@ -126,10 +129,10 @@ const executorConfig = config.get('executor');
 
 executorConfig[executorConfig.plugin].options.pipelineFactory = pipelineFactory;
 const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);
-const executor = new ExecutorPlugin(Object.assign(
-    { ecosystem: hoek.clone(ecosystem) },
-    executorConfig[executorConfig.plugin].options
-));
+const executor = new ExecutorPlugin({
+    ecosystem: hoek.clone(ecosystem),
+    ...executorConfig[executorConfig.plugin].options
+});
 
 // Setup Model Factories
 const commandFactory = Models.CommandFactory.getInstance({
@@ -210,8 +213,8 @@ const buildClusterFactory = Models.BuildClusterFactory.getInstance({
 
 // @TODO run setup for SCM and Executor
 // datastoreConfig.ddlSync => sync datastore schema (ddl) via api (default: true)
-datastore.setup(datastoreConfig.ddlSyncEnabled)
-    .then(() => server({
+datastore.setup(datastoreConfig.ddlSyncEnabled).then(() =>
+    server({
         httpd: httpdConfig,
         auth: authConfig,
         webhooks: webhooksConfig,
@@ -242,12 +245,14 @@ datastore.setup(datastoreConfig.ddlSyncEnabled)
             externalJoin
         },
         stats: {
-            executor, scm
+            executor,
+            scm
         },
         release
-    }))
-    .then(instance => logger.info('Server running at %s', instance.info.uri))
-    .catch((err) => {
-        logger.error(err);
-        process.exit(1);
-    });
+    })
+        .then(instance => logger.info('Server running at %s', instance.info.uri))
+        .catch(err => {
+            logger.error(err);
+            process.exit(1);
+        })
+);

--- a/bin/server
+++ b/bin/server
@@ -248,7 +248,11 @@ datastore.setup(datastoreConfig.ddlSyncEnabled).then(() =>
             executor,
             scm
         },
-        release
+        release,
+        validator: {
+            externalJoin,
+            notificationsValidationErr
+        }
     })
         .then(instance => logger.info('Server running at %s', instance.info.uri))
         .catch(err => {

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -268,14 +268,17 @@ bookends:
     - screwdriver-cache-bookend
 
 notifications:
-  # Email notification when a build finishes
+  # options:
+  #   # Throw error when validation fails (default true); otherwise show warning
+  #   throwValidationErr: true
+  # # Email notification when a build finishes
   # email:
   #   host: email-host
   #   port: email-port
   #   from: email-address-to-send-from
   #   username: optional-username
   #   password: optional-password
-  # Slack notification when build finishes
+  # # Slack notification when build finishes
   # slack:
   #   token: your-slack-bot-token
 ecosystem:
@@ -301,7 +304,7 @@ ecosystem:
     max_go_threads: 10000
 
 # environment release information
-release: 
+release:
     mode: stable
     cookieName: release
     cookieValue: stable

--- a/lib/registerPlugins.js
+++ b/lib/registerPlugins.js
@@ -137,18 +137,20 @@ function registerNotificationEvent(config, server) {
     const notificationConfig = config.notifications || {};
 
     Object.keys(notificationConfig).forEach(plugin => {
-        const Plugin = requireNotificationPlugin(notificationConfig[plugin], plugin);
-        let notificationPlugin;
+        if (plugin !== 'options') {
+            const Plugin = requireNotificationPlugin(notificationConfig[plugin], plugin);
+            let notificationPlugin;
 
-        if (notificationConfig[plugin].config) {
-            notificationPlugin = new Plugin(notificationConfig[plugin].config);
-        } else {
-            notificationPlugin = new Plugin(notificationConfig[plugin]);
+            if (notificationConfig[plugin].config) {
+                notificationPlugin = new Plugin(notificationConfig[plugin].config);
+            } else {
+                notificationPlugin = new Plugin(notificationConfig[plugin]);
+            }
+
+            notificationPlugin.events.forEach(event => {
+                server.events.on(event, buildData => notificationPlugin.notify(buildData));
+            });
         }
-
-        notificationPlugin.events.forEach(event => {
-            server.events.on(event, buildData => notificationPlugin.notify(buildData));
-        });
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "screwdriver-build-bookend": "^2.3.2",
     "screwdriver-cache-bookend": "^2.0.0",
     "screwdriver-command-validator": "^2.0.0",
-    "screwdriver-config-parser": "^6.3.0",
+    "screwdriver-config-parser": "^7.0.0",
     "screwdriver-coverage-bookend": "^1.0.3",
     "screwdriver-coverage-sonar": "^3.0.0",
     "screwdriver-data-schema": "^21.0.0",

--- a/plugins/stats.js
+++ b/plugins/stats.js
@@ -12,8 +12,7 @@ const schema = require('screwdriver-data-schema');
 const statsPlugin = {
     name: 'stats',
     async register(server, options) {
-        const { executor } = options;
-        const { scm } = options;
+        const { executor, scm } = options;
 
         server.route({
             method: 'GET',

--- a/plugins/validator.js
+++ b/plugins/validator.js
@@ -14,7 +14,7 @@ const validatorSchema = schema.api.validator;
  */
 const validatorTemplate = {
     name: 'validator',
-    async register(server) {
+    async register(server, options) {
         server.route({
             method: 'POST',
             path: '/validator',
@@ -27,12 +27,18 @@ const validatorTemplate = {
                         enabled: false
                     }
                 },
-                handler: async (request, h) =>
-                    parser(
-                        request.payload.yaml,
-                        request.server.app.templateFactory,
-                        request.server.app.buildClusterFactory
-                    ).then(pipeline => h.response(pipeline)),
+                handler: async (request, h) => {
+                    const { notificationsValidationErr } = options;
+                    const { buildClusterFactory, templateFactory } = request.server.app;
+
+                    // TODO: Handle externalJoin case (pass in triggerFactory and pipelineId)
+                    return parser({
+                        yaml: request.payload.yaml,
+                        templateFactory,
+                        buildClusterFactory,
+                        notificationsValidationErr
+                    }).then(pipeline => h.response(pipeline));
+                },
                 validate: {
                     payload: validatorSchema.input
                 },


### PR DESCRIPTION
## Context

Would be nice if there was an option to not fail build if slack/email notifications are invalid.

## Objective

This PR adds new flag under `notifications` config to determine if invalid notifications configs should throw error or return warning. Default `true` (throw error).

```
notifications:
    options:
         throwValidationErr: false
    email:
        ...
    slack:
        ...
```
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2339
Blocked by https://github.com/screwdriver-cd/models/pull/488

## License

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
