### PR TITLE
fix: Revert "fix(2398): URI encode rootDir"

### DIFF
--- a/plugins/pipelines/helper.js
+++ b/plugins/pipelines/helper.js
@@ -30,8 +30,7 @@ const formatCheckoutUrl = checkoutUrl => {
 };
 
 /**
- * Get rid of leading/trailing slashes in rootDir, uri encode
- * Return empty string as default
+ * Get rid of leading/trailing slashes in rootDir, return empty string as default
  * @method sanitizeRootDir
  * @param  {String}     rootDir     Root directory (ex: /src/component/app/ or /)
  * @return {String}                 Root dir with no leading/trailing slashes
@@ -46,7 +45,7 @@ const sanitizeRootDir = (rootDir = '') => {
         return '';
     }
 
-    return encodeURIComponent(sanitizedRootDir);
+    return sanitizedRootDir;
 };
 
 module.exports = {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -175,7 +175,6 @@ describe('pipeline plugin test', () => {
     const password = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
     const scmContext = 'github:github.com';
     const scmDisplayName = 'github';
-    const rootDir = 'src%2Fapp%2Fcomponent';
 
     before(() => {
         mockery.enable({
@@ -1584,7 +1583,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir
+                    rootDir: 'src/app/component'
                 });
                 assert.calledWith(userMock.getPermissions, scmUriWithRootDir);
             });
@@ -1614,7 +1613,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir
+                    rootDir: 'src/app/component'
                 });
                 assert.calledWith(userMock.getPermissions, scmUri);
             });
@@ -1629,7 +1628,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir
+                    rootDir: 'src/app/component'
                 });
                 assert.calledWith(userMock.getPermissions, scmUri);
             });
@@ -1858,7 +1857,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir
+                    rootDir: 'src/app/component'
                 });
                 assert.calledWith(userMock.getPermissions, scmUriWithRootDir);
             });
@@ -3132,7 +3131,7 @@ describe('pipeline plugin test', () => {
                     scmContext,
                     checkoutUrl: formattedCheckoutUrl,
                     token,
-                    rootDir
+                    rootDir: 'src/app/component'
                 });
                 assert.calledWith(userMock.getPermissions, scmUriWithRootDir);
             });


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#2406

Don't need to encode here