### PR TITLE
fix(2356): pass executor plugin name to build factory

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -171,6 +171,7 @@ const buildFactory = Models.BuildFactory.getInstance({
     dockerRegistry: ecosystem.dockerRegistry,
     scm,
     executor,
+    executorName: executorConfig.plugin,
     bookend,
     uiUri: ecosystem.ui,
     multiBuildClusterEnabled,

--- a/bin/server
+++ b/bin/server
@@ -137,6 +137,8 @@ const executor = new ExecutorPlugin({
     ...executorConfig[executorConfig.plugin].options
 });
 
+executor.name = executorConfig.plugin;
+
 // Setup Model Factories
 const commandFactory = Models.CommandFactory.getInstance({
     datastore,
@@ -171,7 +173,6 @@ const buildFactory = Models.BuildFactory.getInstance({
     dockerRegistry: ecosystem.dockerRegistry,
     scm,
     executor,
-    executorName: executorConfig.plugin,
     bookend,
     uiUri: ecosystem.ui,
     multiBuildClusterEnabled,


### PR DESCRIPTION
## Context

To have local development work, pass executor name to build factory to choose token scope.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/issues/2356

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
