### PR TITLE
fix(2354): Should be able to start with default.yaml

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -268,9 +268,9 @@ bookends:
     - screwdriver-cache-bookend
 
 notifications:
-  # options:
-  #   # Throw error when validation fails (default true); otherwise show warning
-  #   throwValidationErr: true
+  options:
+    # Throw error when validation fails (default true); otherwise show warning
+    throwValidationErr: true
   # # Email notification when a build finishes
   # email:
   #   host: email-host


### PR DESCRIPTION
## Context

Should not throw error when starting with default.yaml.

## Objective

This PR uncomments the `options` section under notifications to try to fix the start up error.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2354

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
