### PR TITLE
fix(2404): Properly set prInfo.

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -236,7 +236,12 @@ async function createInternalBuild(config) {
     } = config;
     const prRef = event.pr.ref ? event.pr.ref : '';
     const prSource = event.pr.prSource || '';
-    const prInfo = event.pr.prInfo || '';
+    const prInfo = event.pr.prBranchName
+        ? {
+              url: event.pr.url || '',
+              prBranchName: event.pr.prBranchName || ''
+          }
+        : '';
 
     let job = {};
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1465,7 +1465,8 @@ describe('build plugin test', () => {
                     eventMock.pr = {
                         ref: 'pull/15/merge',
                         prSource: 'branch',
-                        prInfo: { prBranchName: 'prBranchName' }
+                        prBranchName: 'prBranchName',
+                        url: 'https://github.com/screwdriver-cd/ui/pull/292'
                     };
 
                     jobMock.name = 'PR-15:main';
@@ -1487,7 +1488,7 @@ describe('build plugin test', () => {
                             eventId: eventMock.id,
                             configPipelineSha,
                             prSource: eventMock.pr.prSource,
-                            prInfo: eventMock.pr.prInfo,
+                            prInfo: { prBranchName: eventMock.pr.prBranchName, url: eventMock.pr.url },
                             prRef: eventMock.pr.ref,
                             start: true,
                             baseBranch: null
@@ -1817,19 +1818,24 @@ describe('build plugin test', () => {
                     eventMock.pr = {
                         ref: 'pull/15/merge',
                         prSource: 'branch',
-                        prInfo: {
-                            prBranchName: 'prBranchName'
-                        }
+                        prBranchName: 'prBranchName',
+                        url: 'https://github.com/screwdriver-cd/ui/pull/292'
                     };
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'PR-15:b' }).resolves(jobB);
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'PR-15:c' }).resolves(jobC);
                     jobMock.name = 'PR-15:a';
                     jobBconfig.prRef = 'pull/15/merge';
                     jobBconfig.prSource = 'branch';
-                    jobBconfig.prInfo = { prBranchName: 'prBranchName' };
+                    jobBconfig.prInfo = {
+                        prBranchName: 'prBranchName',
+                        url: 'https://github.com/screwdriver-cd/ui/pull/292'
+                    };
                     jobCconfig.prRef = 'pull/15/merge';
                     jobCconfig.prSource = 'branch';
-                    jobCconfig.prInfo = { prBranchName: 'prBranchName' };
+                    jobCconfig.prInfo = {
+                        prBranchName: 'prBranchName',
+                        url: 'https://github.com/screwdriver-cd/ui/pull/292'
+                    };
 
                     return server.inject(options).then(() => {
                         // create the builds


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In createInternalaBuild func, prInfo is not set properly.
I fixed the method creating pfInfo.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In createInternalBuild func, prInfo is set from event object.

However, event has no prInfo property on its data-schema.
https://github.com/screwdriver-cd/data-schema/blob/32d1ef39ca80fbdb3bfbe3d9ddc6dbfdcf94698a/models/event.js#L75
https://github.com/screwdriver-cd/data-schema/blob/32d1ef39ca80fbdb3bfbe3d9ddc6dbfdcf94698a/core/scm.js#L94-L127
prInfo is used in the buildFactory.create for adding url and prBranchName info to event data.
https://github.com/screwdriver-cd/models/blob/d107819e0aadcbb6b31344b32729148c0165ce2a/lib/eventFactory.js#L692-L700
So I add url and prBranchName as prInfo from event object.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#2404 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
