### PR TITLE
fix: Logs should not throw when store returns 404

### DIFF
--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -67,7 +67,7 @@ module.exports = config => ({
                             resolve(response.headers);
                         });
                         requestStream.on('error', err => {
-                            if (err.response && err.response.statusCode == 404) {
+                            if (err.response && err.response.statusCode === 404) {
                                 reject(boom.notFound('File not found'));
                             } else {
                                 reject(err);

--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -10,6 +10,7 @@ const uuid = require('uuid');
 
 const MAX_LINES_SMALL = 100;
 const MAX_LINES_BIG = 1000;
+const EOF_MESSAGE = 'Response code 404 (Not Found)';
 
 /**
  * Makes the request to the Store to get lines from a log
@@ -32,7 +33,13 @@ async function fetchLog({ baseUrl, linesFrom, authToken, page, sort }) {
 
     return new Promise((resolve, reject) => {
         requestStream
-            .on('error', e => reject(e))
+            .on('error', e => {
+                if (!e.message.includes(EOF_MESSAGE)) {
+                    return reject(e);
+                }
+
+                return resolve([]);
+            })
             // Parse the ndjson
             .pipe(ndjson.parse({ strict: false }))
             // Only save lines that we care about

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -68,7 +68,7 @@ module.exports = () => ({
             let defaultCollection;
 
             if (collections && collections.length > 0) {
-                defaultCollection = collections[0];
+                [defaultCollection] = collections;
             }
 
             if (!defaultCollection) {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -4794,6 +4794,22 @@ describe('build plugin test', () => {
             });
         });
 
+        it('returns 404 when build does not exist', () => {
+            buildFactoryMock.get.resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 404 when event does not exist', () => {
+            eventFactoryMock.get.resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
         it('returns 404 when step does not exist', () => {
             stepFactoryMock.get.withArgs({ buildId: id, name: step }).resolves(null);
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -4794,6 +4794,25 @@ describe('build plugin test', () => {
             });
         });
 
+        it('does not throw when logs return 404', () => {
+            stepMock = getStepMock({
+                name: 'test',
+                startTime: '2038-01-19T03:15:09.114Z'
+            });
+            stepFactoryMock.get.withArgs({ buildId: id, name: 'test' }).resolves(stepMock);
+            nock('https://store.screwdriver.cd')
+                .get(`/v1/builds/${id}/test/log.0`)
+                .twice()
+                .reply(404);
+            options.url = `/builds/${id}/steps/test/logs`;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, []);
+                assert.propertyVal(reply.headers, 'x-more-data', 'true');
+            });
+        });
+
         it('returns 404 when build does not exist', () => {
             buildFactoryMock.get.resolves(null);
 


### PR DESCRIPTION
## Context

Getting errors with [getMaxLines](https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/builds/steps/logs.js#L35) because got throws error for 404:
```
{"name":"HTTPError","timings":{"start":1631133820277,"socket":1631133820278,"lookup":1631133820313,"connect":1631133820316,"secureConnect":1631133820321,"upload":1631133820321,"response":1631133820379,"end":1631133820381,"phases":{"wait":1,"dns":35,"tcp":3,"tls":5,"request":0,"firstByte":58,"download":2,"total":104}},"level":"error","timestamp":"2021-09-08T20:43:40.382Z"}
210908/204340.383, (1631133820241:sdapi-beta-6f49c864b-hrmnd:18:ktbywcvt:10022) [request,server,error] data: Error: HTTPError: Response code 404 (Not Found)
    at getMaxLines (/usr/src/app/node_modules/screwdriver-api/plugins/builds/steps/logs.js:72:15)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
210908/204340.241, (1631133820241:sdapi-beta-6f49c864b-hrmnd:18:ktbywcvt:10022) 
```
## Objective

This PR does not throw when store returns 404.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2537

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
