### PR TITLE
fix: pin coverage-sonar to pre got version to unblock release

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "screwdriver-command-validator": "^2.1.0",
     "screwdriver-config-parser": "^7.2.0",
     "screwdriver-coverage-bookend": "^1.0.3",
-    "screwdriver-coverage-sonar": "^3.3.0",
+    "screwdriver-coverage-sonar": "3.2.0",
     "screwdriver-data-schema": "^21.8.0",
     "screwdriver-datastore-sequelize": "^7.2.7",
     "screwdriver-executor-base": "^8.4.0",


### PR DESCRIPTION
## Context

[got updates](https://github.com/screwdriver-cd/coverage-sonar/compare/v3.2.0...v3.3.1) to coverage-sonar broke the library. Pinning it to last known working version to unblock release

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/issues/1961

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
