### PR TITLE
fix(1961): 409 will throw error

### DIFF
--- a/features/step_definitions/api-token.js
+++ b/features/step_definitions/api-token.js
@@ -78,27 +78,29 @@ Given(/^"calvin" owns an existing API token named "([^"]*)"$/, function step(tok
         json: {
             name: tokenName
         }
-    }).then(response => {
-        Assert.oneOf(response.statusCode, [409, 201]);
+    })
+        .then(response => {
+            Assert.strictEqual(response.statusCode, 201);
 
-        if (response.statusCode === 201) {
             this.testToken = response.body;
 
             return null;
-        }
+        })
+        .catch(err => {
+            Assert.strictEqual(err.statusCode, 409);
 
-        return request({
-            url: `${this.instance}/${this.namespace}/tokens`,
-            method: 'GET',
-            context: {
-                token: this.jwt
-            }
-        }).then(listResponse => {
-            Assert.strictEqual(listResponse.statusCode, 200);
+            return request({
+                url: `${this.instance}/${this.namespace}/tokens`,
+                method: 'GET',
+                context: {
+                    token: this.jwt
+                }
+            }).then(listResponse => {
+                Assert.strictEqual(listResponse.statusCode, 200);
 
-            this.testToken = listResponse.body.find(token => token.name === tokenName);
+                this.testToken = listResponse.body.find(token => token.name === tokenName);
+            });
         });
-    });
 });
 
 When(/^he lists all his tokens$/, function step() {

--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -4,6 +4,7 @@ const Assert = require('chai').assert;
 const jwt = require('jsonwebtoken');
 const { Before, Given, Then } = require('cucumber');
 const request = require('screwdriver-request');
+const { ID } = require('../support/constants');
 const TIMEOUT = 240 * 1000;
 
 Before('@auth', function hook() {
@@ -58,16 +59,16 @@ Then(/^they can see the pipeline$/, { timeout: TIMEOUT }, function step() {
         }
     })
         .then(response => {
-            Assert.oneOf(response.statusCode, [409, 201]);
+            Assert.strictEqual(response.statusCode, 201);
 
-            if (response.statusCode === 201) {
-                this.pipelineId = response.body.id;
-            } else {
-                const str = response.body.message;
-                const id = str.split(': ')[1];
+            this.pipelineId = response.body.id;
+        })
+        .catch(err => {
+            Assert.strictEqual(err.statusCode, 409);
 
-                this.pipelineId = id;
-            }
+            const [, str] = err.message.split(': ');
+
+            [this.pipelineId] = str.match(ID);
         })
         .then(() =>
             request({

--- a/features/step_definitions/sd-step.js
+++ b/features/step_definitions/sd-step.js
@@ -6,6 +6,7 @@ const Assert = require('chai').assert;
 const { Before, Given, When, Then } = require('cucumber');
 const request = require('screwdriver-request');
 const sdapi = require('../support/sdapi');
+const { ID } = require('../support/constants');
 
 const TIMEOUT = 240 * 1000;
 
@@ -42,16 +43,16 @@ Given(/^an existing pipeline with (.*) image and (.*) package$/, { timeout: TIME
             });
         })
         .then(response => {
-            Assert.oneOf(response.statusCode, [409, 201]);
+            Assert.strictEqual(response.statusCode, 201);
 
-            if (response.statusCode === 201) {
-                this.pipelineId = response.body.id;
-            } else {
-                const str = response.body.message;
-                const id = str.split(': ')[1];
+            this.pipelineId = response.body.id;
+        })
+        .catch(err => {
+            Assert.strictEqual(err.statusCode, 409);
 
-                this.pipelineId = id;
-            }
+            const [, str] = err.message.split(': ');
+
+            [this.pipelineId] = str.match(ID);
         });
 });
 

--- a/features/support/constants.js
+++ b/features/support/constants.js
@@ -1,0 +1,10 @@
+'use strict';
+
+/**
+ * Patterns for common pieces
+ * @type {Object}
+ */
+module.exports = {
+    // ID can have numbers only 0-9
+    ID: /\d+/
+};


### PR DESCRIPTION
## Context

409 throws error with new screwdriver-request package:
```
14:37:53 1) Scenario: List API Tokens (attempt 3) # features/api-token.feature:26
14:37:53    ✔ Before # features/step_definitions/api-token.js:9
14:37:53    ✔ Given "calvin" is logged in # features/step_definitions/authorization.js:19
14:37:53    ✖ Given "calvin" owns an existing API token named "tiger" # features/step_definitions/api-token.js:71
14:37:53        Error: 409 Reason "Token with name tiger already exists"
14:37:53            at throwError (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:14:17)
14:37:53            at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:56:28
14:37:53            at processTicksAndRejections (internal/process/task_queues.js:97:5)
14:37:53    - When he lists all his tokens # features/step_definitions/api-token.js:104
14:37:53    - Then his "tiger" token is in the list # features/step_definitions/api-token.js:118
14:37:53    - And his token is safely described # features/step_definitions/api-token.js:126
```
## Objective

This PR catches 409 and handles information accordingly.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2537

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
