### PR TITLE
fix: remove user id from url param

### DIFF
--- a/plugins/users/settings/get.js
+++ b/plugins/users/settings/get.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const boom = require('@hapi/boom');
-const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const idSchema = schema.models.user.base.extract('id');
 const getSchema = schema.models.user.base.extract('settings');
 
 module.exports = () => ({

--- a/plugins/users/settings/get.js
+++ b/plugins/users/settings/get.js
@@ -8,7 +8,7 @@ const getSchema = schema.models.user.base.extract('settings');
 
 module.exports = () => ({
     method: 'GET',
-    path: '/users/{id}/settings',
+    path: '/users/settings',
     options: {
         description: 'Get user settings',
         notes: 'Returns user settings record',
@@ -20,22 +20,19 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { userFactory } = request.server.app;
-            const user = await userFactory.get(request.params.id);
+            const { scmContext, username } = request.auth.credentials;
+            const user = await userFactory.get({ username, scmContext });
 
             if (!user) {
                 throw boom.notFound('User does not exist');
             }
+
             const userSettings = user.getSettings();
 
             return h.response(userSettings);
         },
         response: {
             schema: getSchema
-        },
-        validate: {
-            params: joi.object({
-                id: idSchema
-            })
         }
     }
 });

--- a/plugins/users/settings/get.js
+++ b/plugins/users/settings/get.js
@@ -2,7 +2,6 @@
 
 const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
-const logger = require('screwdriver-logger');
 const getSchema = schema.models.user.base.extract('settings');
 
 module.exports = () => ({
@@ -20,22 +19,15 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { userFactory } = request.server.app;
             const { scmContext, username } = request.auth.credentials;
+            const user = await userFactory.get({ username, scmContext });
 
-            try {
-                const user = await userFactory.get({ username, scmContext });
-
-                if (!user) {
-                    throw boom.notFound('User does not exist');
-                }
-
-                const userSettings = user.getSettings();
-
-                return h.response(userSettings);
-            } catch (err) {
-                logger.info(err.message);
+            if (!user) {
+                throw boom.notFound('User does not exist');
             }
 
-            return Promise.resolve();
+            const userSettings = user.getSettings();
+
+            return h.response(userSettings);
         },
         response: {
             schema: getSchema

--- a/plugins/users/settings/update.js
+++ b/plugins/users/settings/update.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const boom = require('@hapi/boom');
-const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const updateSchema = schema.models.user.base.extract('settings');
-const idSchema = schema.models.user.base.extract('id');
 
 module.exports = () => ({
     method: 'PUT',

--- a/plugins/users/settings/update.js
+++ b/plugins/users/settings/update.js
@@ -8,7 +8,7 @@ const idSchema = schema.models.user.base.extract('id');
 
 module.exports = () => ({
     method: 'PUT',
-    path: '/users/{id}/settings',
+    path: '/users/settings',
     options: {
         description: 'Update user settings',
         notes: 'Update a specific users settings',
@@ -20,16 +20,12 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { userFactory } = request.server.app;
-            const { username } = request.auth.credentials;
+            const { scmContext, username } = request.auth.credentials;
             const { settings } = request.payload;
-            const user = await userFactory.get(request.params.id);
+            const user = await userFactory.get({ username, scmContext });
 
             if (!user) {
                 throw boom.notFound('User does not exist');
-            }
-
-            if (user.username !== username) {
-                throw boom.forbidden(`User ${username} cannot update user settings for user ${user.username}`);
             }
 
             return user.updateSettings(settings).then(results => {
@@ -38,11 +34,6 @@ module.exports = () => ({
         },
         response: {
             schema: updateSchema
-        },
-        validate: {
-            params: joi.object({
-                id: idSchema
-            })
         }
     }
 });

--- a/plugins/users/settings/update.js
+++ b/plugins/users/settings/update.js
@@ -2,7 +2,6 @@
 
 const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
-const logger = require('screwdriver-logger');
 const updateSchema = schema.models.user.base.extract('settings');
 
 module.exports = () => ({
@@ -10,7 +9,7 @@ module.exports = () => ({
     path: '/users/settings',
     options: {
         description: 'Update user settings',
-        notes: 'Update a specific users settings',
+        notes: 'Update user settings',
         tags: ['api', 'users'],
         auth: {
             strategies: ['token'],
@@ -21,22 +20,15 @@ module.exports = () => ({
             const { userFactory } = request.server.app;
             const { scmContext, username } = request.auth.credentials;
             const { settings } = request.payload;
+            const user = await userFactory.get({ username, scmContext });
 
-            try {
-                const user = await userFactory.get({ username, scmContext });
-
-                if (!user) {
-                    throw boom.notFound('User does not exist');
-                }
-
-                return user.updateSettings(settings).then(results => {
-                    return h.response(results).code(200);
-                });
-            } catch (err) {
-                logger.info(err.message);
+            if (!user) {
+                throw boom.notFound('User does not exist');
             }
 
-            return Promise.resolve();
+            return user.updateSettings(settings).then(results => {
+                return h.response(results).code(200);
+            });
         },
         response: {
             schema: updateSchema

--- a/test/plugins/user.test.js
+++ b/test/plugins/user.test.js
@@ -210,13 +210,5 @@ describe('user plugin test', () => {
                 assert.equal(reply.statusCode, 500);
             });
         });
-
-        it('throws error when get user does not have permission to update settings', () => {
-            userFactoryMock.get.resolves(getUserMock({ username: 'otherUser', scmContext }));
-
-            return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 403);
-            });
-        });
     });
 });

--- a/test/plugins/user.test.js
+++ b/test/plugins/user.test.js
@@ -80,22 +80,24 @@ describe('user plugin test', () => {
         assert.isOk(server.registrations.users);
     });
 
-    describe('GET /user/{id}/settings', () => {
-        const id = 123;
+    describe('GET /user/settings', () => {
         let options;
 
         beforeEach(() => {
             options = {
                 method: 'GET',
-                url: `/users/${id}/settings`
+                url: `/users/settings`
             };
             settings = {
-                displayJobNameLength: 25
+                1: {
+                    displayJobNameLength: 25,
+                    showPRJobs: true
+                }
             };
         });
 
         it('exposes a route for updating user settings', () => {
-            userFactoryMock.get.withArgs(id).resolves(userMock);
+            userFactoryMock.get.withArgs(username).resolves(userMock);
             userMock.getSettings.returns(settings);
 
             return server.inject(options).then(reply => {
@@ -111,7 +113,7 @@ describe('user plugin test', () => {
                 message: 'User does not exist'
             };
 
-            userFactoryMock.get.withArgs(id).resolves(null);
+            userFactoryMock.get.resolves(null);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
@@ -120,7 +122,7 @@ describe('user plugin test', () => {
         });
 
         it('throws error when get user call returns error', () => {
-            userFactoryMock.get.withArgs(id).rejects(new Error('Failed'));
+            userFactoryMock.get.rejects(new Error('Failed'));
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 500);
@@ -128,7 +130,7 @@ describe('user plugin test', () => {
         });
 
         it('throws error when get user settings call returns error', () => {
-            userFactoryMock.get.withArgs(id).resolves(userMock);
+            userFactoryMock.get.resolves(userMock);
             userMock.getSettings.throws(new Error('Failed'));
 
             return server.inject(options).then(reply => {
@@ -137,15 +139,19 @@ describe('user plugin test', () => {
         });
     });
 
-    describe('PUT /user/{id}/settings', () => {
-        const id = 123;
+    describe('PUT /user/settings', () => {
         let options;
 
         beforeEach(() => {
             options = {
                 method: 'PUT',
-                url: `/users/${id}/settings`,
-                payload: { displayJobNameLength: 50 },
+                url: `/users/settings`,
+                payload: {
+                    1: {
+                        displayJobNameLength: 50,
+                        showPRJobs: false
+                    }
+                },
                 auth: {
                     credentials: {
                         username,
@@ -156,12 +162,15 @@ describe('user plugin test', () => {
                 }
             };
             settings = {
-                displayJobNameLength: 50
+                1: {
+                    displayJobNameLength: 50,
+                    showPRJobs: false
+                }
             };
         });
 
         it('exposes a route for updating user settings', () => {
-            userFactoryMock.get.withArgs(id).resolves(userMock);
+            userFactoryMock.get.resolves(userMock);
             userMock.updateSettings.resolves(settings);
 
             return server.inject(options).then(reply => {
@@ -177,7 +186,7 @@ describe('user plugin test', () => {
                 message: 'User does not exist'
             };
 
-            userFactoryMock.get.withArgs(id).resolves(null);
+            userFactoryMock.get.resolves(null);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
@@ -186,7 +195,7 @@ describe('user plugin test', () => {
         });
 
         it('throws error when get user call returns error', () => {
-            userFactoryMock.get.withArgs(id).rejects(new Error('Failed'));
+            userFactoryMock.get.rejects(new Error('Failed'));
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 500);
@@ -194,7 +203,7 @@ describe('user plugin test', () => {
         });
 
         it('throws error when update user settings call returns error', () => {
-            userFactoryMock.get.withArgs(id).resolves(userMock);
+            userFactoryMock.get.resolves(userMock);
             userMock.updateSettings.rejects(new Error('Failed'));
 
             return server.inject(options).then(reply => {
@@ -203,7 +212,7 @@ describe('user plugin test', () => {
         });
 
         it('throws error when get user does not have permission to update settings', () => {
-            userFactoryMock.get.withArgs(id).resolves(getUserMock({ username: 'otherUser', scmContext }));
+            userFactoryMock.get.resolves(getUserMock({ username: 'otherUser', scmContext }));
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 403);

--- a/test/plugins/user.test.js
+++ b/test/plugins/user.test.js
@@ -97,7 +97,7 @@ describe('user plugin test', () => {
         });
 
         it('exposes a route for updating user settings', () => {
-            userFactoryMock.get.withArgs(username).resolves(userMock);
+            userFactoryMock.get.resolves(userMock);
             userMock.getSettings.returns(settings);
 
             return server.inject(options).then(reply => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
userId is not exposed to UI easily, and I was able to find my userId by using the return value of creating a pipeline collection. 
## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Backend needs to find the user by using its username and scmContext
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/ui/pull/671
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
