### PR TITLE
fix(2432): support external trigger format for same pipeline

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -969,10 +969,10 @@ const buildsPlugin = {
                 if (isCurrentPipeline) {
                     for (const nextJobName of Object.keys(pipelineJoinData[pid].jobs)) {
                         try {
-                            const forceExternalTrigger = pipelineJoinData[pid].jobs[nextJobName].isExternal;
+                            const isExternal = pipelineJoinData[pid].jobs[nextJobName].isExternal;
 
-                            triggerCurrentPipelineAsExternal = triggerCurrentPipelineAsExternal || forceExternalTrigger;
-                            if (!forceExternalTrigger) {
+                            triggerCurrentPipelineAsExternal = triggerCurrentPipelineAsExternal || isExternal;
+                            if (!isExternal) {
                                 const resource = `pipeline:${current.pipeline.id}:event:${current.event.id}`;
                                 const lock = await locker.lock(resource);
 

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -33,17 +33,19 @@ function isExternalTrigger(jobName) {
  * If internal, pipelineId will be the current pipelineId
  * @param  {String} name        Job name
  * @param  {String} pipelineId  Pipeline ID
- * @return {Object}             With pipeline id and job name
+ * @return {Object}             With pipeline id, job name and isExternal flag
  */
 function getPipelineAndJob(name, pipelineId) {
     let externalJobName = name;
     let externalPipelineId = pipelineId;
+    let isExternal = false;
 
     if (isExternalTrigger(name)) {
+        isExternal = true;
         [, externalPipelineId, externalJobName] = EXTERNAL_TRIGGER_ALL.exec(name);
     }
 
-    return { externalPipelineId, externalJobName };
+    return { externalPipelineId, externalJobName, isExternal };
 }
 
 /**
@@ -618,6 +620,10 @@ async function createJoinObject(nextJobs, current, eventFactory) {
         const jobInfo = getPipelineAndJob(jobName, current.pipeline.id);
         const pid = jobInfo.externalPipelineId;
         const jName = jobInfo.externalJobName;
+        // needed to determine if join in same pipeline
+        // is expressed in external format
+        const isExternal = jobInfo.isExternal;
+
         const jId = event.workflowGraph.nodes.find(n => n.name === trimJobName(jobName)).id;
 
         if (!joinObj[pid]) joinObj[pid] = {};
@@ -638,7 +644,7 @@ async function createJoinObject(nextJobs, current, eventFactory) {
         }
 
         if (!pipelineObj.jobs) pipelineObj.jobs = {};
-        pipelineObj.jobs[jName] = { id: jId, join: jobs };
+        pipelineObj.jobs[jName] = { id: jId, join: jobs, isExternal };
     }
 
     return joinObj;
@@ -961,14 +967,22 @@ const buildsPlugin = {
 
             for (const pid of Object.keys(pipelineJoinData)) {
                 // typecast pid to number
-                if (+pid === current.pipeline.id) {
+                let triggerCurrentPipelineAsExternal = false;
+                const isCurrentPipeline = +pid === current.pipeline.id;
+
+                if (isCurrentPipeline) {
                     for (const nextJobName of Object.keys(pipelineJoinData[pid].jobs)) {
                         try {
-                            const resource = `pipeline:${current.pipeline.id}:event:${current.event.id}`;
-                            const lock = await locker.lock(resource);
+                            const forceExternalTrigger = pipelineJoinData[pid].jobs[nextJobName].isExternal;
 
-                            await triggerNextJobInSamePipeline(nextJobName, pipelineJoinData[pid].jobs);
-                            await locker.unlock(lock, resource);
+                            triggerCurrentPipelineAsExternal = triggerCurrentPipelineAsExternal || forceExternalTrigger;
+                            if (!forceExternalTrigger) {
+                                const resource = `pipeline:${current.pipeline.id}:event:${current.event.id}`;
+                                const lock = await locker.lock(resource);
+
+                                await triggerNextJobInSamePipeline(nextJobName, pipelineJoinData[pid].jobs);
+                                await locker.unlock(lock, resource);
+                            }
                         } catch (err) {
                             logger.error(
                                 `Error in triggerNextJobInSamePipeline:${nextJobName} from pipeline:${current.pipeline.id}-${current.job.name}-event:${current.event.id} `,
@@ -976,8 +990,13 @@ const buildsPlugin = {
                             );
                         }
                     }
-                } else {
+                }
+                if (triggerCurrentPipelineAsExternal || !isCurrentPipeline) {
                     try {
+                        if (isCurrentPipeline) {
+                            // force external trigger for jobs in same pipeline if user used external trigger syntax
+                            delete pipelineJoinData[pid].event;
+                        }
                         const extEvent = pipelineJoinData[pid].event;
                         let lock;
                         let resource;

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -618,11 +618,7 @@ async function createJoinObject(nextJobs, current, eventFactory) {
 
     for (const jobName of nextJobs) {
         const jobInfo = getPipelineAndJob(jobName, current.pipeline.id);
-        const pid = jobInfo.externalPipelineId;
-        const jName = jobInfo.externalJobName;
-        // needed to determine if join in same pipeline
-        // is expressed in external format
-        const isExternal = jobInfo.isExternal;
+        const { externalPipelineId: pid, externalJobName: jName, isExternal } = jobInfo;
 
         const jId = event.workflowGraph.nodes.find(n => n.name === trimJobName(jobName)).id;
 


### PR DESCRIPTION
## Context

Users can use external trigger syntax for same pipeline 🙄 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/issues/2432

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
