### PR TITLE
fix(466): allow user to set pipeline to public

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -126,7 +126,7 @@ module.exports = () => ({
             };
 
             if (settings) {
-                oldPipeline.settings = settings;
+                oldPipeline.settings = { ...oldPipeline.settings, ...settings };
             }
 
             // update pipeline

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -5153,7 +5153,7 @@ describe('build plugin test', () => {
                 }
             };
 
-            pipelineFactoryMock.get.resolves(privatePipelineMock);
+            pipelineFactoryMock.get.resolves(publicPipelineMock);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 302);

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1826,12 +1826,19 @@ describe('pipeline plugin test', () => {
             }));
 
         it('returns 200 and updates settings only', () => {
-            options.payload = { settings: { metricsDowntimeJobs: [123, 456] } };
+            const expectedSetting = {
+                metricsDowntimeJobs: [123, 456],
+                public: true
+            };
+
+            pipelineMock.settings = { metricsDowntimeJobs: [123, 456] };
+            options.payload = { settings: { public: true } };
 
             return server.inject(options).then(reply => {
                 assert.notCalled(pipelineFactoryMock.scm.parseUrl);
                 assert.calledOnce(pipelineMock.update);
                 assert.calledOnce(updatedPipelineMock.addWebhooks);
+                assert.deepEqual(expectedSetting, pipelineMock.settings);
                 assert.equal(reply.statusCode, 200);
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
there could be situation where user need pipeline to stay public despite having a private repo
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
allow user to set pipeline to public
## References
https://github.com/screwdriver-cd/screwdriver/issues/466
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
