### PR TITLE
fix(2398): URI encode rootDir

### DIFF
--- a/plugins/pipelines/helper.js
+++ b/plugins/pipelines/helper.js
@@ -30,7 +30,8 @@ const formatCheckoutUrl = checkoutUrl => {
 };
 
 /**
- * Get rid of leading/trailing slashes in rootDir, return empty string as default
+ * Get rid of leading/trailing slashes in rootDir, uri encode
+ * Return empty string as default
  * @method sanitizeRootDir
  * @param  {String}     rootDir     Root directory (ex: /src/component/app/ or /)
  * @return {String}                 Root dir with no leading/trailing slashes
@@ -45,7 +46,7 @@ const sanitizeRootDir = (rootDir = '') => {
         return '';
     }
 
-    return sanitizedRootDir;
+    return encodeURIComponent(sanitizedRootDir);
 };
 
 module.exports = {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -175,6 +175,7 @@ describe('pipeline plugin test', () => {
     const password = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
     const scmContext = 'github:github.com';
     const scmDisplayName = 'github';
+    const rootDir = 'src%2Fapp%2Fcomponent';
 
     before(() => {
         mockery.enable({
@@ -1583,7 +1584,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir: 'src/app/component'
+                    rootDir
                 });
                 assert.calledWith(userMock.getPermissions, scmUriWithRootDir);
             });
@@ -1613,7 +1614,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir: 'src/app/component'
+                    rootDir
                 });
                 assert.calledWith(userMock.getPermissions, scmUri);
             });
@@ -1628,7 +1629,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir: 'src/app/component'
+                    rootDir
                 });
                 assert.calledWith(userMock.getPermissions, scmUri);
             });
@@ -1857,7 +1858,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir: 'src/app/component'
+                    rootDir
                 });
                 assert.calledWith(userMock.getPermissions, scmUriWithRootDir);
             });
@@ -3131,7 +3132,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir: 'src/app/component'
+                    rootDir
                 });
                 assert.calledWith(userMock.getPermissions, scmUriWithRootDir);
             });


### PR DESCRIPTION
## Context

Gitlab requires the path to a file be URI encoded.

## Objective

This PR URI encodes the rootDir path.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2398

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
