### PR TITLE
fix(2437): Handle webhooks for read-only SCM [2]

### DIFF
--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -64,16 +64,20 @@ async function getUserPermissions({ user, scmUri, level = 'admin', isAdmin = fal
 /**
  * Get read only information
  * @method getReadOnlyInfo
- * @param  {Object} pipeline Pipeline
- * @param  {Object} scm      Scm
- * @return {Object}          Read only info
+ * @param  {Object} [pipeline]      Pipeline
+ * @param  {Object} scm             Scm
+ * @param  {String} [scmContext]    Scm context
+ * @return {Object}                 Read only info
  */
-function getReadOnlyInfo({ pipeline, scm }) {
-    const { enabled, username, accessToken } = scm.getReadOnlyInfo({ scmContext: pipeline.scmContext });
+function getReadOnlyInfo({ pipeline, scm, scmContext }) {
+    const context = scmContext || pipeline.scmContext;
+    const { enabled, username, accessToken } = scm.getReadOnlyInfo({ scmContext: context });
+
+    console.log('scm.getReadOnlyInfo({ scmContext: context }): ', scm.getReadOnlyInfo({ scmContext: context }));
 
     return {
         readOnlyEnabled: enabled,
-        pipelineContext: pipeline.scmContext,
+        pipelineContext: context,
         headlessUsername: username,
         headlessAccessToken: accessToken
     };
@@ -105,8 +109,9 @@ async function getScmUri({ pipeline, pipelineFactory }) {
 }
 
 module.exports = {
-    setDefaultTimeRange,
-    validTimeRange,
+    getReadOnlyInfo,
+    getScmUri,
     getUserPermissions,
-    getScmUri
+    setDefaultTimeRange,
+    validTimeRange
 };

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -73,8 +73,6 @@ function getReadOnlyInfo({ pipeline, scm, scmContext }) {
     const context = scmContext || pipeline.scmContext;
     const { enabled, username, accessToken } = scm.getReadOnlyInfo({ scmContext: context });
 
-    console.log('scm.getReadOnlyInfo({ scmContext: context }): ', scm.getReadOnlyInfo({ scmContext: context }));
-
     return {
         readOnlyEnabled: enabled,
         pipelineContext: context,


### PR DESCRIPTION
## Context

Should be able to pass in scmContext to buildcluster endpoints.
Also should not try to get user token for webhooks.

## Objective

This PR:
- allows user to pass `scmContext` for `POST/PUT buildcluster`
- checks for read-only SCM and uses read-only token when appropriate

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
