### PR TITLE
fix: events are broken during restart flow

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2997,6 +2997,7 @@ describe('build plugin test', () => {
                     const externalEventMock = {
                         id: 2,
                         pipelineId: 123,
+                        parentEventId: 2,
                         builds: [
                             {
                                 id: 888,
@@ -3070,7 +3071,8 @@ describe('build plugin test', () => {
                             id: 4,
                             jobId: 4,
                             eventId: '8888',
-                            status: 'SUCCESS'
+                            status: 'SUCCESS',
+                            parentBuilds: JSON.stringify({})
                         }
                     ]);
 


### PR DESCRIPTION
## Context

During restart flow, `parentBuilds` is taken from output of `buildFactory.getLatestBuilds` which is not a proper JSON object. This leads to `string` `parentBuilds` getting stored into DB which breaks events.

## Objective

JSON parse `parentBuilds` explicitly 

## References

https://github.com/screwdriver-cd/screwdriver/pull/2374

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
