### PR TITLE
fix: default get artifact request to preview

### DIFF
--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -8,7 +8,7 @@ const got = require('got');
 
 const idSchema = schema.models.build.base.extract('id');
 const artifactSchema = joi.string().label('Artifact Name');
-const typeSchema = joi.string().valid('', 'download', 'preview').label('Flag to trigger type either to download or preview');
+const typeSchema = joi.string().default('preview').valid('download', 'preview').label('Flag to trigger type either to download or preview');
 
 module.exports = config => ({
     method: 'GET',
@@ -57,7 +57,7 @@ module.exports = config => ({
         
                     let baseUrl = `${config.ecosystem.store}/v1/builds/`
                         + `${buildId}/ARTIFACTS/${encodedArtifact}?token=${token}`;
-        
+
                     if (request.query.type) {
                         baseUrl += `&type=${request.query.type}`;
                     }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -5067,7 +5067,7 @@ describe('build plugin test', () => {
         });
 
         it('returns 200 for an artifact request', () => {
-            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/manifest?token=sign`;
+            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/manifest?token=sign&type=preview`;
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
@@ -5077,7 +5077,7 @@ describe('build plugin test', () => {
 
         it('returns 200 for an multi-byte artifact request', () => {
             const encodedArtifact = '%E3%81%BE%E3%81%AB%E3%81%B5%E3%81%87manife%E6%BC%A2%E5%AD%97';
-            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/${encodedArtifact}?token=sign`;
+            const url = `${logBaseUrl}/v1/builds/12345/ARTIFACTS/${encodedArtifact}?token=sign&type=preview`;
 
             options.url = `/builds/${id}/artifacts/${multiByteArtifact}`;
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
get artifact should default to preview due to store change
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
get artifact should default to preview due to store change
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
