### PR TITLE
fix(1961): Do not need to JSON parse response

### DIFF
--- a/features/step_definitions/server.js
+++ b/features/step_definitions/server.js
@@ -14,7 +14,7 @@ When(/^I access the status endpoint$/, function step() {
 
 When(/^I access the versions endpoint$/, function step() {
     return request({ method: 'GET', url: `${this.instance}/v4/versions` }).then(result => {
-        this.body = result ? JSON.parse(result.body) : null;
+        this.body = result ? result.body : null;
     });
 });
 

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -238,7 +238,7 @@ function cleanupToken(config) {
             token: jwt
         }
     }).then(response => {
-        const match = JSON.parse(response.body).find(token => token.name === tokenName);
+        const match = response.body.find(token => token.name === tokenName);
 
         if (!match) return Promise.resolve();
 


### PR DESCRIPTION
Getting error with `cleanupToken()` in feature test:
```
16:05:38 1) Scenario: Generate New API Token (attempt 3) # features/api-token.feature:19
16:05:38    ✔ Before # features/step_definitions/api-token.js:9
16:05:38    ✔ Given "calvin" is logged in # features/step_definitions/authorization.js:19
16:05:38    ✖ Given "calvin" does not own a token named "tiger" # features/step_definitions/api-token.js:15
16:05:38        SyntaxError: Unexpected token o in JSON at position 1
16:05:38            at JSON.parse (<anonymous>)
16:05:38            at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/features/support/sdapi.js:241:28
16:05:38            at processTicksAndRejections (internal/process/task_queues.js:97:5)
16:05:38    - When a new API token named "tiger" is generated # features/step_definitions/api-token.js:25
16:05:38    - And the token is used to log in # features/step_definitions/api-token.js:45
16:05:38    - Then a valid JWT is received that represents "calvin" # features/step_definitions/api-token.js:49
16:05:38    - And the "tiger" token's 'last used' property is updated # features/step_definitions/api-token.js:57
```

## Objective

Response for getting token no longer needs to be JSON parsed because the [screwdriver-request repo](https://github.com/screwdriver-cd/request/blob/master/index.js#L21) returns responses in JSON format.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2537

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
