### PR TITLE
fix(2342): Search pipeline event for latest commit

### DIFF
--- a/plugins/pipelines/latestCommitEvent.js
+++ b/plugins/pipelines/latestCommitEvent.js
@@ -24,7 +24,8 @@ module.exports = () => ({
                 .list({
                     params: {
                         pipelineId: request.params.id,
-                        parentEventId: null
+                        parentEventId: null,
+                        type: 'pipeline'
                     },
                     paginate: {
                         count: 1

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -904,7 +904,8 @@ describe('pipeline plugin test', () => {
                 assert.calledWith(eventFactoryMock.list, {
                     params: {
                         pipelineId: id,
-                        parentEventId: null
+                        parentEventId: null,
+                        type: 'pipeline'
                     },
                     paginate: {
                         count: 1


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In order to highlight the latest commit in the event tab, /getLatestCommit should return latest commit of pipeline events (not including the pr event).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add `type: pipeline` search parameter in order to list only pipeline events.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#2342 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
