### PR TITLE
fix(466): allow search for pipeline admin and guest

### DIFF
--- a/test/plugins/data/privatePipelines.json
+++ b/test/plugins/data/privatePipelines.json
@@ -42,5 +42,21 @@
         "admins": {
             "d2lam": true
         }
+    },
+    {
+        "id": 126,
+        "scmUri": "github.com:12345:branchName",
+        "scmContext": "github:github.com",
+        "createTime": "2038-01-19T03:14:08.131Z",
+        "scmRepo": {
+            "name": "foo/bar",
+            "branch": "master",
+            "url": "https://github.com/foo/bar/tree/master",
+            "private": true
+        },
+        "admins": {
+            "foo": true
+        },
+        "lastEventId": 789
     }
 ]

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -385,10 +385,37 @@ describe('pipeline plugin test', () => {
                     sort: 'descending'
                 })
                 .resolves(getPipelineMocks(testPrivatePipelines));
+            options.auth.credentials = {
+                username: 'guest/1234',
+                scmContext: null,
+                scope: ['user', 'guest']
+            };
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, [testPrivatePipelines[1], testPrivatePipelines[2]]);
+            });
+        });
+
+        it('returns 200 and does not filter private pipelines for pipeline admin', () => {
+            screwdriverAdminDetailsMock.returns({ isAdmin: true });
+            pipelineFactoryMock.scm.getScmContexts.returns(['github:github.com']);
+            pipelineFactoryMock.list
+                .withArgs({
+                    params: {
+                        scmContext: 'github:github.com'
+                    },
+                    paginate: {
+                        page: 1,
+                        count: 3
+                    },
+                    sort: 'descending'
+                })
+                .resolves(getPipelineMocks(testPrivatePipelines));
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testPrivatePipelines);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
guest login now throws 500 error when searching pipelines and pipeline admin should be able to search private pipeline
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
fix both 
## References
https://github.com/screwdriver-cd/screwdriver/issues/466
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
