### PR TITLE
fix(2071): trigger next build could create duplicate build

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -407,3 +407,7 @@ build:
 rateLimit:
   __name: RATE_LIMIT_VARIABLES
   __format: json
+
+redisLock:
+  __name: REDIS_LOCK_VARIABLES
+  __format: json

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -325,3 +325,24 @@ rateLimit:
   limit: 300
   # limit duration in milliseconds, default: 300000 (5 mins)
   duration: 300000
+
+redisLock:
+  # set true to enable redis lock
+  enabled: false
+  options:
+    # maximum retry limit to obtain lock
+    retryCount: 200 
+    # the expected clock drift
+    driftFactor: 0.01
+    # the time in milliseconds between retry attempts
+    retryDelay: 500
+    # the maximum time in milliseconds randomly added to retries
+    retryJitter: 200
+    # Configuration of the redis instance
+    redisConnection:
+      host: "127.0.0.1"
+      port: 9999
+      options:
+        password: "THIS-IS-A-PASSWORD"
+        tls: false
+      database: 0

--- a/package.json
+++ b/package.json
@@ -125,7 +125,9 @@
     "sqlite3": "^5.0.1",
     "tinytim": "^0.1.1",
     "uuid": "^8.3.2",
-    "verror": "^1.6.1"
+    "verror": "^1.6.1",
+    "ioredis": "^3.2.2",
+    "redlock": "^4.1.0"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "hapi-auth-jwt2": "^10.2.0",
     "hapi-rate-limit": "^5.0.0",
     "hapi-swagger": "^14.1.0",
+    "ioredis": "^3.2.2",
     "joi": "^17.4.0",
     "js-yaml": "^3.14.1",
     "jsonwebtoken": "^8.5.1",
@@ -95,6 +96,7 @@
     "ndjson": "^1.4.3",
     "node-env-file": "^0.1.8",
     "prom-client": "^12.0.0",
+    "redlock": "^4.1.0",
     "request": "^2.88.2",
     "requestretry": "^4.1.2",
     "screwdriver-artifact-bookend": "^1.1.27",
@@ -125,9 +127,7 @@
     "sqlite3": "^5.0.1",
     "tinytim": "^0.1.1",
     "uuid": "^8.3.2",
-    "verror": "^1.6.1",
-    "ioredis": "^3.2.2",
-    "redlock": "^4.1.0"
+    "verror": "^1.6.1"
   },
   "release": {
     "debug": false,

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -804,7 +804,7 @@ const buildsPlugin = {
                 if (!newBuild && nextBuild) {
                     newBuild = await updateParentBuilds({
                         joinParentBuilds: parentBuilds,
-                        nextBuild: await buildFactory.get(nextBuild.id),
+                        nextBuild,
                         build: current.build
                     });
                 }
@@ -974,8 +974,6 @@ const buildsPlugin = {
                     parentEventId: current.event.id,
                     groupEventId: null
                 };
-
-                console.log('here');
 
                 return createExternalBuild(externalBuildConfig);
             };

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -975,6 +975,8 @@ const buildsPlugin = {
                     groupEventId: null
                 };
 
+                console.log('here');
+
                 return createExternalBuild(externalBuildConfig);
             };
 
@@ -999,11 +1001,18 @@ const buildsPlugin = {
                     }
                 } else {
                     try {
-                        const resource = `pipeline:${pid}:event:${pipelineJoinData[pid].event.id}`;
-                        const lock = await redLock.getLock(resource, ttl);
+                        const extEvent = pipelineJoinData[pid].event;
+                        let lock;
+
+                        // no need to lock if there is no external event
+                        if (extEvent) {
+                            const resource = `pipeline:${pid}:event:${pipelineJoinData[pid].event.id}`;
+
+                            lock = await redLock.getLock(resource, ttl);
+                        }
 
                         await triggerJobsInExternalPipeline(pid, pipelineJoinData[pid]);
-                        if (lock) {
+                        if (extEvent && lock) {
                             lock.unlock();
                         }
                     } catch (err) {

--- a/plugins/lock.js
+++ b/plugins/lock.js
@@ -32,7 +32,7 @@ class Lock {
     }
 
     /**
-     * attempt to acquire a lock for resource, will retry accuqiring lock depending
+     * Attempt to acquire a lock for resource, will retry acquiring lock depending
      * on configuration.
      * @method  getLock
      * @param   {String}      resource      the string identifier for the resource to lock

--- a/plugins/lock.js
+++ b/plugins/lock.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Redis = require('ioredis');
+const Redlock = require('redlock');
+const config = require('config');
+
+class Lock {
+    constructor() {
+        if (config.get('redisLock.enabled')) {
+            const redisLockConfig = config.get('redisLock.options');
+            const connectionDetails = {
+                host: redisLockConfig.redisConnection.host,
+                options: {
+                    password:
+                        redisLockConfig.redisConnection.options && redisLockConfig.redisConnection.options.password,
+                    tls: redisLockConfig.redisConnection.options ? redisLockConfig.redisConnection.options.tls : false
+                },
+                port: redisLockConfig.redisConnection.port
+            };
+
+            this.redis = new Redis(connectionDetails.port, connectionDetails.host, connectionDetails.options);
+            this.redlock = new Redlock([this.redis], {
+                driftFactor: redisLockConfig.driftFactor,
+                retryCount: redisLockConfig.retryCount,
+                retryDelay: redisLockConfig.retryDelay,
+                retryJitter: redisLockConfig.retryJitter
+            });
+        }
+    }
+
+    getLock(resource, ttl) {
+        if (this.redlock) {
+            return this.redlock.lock(resource, ttl);
+        }
+
+        return null;
+    }
+}
+
+module.exports = new Lock();

--- a/plugins/lock.js
+++ b/plugins/lock.js
@@ -5,6 +5,9 @@ const Redlock = require('redlock');
 const config = require('config');
 
 class Lock {
+    /**
+     * Constructor
+     */
     constructor() {
         if (config.get('redisLock.enabled')) {
             const redisLockConfig = config.get('redisLock.options');
@@ -28,6 +31,14 @@ class Lock {
         }
     }
 
+    /**
+     * attempt to acquire a lock for resource, will retry accuqiring lock depending
+     * on configuration.
+     * @method  getLock
+     * @param   {String}      resource      the string identifier for the resource to lock
+     * @param   {Number}      ttl           maximum lock duration in milliseconds
+     * @returns {Promise}
+     */
     getLock(resource, ttl) {
         if (this.redlock) {
             return this.redlock.lock(resource, ttl);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
multiple build could be created same job which splits parent build status and will never start


## Objective
only one build should be created for same job


<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2071
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
