### PR TITLE
fix: do proper merging of parent build data

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -763,6 +763,7 @@ const buildsPlugin = {
 
                     newBuild = await createInternalBuild(internalBuildConfig);
                 } else {
+                    console.log('before updateParentBuilds', nextBuild.id);
                     // nextBuild is not build object, so fetch proper build
                     newBuild = await updateParentBuilds({
                         joinParentBuilds: parentBuilds,

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -763,8 +763,7 @@ const buildsPlugin = {
 
                     newBuild = await createInternalBuild(internalBuildConfig);
                 } else {
-                    console.log('before updateParentBuilds', nextBuild.id);
-                    // nextBuild is not build object, so fetch proper build
+                    // nextBuild is not build model, so fetch proper build
                     newBuild = await updateParentBuilds({
                         joinParentBuilds: parentBuilds,
                         nextBuild: await buildFactory.get(nextBuild.id),
@@ -867,7 +866,7 @@ const buildsPlugin = {
 
                         if (nextBuild) {
                             // update current build info in parentBuilds
-                            // nextBuild is not build object, so fetch proper build
+                            // nextBuild is not build model, so fetch proper build
                             newBuild = await updateParentBuilds({
                                 joinParentBuilds: parentBuilds,
                                 nextBuild: await buildFactory.get(nextBuild.id),

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -401,7 +401,10 @@ async function getFinishedBuilds(event, buildFactory) {
  */
 async function updateParentBuilds({ joinParentBuilds, nextBuild, build }) {
     // Override old parentBuilds info
-    const newParentBuilds = merge({}, joinParentBuilds, nextBuild.parentBuilds, (objVal, srcVal) => objVal || srcVal);
+    const newParentBuilds = merge({}, joinParentBuilds, nextBuild.parentBuilds, (objVal, srcVal) =>
+        // passthrough objects, else mergeWith mutates source
+        srcVal && typeof srcVal === 'object' ? undefined : objVal || srcVal
+    );
 
     nextBuild.parentBuilds = newParentBuilds;
     nextBuild.parentBuildId = [build.id].concat(nextBuild.parentBuildId || []);
@@ -437,6 +440,7 @@ async function getParentBuildStatus({ newBuild, joinListNames, pipelineId, build
         ) {
             bId = upstream[joinInfo.externalPipelineId].jobs[joinInfo.externalJobName];
         }
+
         // If buildId is empty, the job hasn't executed yet and the join is not done
         if (!bId) {
             done = false;
@@ -759,9 +763,10 @@ const buildsPlugin = {
 
                     newBuild = await createInternalBuild(internalBuildConfig);
                 } else {
+                    // nextBuild is not build object, so fetch proper build
                     newBuild = await updateParentBuilds({
                         joinParentBuilds: parentBuilds,
-                        nextBuild,
+                        nextBuild: await buildFactory.get(nextBuild.id),
                         build: current.build
                     });
                 }
@@ -861,9 +866,10 @@ const buildsPlugin = {
 
                         if (nextBuild) {
                             // update current build info in parentBuilds
+                            // nextBuild is not build object, so fetch proper build
                             newBuild = await updateParentBuilds({
                                 joinParentBuilds: parentBuilds,
-                                nextBuild,
+                                nextBuild: await buildFactory.get(nextBuild.id),
                                 build: current.build
                             });
                         } else {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -3428,6 +3428,7 @@ describe('build plugin test', () => {
                         },
                         {
                             jobId: 2,
+                            id: 5555,
                             eventId: '8888',
                             status: 'RUNNING'
                         },

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1765,6 +1765,7 @@ describe('build plugin test', () => {
 
                     eventMock.getBuilds.resolves(buildMocks);
                     buildFactoryMock.get.withArgs(123456).resolves(buildMocks[1]);
+                    buildFactoryMock.get.withArgs(123455).resolves(buildC);
 
                     return server.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);
@@ -1799,6 +1800,7 @@ describe('build plugin test', () => {
                         },
                         buildC
                     ]);
+                    buildFactoryMock.get.withArgs(333).resolves(buildC);
 
                     return server.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);
@@ -2207,6 +2209,7 @@ describe('build plugin test', () => {
 
                     const buildC = {
                         jobId: 3,
+                        id: 3,
                         eventId: '8888',
                         status: 'CREATED',
                         parentBuilds: {
@@ -2253,7 +2256,7 @@ describe('build plugin test', () => {
                     };
 
                     buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
-                    buildFactoryMock.create.resolves(buildC);
+                    buildFactoryMock.get.withArgs(3).resolves(buildC);
 
                     return newServer.inject(options).then(() => {
                         assert.calledWith(buildFactoryMock.create, jobBconfig);
@@ -2286,6 +2289,7 @@ describe('build plugin test', () => {
                     };
                     const buildC = {
                         jobId: 3,
+                        id: 3,
                         status: 'CREATED',
                         parentBuilds: {
                             2: {
@@ -2382,6 +2386,7 @@ describe('build plugin test', () => {
                     eventFactoryMock.get.withArgs('8887').resolves(externalEventMock);
                     eventFactoryMock.list.resolves([Object.assign(externalEventMock, { id: '8889' })]);
                     buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
+                    buildFactoryMock.get.withArgs(3).resolves(buildC); // d is done
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
@@ -2730,6 +2735,7 @@ describe('build plugin test', () => {
 
                     const buildC = {
                         jobId: 3,
+                        id: 3,
                         status: 'CREATED',
                         eventId: '8888',
                         parentBuilds: {
@@ -2787,7 +2793,7 @@ describe('build plugin test', () => {
                     };
 
                     buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
-                    buildFactoryMock.create.resolves(buildC);
+                    buildFactoryMock.get.withArgs(3).resolves(buildC); // d is done
 
                     return newServer.inject(options).then(() => {
                         assert.calledWith(buildFactoryMock.create, jobBconfig);
@@ -2806,6 +2812,7 @@ describe('build plugin test', () => {
                     const buildC = {
                         jobId: 3, // job c was previously created,
                         eventId: '8888',
+                        id: 3,
                         remove: sinon.stub().resolves(null)
                     };
 
@@ -2832,6 +2839,7 @@ describe('build plugin test', () => {
                     ]);
 
                     buildFactoryMock.get.withArgs(5555).resolves({ status: 'FAILURE' });
+                    buildFactoryMock.get.withArgs(3).resolves(buildC);
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);
@@ -3398,6 +3406,7 @@ describe('build plugin test', () => {
 
                     const buildC = {
                         jobId: 3,
+                        id: 3,
                         eventId: '8888',
                         status: 'CREATED',
                         parentBuilds: { 123: { jobs: { a: null, b: 5555 }, eventId: '8888' } }
@@ -3443,6 +3452,7 @@ describe('build plugin test', () => {
 
                     const buildC = {
                         jobId: 3,
+                        id: 3,
                         eventId: '8888',
                         status: 'CREATED',
                         parentBuilds: { 123: { jobs: { a: null, b: 5555 }, eventId: '8888' } }
@@ -3471,6 +3481,7 @@ describe('build plugin test', () => {
                     ]);
 
                     buildFactoryMock.get.withArgs(5555).resolves({ status: 'FAILURE' }); // d is done
+                    buildFactoryMock.get.withArgs(3).resolves(buildC); // d is done
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

1. getFinishedBuilds doesn't return build model
2. Prevent _.mergeWith from mutating sources and `null` values needs to be handled properly

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/2374

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
