### PR TITLE
fix(2462): Allow pipeline scope for list secrets

### DIFF
--- a/plugins/pipelines/listSecrets.js
+++ b/plugins/pipelines/listSecrets.js
@@ -18,7 +18,7 @@ module.exports = () => ({
         tags: ['api', 'pipelines', 'secrets'],
         auth: {
             strategies: ['token'],
-            scope: ['user', '!guest']
+            scope: ['user', 'pipeline', '!guest']
         },
 
         handler: async (request, h) => {

--- a/plugins/secrets/index.js
+++ b/plugins/secrets/index.js
@@ -32,9 +32,7 @@ const secretsPlugin = {
          */
         server.expose('canAccess', (credentials, secret, permission, app) => {
             const { userFactory, pipelineFactory } = app;
-            const { username } = credentials;
-            const { scmContext } = credentials;
-            const { scope } = credentials;
+            const { scmContext, scope, username } = credentials;
 
             return pipelineFactory.get(secret.pipelineId).then(pipeline => {
                 if (!pipeline) {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1110,6 +1110,42 @@ describe('pipeline plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, expected);
             }));
+
+        it('returns 200 for getting secrets with proper pipeline scope', () => {
+            options = {
+                method: 'GET',
+                url: `/pipelines/${pipelineId}/secrets`,
+                auth: {
+                    credentials: {
+                        username,
+                        scmContext,
+                        scope: ['pipeline'],
+                        pipelineId: 123
+                    },
+                    strategy: ['token']
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                const expected = [
+                    {
+                        id: 1234,
+                        pipelineId: 123,
+                        name: 'NPM_TOKEN',
+                        allowInPR: false
+                    },
+                    {
+                        id: 1235,
+                        pipelineId: 123,
+                        name: 'GIT_TOKEN',
+                        allowInPR: true
+                    }
+                ];
+
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, expected);
+            });
+        });
     });
 
     describe('GET /pipelines/{id}/events', () => {


### PR DESCRIPTION
## Context

Pipeline tokens should have access to list pipeline secrets.

## Objective

This PR adds `pipeline` scope to `GET pipelines/:id/secrets`.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2462

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
