### PR TITLE
fix:(2534) Enabling the --exit option in cucumber.js

### DIFF
--- a/features/workflow.feature
+++ b/features/workflow.feature
@@ -93,6 +93,7 @@ Feature: Workflow
         And that "REGEX" build uses the same SHA as the "STAGING" build
 
     @workflow-chainPR
+    @ignore
     Scenario: chainPR
         Given an existing pipeline on "master" branch with the workflow jobs:
             | job          | requires  |

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "start": "./bin/server",
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",
-    "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast",
-    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast",
-    "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast",
+    "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
+    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
+    "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Related to  https://github.com/screwdriver-cd/screwdriver/issues/2534
In this PR, the `--exit` option will be enabled until the cause of the build timeout is known.
Also, if the `--exit` option is enabled, the chainPR function test will not work properly, so`@ignore` it.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Make sure that functional tests do not fail.
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2534
https://github.com/screwdriver-cd/screwdriver/pull/2533
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
