### PR TITLE
fix(2507): fix QUEUED notification

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -136,7 +136,9 @@ function updateBuildStatus(build, desiredStatus, statusMessage, username) {
     const currentStatus = build.status;
 
     if (currentStatus !== 'UNSTABLE') {
-        build.status = desiredStatus;
+        if (desiredStatus !== undefined) {
+            build.status = desiredStatus;
+        }
         if (build.status === 'ABORTED') {
             if (currentStatus === 'FROZEN') {
                 build.statusMessage = `Frozen build aborted by ${username}`;


### PR DESCRIPTION
## Context
Since #2485 is merged, QUEUED notifications are not sent. When a build is started in the executor [here](https://github.com/screwdriver-cd/queue-service/blob/491b969df61bd3d1c7070833c1f2b05368eae265/plugins/queue/scheduler.js#L394), queue-service calls `/builds/{id}` without `status`. Then `build.status` is set to `undefined` [here](https://github.com/screwdriver-cd/screwdriver/blob/bf1588e5195fa950c0cc0b9b62de55e35530359b/plugins/builds/update.js#L223). Because of this, `QUEUED` notifications are no longer sent to Slack. Originally, if `desiredStatus` was `undefined`, `build.status` was not changed because of [this](https://github.com/screwdriver-cd/screwdriver/blob/69e3d7c466b02363951f328f7458e2a9cce6d471/plugins/builds/update.js#L142-L148).
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR changes `updateBuildStatus` of `builds/update.js` not to change the `status` of build when `desiredStatus` is `undefined`. As a result, `QUEUED` notification to the Slack is fixed.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
#2507 
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
