### PR TITLE
feat(2399): Change remove command tag API

### DIFF
--- a/plugins/commands/removeTag.js
+++ b/plugins/commands/removeTag.js
@@ -46,10 +46,21 @@ module.exports = () => ({
                         }
 
                         // Remove the command tag, not the command
-                        return commandTag.remove();
+                        return commandTag.remove().then(() =>
+                            h
+                                .response(
+                                    JSON.stringify({
+                                        name,
+                                        namespace,
+                                        version: commandTag.version,
+                                        pipelineId: pipeline.id,
+                                        tag
+                                    })
+                                )
+                                .code(200)
+                        );
                     });
                 })
-                .then(() => h.response().code(204))
                 .catch(err => {
                     throw err;
                 });

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -1214,7 +1214,7 @@ describe('command plugin test', () => {
         it('deletes command tag if has good permission and tag exists', () =>
             server.inject(options).then(reply => {
                 assert.calledOnce(testCommandTag.remove);
-                assert.equal(reply.statusCode, 204);
+                assert.equal(reply.statusCode, 200);
             }));
     });
 


### PR DESCRIPTION
## Context
The APIs for commands return some kind of response body except for removeTag. In sd-cmd, the implementation assumes that the API for commands returns a response body. So we want to change the API for remove commad tags to return a response body.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- We modify the command removeTag API to return a response body.
- We change the status code returned in normal case from 204 to 200
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2399
https://github.com/screwdriver-cd/sd-cmd/blob/master/screwdriver/api/api_test.go#L52-L57
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
