### PR TITLE
fix: return property header for artifact endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "jsonwebtoken": "^8.5.1",
     "license-checker": "^17.0.0",
     "lodash.mergewith": "^4.6.2",
-    "mime-types": "^2.1.25",
     "ndjson": "^1.4.3",
     "node-env-file": "^0.1.8",
     "prom-client": "^12.0.0",

--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -62,16 +62,7 @@ module.exports = config => ({
                         baseUrl += `&type=${request.query.type}`;
                     }
         
-                    const gotStream = got.stream(baseUrl,{
-                        hooks: {
-                            afterResponse: [
-                                (response, retryWithMergedOptions) => {
-                                    console.log(response.headers);
-                                    return response;
-                                }
-                            ]
-                        }
-                    });
+                    const gotStream = got.stream(baseUrl);
 
                     let response = h.response(gotStream);
                     

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -2,53 +2,6 @@
 
 const boom = require('@hapi/boom');
 const dayjs = require('dayjs');
-const mime = require('mime-types');
-
-const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
-    'js',
-    'c',
-    'cpp',
-    'cs',
-    'dtd',
-    'h',
-    'm',
-    'java',
-    'lua',
-    'pl',
-    'go',
-    'py',
-    'tox',
-    'env',
-    'sh',
-    'vb',
-    'swift',
-    'yidf',
-    'state',
-    'diff',
-    'deps',
-    'xml'
-];
-
-/**
- * Get MIME types from file name and file extension
- * @method getMimeFromFileName
- * @param  {String} fileExtension  File extension (e.g. css, txt, html)
- * @param  {String} fileName       File name      (e.g. dockerfile, main)
- * @return {String} MIME Type      eg. text/html, text/plain
- */
-function getMimeFromFileName(fileExtension, fileName = '') {
-    if (fileName.toLowerCase().endsWith('file')) {
-        return 'text/plain';
-    }
-
-    if (KNOWN_FILE_EXTS_IN_TEXT_FORMAT.includes(fileExtension.toLowerCase())) {
-        return 'text/plain';
-    }
-
-    return mime.lookup(fileExtension) || '';
-}
-
-const displayableMimes = ['text/html'];
 
 /**
  * Set default start time and end time
@@ -158,7 +111,5 @@ module.exports = {
     getScmUri,
     getUserPermissions,
     setDefaultTimeRange,
-    validTimeRange,
-    getMimeFromFileName,
-    displayableMimes
+    validTimeRange
 };

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -93,8 +93,23 @@ const badgeMock = {
     makeBadge: () => 'badge'
 };
 
+const responseMock = {
+    headers: {
+        'content-type': 'application/octet-stream',
+        'content-disposition': 'attachment; filename="manifest.txt"',
+        'content-length': '1077'
+    }
+};
+
+const streamMock = {
+    on: sinon
+        .stub()
+        .withArgs('response')
+        .yields(responseMock)
+};
+
 const gotMock = {
-    stream: sinon.stub().returns({})
+    stream: sinon.stub().returns(streamMock)
 };
 
 /**


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
previous logic for artifact endpoint did not return proper header
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
read header from store response instead
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
