### PR TITLE
[2] fix: Add error handling for CircuitBreaker timeout

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -404,8 +404,6 @@ async function createPREvents(options, request) {
                 } catch (err) {
                     if (err.status >= 500) {
                         throw err;
-                    } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
-                        throw err;
                     } else {
                         logger.info(`skip create event for branch: ${b}`);
                     }
@@ -417,8 +415,6 @@ async function createPREvents(options, request) {
                     configPipelineSha = await pipelineFactory.scm.getCommitSha(scmConfig);
                 } catch (err) {
                     if (err.status >= 500) {
-                        throw err;
-                    } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
                         throw err;
                     } else {
                         logger.info(`skip create event for branch: ${b}`);
@@ -891,8 +887,6 @@ async function createEvents(
                 } catch (err) {
                     if (err.status >= 500) {
                         throw err;
-                    } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
-                        throw err;
                     } else {
                         logger.info(`skip create event for branch: ${pipelineBranch}`);
                     }
@@ -926,8 +920,6 @@ async function createEvents(
                     } catch (err) {
                         if (err.status >= 500) {
                             throw err;
-                        } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
-                            throw err;
                         } else {
                             logger.info(`skip create event for this subscribed trigger`);
                         }
@@ -944,8 +936,6 @@ async function createEvents(
                         eventConfig.subscribedSourceUrl = commitInfo.url;
                     } catch (err) {
                         if (err.status >= 500) {
-                            throw err;
-                        } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
                             throw err;
                         } else {
                             logger.info(`skip create event for this subscribed trigger`);

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -542,7 +542,7 @@ async function pullRequestOpened(options, request, h) {
             return h.response().code(201);
         })
         .catch(err => {
-            logger.error(`[${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
+            logger.error(`Failed to pullRequestOpened: [${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
 
             throw err;
         });
@@ -584,7 +584,7 @@ async function pullRequestClosed(options, request, h) {
     )
         .then(() => h.response().code(200))
         .catch(err => {
-            logger.error(`[${hookId}]: ${err}`);
+            logger.error(`Failed to pullRequestClosed: [${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
 
             throw err;
         });
@@ -622,7 +622,7 @@ async function pullRequestSync(options, request, h) {
             return h.response().code(201);
         })
         .catch(err => {
-            logger.error(`[${hookId}]: ${err}`);
+            logger.error(`Failed to pullRequestSync: [${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
 
             throw err;
         });

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -404,6 +404,8 @@ async function createPREvents(options, request) {
                 } catch (err) {
                     if (err.status >= 500) {
                         throw err;
+                    } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
+                        throw err;
                     } else {
                         logger.info(`skip create event for branch: ${b}`);
                     }
@@ -415,6 +417,8 @@ async function createPREvents(options, request) {
                     configPipelineSha = await pipelineFactory.scm.getCommitSha(scmConfig);
                 } catch (err) {
                     if (err.status >= 500) {
+                        throw err;
+                    } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
                         throw err;
                     } else {
                         logger.info(`skip create event for branch: ${b}`);
@@ -542,7 +546,7 @@ async function pullRequestOpened(options, request, h) {
             return h.response().code(201);
         })
         .catch(err => {
-            logger.error(`[${hookId}]: ${err}`);
+            logger.error(`[${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
 
             throw err;
         });
@@ -887,6 +891,8 @@ async function createEvents(
                 } catch (err) {
                     if (err.status >= 500) {
                         throw err;
+                    } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
+                        throw err;
                     } else {
                         logger.info(`skip create event for branch: ${pipelineBranch}`);
                     }
@@ -920,6 +926,8 @@ async function createEvents(
                     } catch (err) {
                         if (err.status >= 500) {
                             throw err;
+                        } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
+                            throw err;
                         } else {
                             logger.info(`skip create event for this subscribed trigger`);
                         }
@@ -936,6 +944,8 @@ async function createEvents(
                         eventConfig.subscribedSourceUrl = commitInfo.url;
                     } catch (err) {
                         if (err.status >= 500) {
+                            throw err;
+                        } else if (err.message !== undefined && err.message.indexOf('CircuitBreaker timeout') !== -1) {
                             throw err;
                         } else {
                             logger.info(`skip create event for this subscribed trigger`);

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -1546,10 +1546,10 @@ describe('webhooks plugin test', () => {
                 });
             });
 
-            it('returns 204  when getCommitSha() is rejected on undefined status error', () => {
+            it('returns 204  when getCommitSha() is rejected on 504 status error', () => {
                 const err = new Error('Failed to getCommitSha: CircuitBreaker timeout');
 
-                err.status = undefined;
+                err.status = 504;
                 pipelineFactoryMock.scm.getCommitSha.rejects(err);
 
                 return server.inject(options).then(reply => {

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -1546,6 +1546,18 @@ describe('webhooks plugin test', () => {
                 });
             });
 
+            it('returns 204  when getCommitSha() is rejected on undefined status error', () => {
+                const err = new Error('Failed to getCommitSha: CircuitBreaker timeout');
+
+                err.status = undefined;
+                pipelineFactoryMock.scm.getCommitSha.rejects(err);
+
+                return server.inject(options).then(reply => {
+                    assert.equal(reply.statusCode, 204);
+                    assert.notCalled(eventFactoryMock.create);
+                });
+            });
+
             it('handles checkouting when given a non-listed user on push event', () => {
                 userFactoryMock.get.resolves(null);
                 userFactoryMock.get


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When a timeout occurs in CircuitBreaker, err.status becomes undefined.
Now the following code will be processed successfully.
https://github.com/screwdriver-cd/screwdriver/blob/f1b25fd35576310e9119393cb890ffbb625f1317/plugins/webhooks/index.js#L416-L421

This will cause problems in later processing, Add the case when a timeout occurs in CircuitBreaker.

It also adds information on which pipeline the error occurred.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

In this PR, I will add error handling when CircuitBreaker times out in [getCommitSha()](https://github.com/screwdriver-cd/scm-github/blob/4c2a843ce5266a14b27d4788b3cd6d9b8f6e98a3/index.js#L860).

Circuitbreaker will output a log like the following when it times out.
```
Failed to getCommitSha:  CircuitBreaker timeout
```

~~Error handling is done with the `CircuitBreaker timeout` string in err.message. Is there a better way?~~
Fix circuit breaker to return error status 504 on timeout

## References
[1] https://github.com/screwdriver-cd/circuit-fuses/pull/30
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
