### PR TITLE
fix(2437): Pass in username to startAll [3]

### DIFF
--- a/plugins/pipelines/startAll.js
+++ b/plugins/pipelines/startAll.js
@@ -43,7 +43,6 @@ module.exports = () => ({
             await Promise.all(
                 pipelines.map(async p => {
                     const pipelineToken = await p.token;
-                    const pipelineUsername = await p.admin;
                     const pipelineScmContext = p.scmContext;
                     const sha = await scm.getCommitSha({
                         scmContext: pipelineScmContext,
@@ -54,10 +53,10 @@ module.exports = () => ({
                     await eventFactory.create({
                         pipelineId: p.id,
                         sha,
-                        username: pipelineUsername,
+                        username,
                         scmContext: pipelineScmContext,
                         startFrom: '~commit',
-                        causeMessage: `Started by ${pipelineUsername}`
+                        causeMessage: `Started by ${username}`
                     });
                 })
             );


### PR DESCRIPTION
## Context

Username was not being passed as a string.

## Objective

This PR fixes username param for event create in `POST pipelines/:id/startall` endpoint.
No longer need to worry about username here, as it will be handled in [scm-base](https://github.com/screwdriver-cd/scm-base/pull/88).

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437, https://github.com/screwdriver-cd/screwdriver/pull/2460
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
