### PR TITLE
fix(2071): trigger next build could create duplicate build

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -408,3 +408,7 @@ build:
 rateLimit:
   __name: RATE_LIMIT_VARIABLES
   __format: json
+
+redisLock:
+  __name: REDIS_LOCK_VARIABLES
+  __format: json

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -326,3 +326,24 @@ rateLimit:
   limit: 300
   # limit duration in milliseconds, default: 300000 (5 mins)
   duration: 300000
+
+redisLock:
+  # set true to enable redis lock
+  enabled: false
+  options:
+    # maximum retry limit to obtain lock
+    retryCount: 200 
+    # the expected clock drift
+    driftFactor: 0.01
+    # the time in milliseconds between retry attempts
+    retryDelay: 500
+    # the maximum time in milliseconds randomly added to retries
+    retryJitter: 200
+    # Configuration of the redis instance
+    redisConnection:
+      host: "127.0.0.1"
+      port: 9999
+      options:
+        password: "THIS-IS-A-PASSWORD"
+        tls: false
+      database: 0

--- a/package.json
+++ b/package.json
@@ -96,6 +96,8 @@
     "prom-client": "^12.0.0",
     "request": "^2.88.2",
     "requestretry": "^4.1.2",
+    "ioredis": "^3.2.2",
+    "redlock": "^4.1.0",
     "screwdriver-artifact-bookend": "^1.1.27",
     "screwdriver-build-bookend": "^2.3.3",
     "screwdriver-cache-bookend": "^2.0.1",

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -1450,14 +1450,12 @@ const buildsPlugin = {
                                         sha: externalEvent.sha
                                     });
                                 } catch (err) {
-                                    nextBuild = await getNextBuild(getConfig);
+                                    finishedExternalBuilds = await externalEvent.getBuilds();
+                                    nextBuild = finishedExternalBuilds.find(b => b.jobId === jobId && b.status === 'CREATED');
                                 }
                             }
                         }
 
-                        // get next build again in case of race condition
-                        finishedExternalBuilds = await externalEvent.getBuilds();
-                        nextBuild = finishedExternalBuilds.find(b => b.jobId === jobId && b.status === 'CREATED');
                         // If next build exists, update next build with parentBuilds info
                         if (!newBuild && nextBuild){
                             newBuild = await updateParentBuilds({

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -17,7 +17,7 @@ const redis = new Redis(connectionDetails.port, connectionDetails.host, connecti
 // https://github.com/mike-marcacci/node-redlock
 const redlock = new Redlock([redis], {
     driftFactor: 0.01, // time in ms
-    retryCount: 5,
+    retryCount: 200,
     retryDelay: 500, // time in ms
     retryJitter: 200 // time in ms
 });

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -1,6 +1,26 @@
 'use strict';
 
 const dayjs = require('dayjs');
+const Redis = require('ioredis');
+const Redlock = require('redlock');
+const config = require('config');
+const redisConfig = config.get('executor.queue.options.redisConnection');
+const connectionDetails = {
+    host: redisConfig.host,
+    options: {
+        password: redisConfig.options && redisConfig.options.password,
+        tls: redisConfig.options ? redisConfig.options.tls : false
+    },
+    port: redisConfig.port
+};
+const redis = new Redis(connectionDetails.port, connectionDetails.host, connectionDetails.options);
+// https://github.com/mike-marcacci/node-redlock
+const redlock = new Redlock([redis], {
+    driftFactor: 0.01, // time in ms
+    retryCount: 5,
+    retryDelay: 500, // time in ms
+    retryJitter: 200 // time in ms
+});
 
 /**
  * Set default start time and end time
@@ -37,5 +57,6 @@ function validTimeRange(start, end, maxDay) {
 
 module.exports = {
     setDefaultTimeRange,
-    validTimeRange
+    validTimeRange,
+    redlock
 };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
multiple build could be created same job which splits parent build status and will never start
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
only one build should be created for same job
## References
https://github.com/screwdriver-cd/screwdriver/issues/2071
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
