### PR TITLE
feat(#2410): Abort frozen build implementation

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -89,7 +89,7 @@ module.exports = () => ({
 
                     // Check build status
                     if (!['RUNNING', 'QUEUED', 'BLOCKED', 'UNSTABLE', 'FROZEN'].includes(build.status)) {
-                        throw boom.forbidden('Can only update RUNNING, QUEUED, BLOCKED, or UNSTABLE builds');
+                        throw boom.forbidden('Can only update RUNNING, QUEUED, BLOCKED, FROZEN, or UNSTABLE builds');
                     }
 
                     // Users can only mark a running or queued build as aborted

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -35,10 +35,10 @@ async function isFixedBuild(build, jobFactory) {
 }
 
 /**
- * Stops a frozne build from executing
+ * Stops a frozen build from executing
  * @method stopFrozenBuild
  * @param  {Object} build         Build Object
- * @param  {string} previousStatus    prevous build status
+ * @param  {String} previousStatus    Prevous build status
  */
 async function stopFrozenBuild(build, previousStatus) {
     if (previousStatus !== 'FROZEN') {


### PR DESCRIPTION
## Context

Screwdriver needs a way to allow users to abort a build that has entered frozen state


## Objective

This PR adds check to the update build api for frozen build  status and abort build it via build model

## References

https://github.com/screwdriver-cd/screwdriver/issues/2410

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
