### PR TITLE
fix: missing mocks for libs and perf issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "screwdriver-config-parser": "^7.1.2",
     "screwdriver-coverage-bookend": "^1.0.3",
     "screwdriver-coverage-sonar": "^3.1.4",
-    "screwdriver-data-schema": "^21.2.8",
+    "screwdriver-data-schema": "^21.3.1",
     "screwdriver-datastore-sequelize": "^7.2.6",
     "screwdriver-executor-base": "^8.1.2",
     "screwdriver-executor-docker": "^5.0.1",

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -542,7 +542,9 @@ async function pullRequestOpened(options, request, h) {
             return h.response().code(201);
         })
         .catch(err => {
-            logger.error(`Failed to pullRequestOpened: [${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
+            logger.error(
+                `Failed to pullRequestOpened: [${hookId}, pipeline:${options.pipeline && options.pipeline.id}]: ${err}`
+            );
 
             throw err;
         });
@@ -584,7 +586,9 @@ async function pullRequestClosed(options, request, h) {
     )
         .then(() => h.response().code(200))
         .catch(err => {
-            logger.error(`Failed to pullRequestClosed: [${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
+            logger.error(
+                `Failed to pullRequestClosed: [${hookId}, pipeline:${options.pipeline && options.pipeline.id}]: ${err}`
+            );
 
             throw err;
         });
@@ -622,7 +626,9 @@ async function pullRequestSync(options, request, h) {
             return h.response().code(201);
         })
         .catch(err => {
-            logger.error(`Failed to pullRequestSync: [${hookId}, pipeline:${options.pipeline.id}]: ${err}`);
+            logger.error(
+                `Failed to pullRequestSync: [${hookId}, pipeline:${options.pipeline && options.pipeline.id}]: ${err}`
+            );
 
             throw err;
         });

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -23,7 +23,7 @@ jobs:
             - teardown-cp-coverage-to-artifacts: cp -rf artifacts/coverage $SD_ARTIFACTS_DIR
         environment:
             SD_SONAR_OPTS:  "-Dsonar.sources=lib,plugins -Dsonar.tests=test -Dsonar.javascript.lcov.reportPaths=artifacts/coverage/lcov.info -Dsonar.testExecutionReportPaths=artifacts/report/test.xml"
-            NODE_OPTIONS: "--max_old_space_size=8192"
+            NODE_OPTIONS: "--max_old_space_size=4096"
         secrets:
             # Uploading coverage information to coveralls
             - COVERALLS_REPO_TOKEN

--- a/test/plugins/buildClusters.test.js
+++ b/test/plugins/buildClusters.test.js
@@ -30,6 +30,10 @@ const getMockBuildClusters = buildClusters => {
     return decorateBuildClusterObject(buildClusters);
 };
 
+const badgeMock = {
+    makeBadge: () => 'badge'
+};
+
 describe('buildCluster plugin test', () => {
     const username = 'myself';
     const scmContext = 'github:github.com';
@@ -77,6 +81,8 @@ describe('buildCluster plugin test', () => {
             }
         };
         screwdriverAdminDetailsMock = sinon.stub().returns({ isAdmin: true });
+
+        mockery.registerMock('badge-maker', badgeMock);
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/buildClusters');

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -76,6 +76,22 @@ const jwtMock = {
     sign: () => 'sign'
 };
 
+const badgeMock = {
+    makeBadge: () => 'badge'
+};
+
+/**
+ * mock Lockobj class
+ */
+class LockMockObj {
+    constructor() {
+        this.lock = sinon.stub();
+        this.unlock = sinon.stub();
+    }
+}
+
+const lockMock = new LockMockObj();
+
 describe('build plugin test', () => {
     let buildFactoryMock;
     let stepFactoryMock;
@@ -160,6 +176,8 @@ describe('build plugin test', () => {
         generateTokenMock = sinon.stub();
 
         mockery.registerMock('jsonwebtoken', jwtMock);
+        mockery.registerMock('badge-maker', badgeMock);
+        mockery.registerMock('../lock', lockMock);
         /* eslint-disable global-require */
         plugin = require('../../plugins/builds');
         /* eslint-enable global-require */

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -40,6 +40,10 @@ const getPipelineMocks = pipelines => {
     return decoratePipelineMock(pipelines);
 };
 
+const badgeMock = {
+    makeBadge: () => 'badge'
+};
+
 const getUserMock = user => {
     const mock = hoek.clone(user);
 
@@ -127,6 +131,8 @@ describe('DELETE /pipelines/1234/caches', () => {
 
         generateProfileMock = sinon.stub();
         generateTokenMock = sinon.stub();
+
+        mockery.registerMock('badge-maker', badgeMock);
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/pipelines');

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -40,6 +40,10 @@ const getEventMock = event => {
     return decorated;
 };
 
+const badgeMock = {
+    makeBadge: format => `${format.label}: ${format.message}`
+};
+
 describe('event plugin test', () => {
     let bannerMock;
     let screwdriverAdminDetailsMock;
@@ -93,6 +97,8 @@ describe('event plugin test', () => {
                 s.expose('screwdriverAdminDetails', screwdriverAdminDetailsMock);
             }
         };
+
+        mockery.registerMock('badge-maker', badgeMock);
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/events');

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -46,6 +46,10 @@ const getJobMocks = jobs => {
     return decorateJobMock(jobs);
 };
 
+const badgeMock = {
+    makeBadge: () => 'badge'
+};
+
 describe('job plugin test', () => {
     let jobFactoryMock;
     let pipelineFactoryMock;
@@ -88,6 +92,7 @@ describe('job plugin test', () => {
             get: sinon.stub().resolves(userMock)
         };
 
+        mockery.registerMock('badge-maker', badgeMock);
         /* eslint-disable global-require */
         plugin = require('../../plugins/jobs');
         /* eslint-enable global-require */

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -157,6 +157,10 @@ const getCollectionMock = collection => {
     return mock;
 };
 
+const badgeMock = {
+    makeBadge: format => `${format.label}: ${format.message}`
+};
+
 describe('pipeline plugin test', () => {
     let pipelineFactoryMock;
     let userFactoryMock;
@@ -238,6 +242,8 @@ describe('pipeline plugin test', () => {
             }
         };
         screwdriverAdminDetailsMock = sinon.stub();
+
+        mockery.registerMock('badge-maker', badgeMock);
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/pipelines');

--- a/test/plugins/secrets.test.js
+++ b/test/plugins/secrets.test.js
@@ -40,6 +40,10 @@ const getSecretMock = secret => {
     return mock;
 };
 
+const badgeMock = {
+    makeBadge: () => 'badge'
+};
+
 describe('secret plugin test', () => {
     let secretFactoryMock;
     let userFactoryMock;
@@ -67,6 +71,8 @@ describe('secret plugin test', () => {
         userFactoryMock = {
             get: sinon.stub()
         };
+
+        mockery.registerMock('badge-maker', badgeMock);
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/secrets');


### PR DESCRIPTION
## Context

Screwdriver tests are failing due to memory and performance issues 

## Objective

This PR fixes some of the test functions which are constantly at the top of the stack and are slow by adding mocks wherever necessary.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2483

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
