### PR TITLE
fix: simple functional test of chainPR

### DIFF
--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -102,8 +102,8 @@ When(
         timeout: TIMEOUT
     },
     function step(branch) {
-        const prefix = new Date().getTime().toString();
-        const branchName = `${branch}-${prefix}`;
+        const postfix = new Date().getTime().toString();
+        const branchName = `${branch}-${postfix}`;
 
         return github
             .createBranch(branchName, this.repoOrg, this.repoName)

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -407,9 +407,11 @@ After(
         tags: '@workflow-chainPR'
     },
     function hook() {
-        Promise.resolve()
-            .then(github.closePullRequest(this.repoOrg, this.repoName, this.pullRequestNumber))
-            .then(github.removeBranch(this.repoOrg, this.repoName, this.branch))
+        github
+            .closePullRequest(this.repoOrg, this.repoName, this.pullRequestNumber)
+            .then(() => {
+                github.removeBranch(this.repoOrg, this.repoName, this.branch);
+            })
             .catch(() => {
                 Assert.fail('Failed to close Pull Request or remove branch.');
             });

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -102,12 +102,15 @@ When(
         timeout: TIMEOUT
     },
     function step(branch) {
+        const prefix = new Date().getTime().toString();
+        const branchName = `${branch}-${prefix}`;
+
         return github
-            .createBranch(branch, this.repoOrg, this.repoName)
-            .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(() => github.createPullRequest(branch, this.repoOrg, this.repoName))
+            .createBranch(branchName, this.repoOrg, this.repoName)
+            .then(() => github.createFile(branchName, this.repoOrg, this.repoName))
+            .then(() => github.createPullRequest(branchName, this.repoOrg, this.repoName))
             .then(({ data }) => {
-                this.branch = branch;
+                this.branch = branchName;
                 this.pullRequestNumber = data.number;
                 this.sha = data.head.sha;
             })

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "start": "./bin/server",
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",
-    "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
-    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
-    "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
+    "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast",
+    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast",
+    "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Existing chainPR functional tests will fail if the tests are run in parallel or if there is any PR left from the previous run.
The reason is that it uses a single branch.

Also, PR close is not stable because it uses the `--exit` option when starting `cucumber.js`.
This is deprecated and should be removed.
https://github.com/cucumber/cucumber-js/blob/main/docs/cli.md#exiting

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In this PR, modify the test run to test on a unique branch. (ex branchName: testpr-12345678)
Specifically, it uses the [time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime) as the postfix.

And fix the option when starting `cucumber.js`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Previous PRs
- https://github.com/screwdriver-cd/screwdriver/pull/2527
- https://github.com/screwdriver-cd/screwdriver/pull/2515

related: #1393

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
