### PR TITLE
fix(1961): Catch errors and handle in func tests

### DIFF
--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -258,9 +258,9 @@ Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step()
 });
 
 When(/^they create another collection with the same name "myCollection"$/, { timeout: TIMEOUT }, function step() {
-    return createCollection.call(this, { name: 'myCollection' }).then(response => {
-        Assert.ok(response);
-        this.lastResponse = response;
+    return createCollection.call(this, { name: 'myCollection' }).catch(err => {
+        Assert.isOk(err, 'Error should be returned');
+        this.lastResponse = err;
     });
 });
 

--- a/features/step_definitions/sd-cmd.js
+++ b/features/step_definitions/sd-cmd.js
@@ -56,22 +56,23 @@ Given(/^(.+) command does not exist yet$/, { timeout: TIMEOUT }, function step(c
         context: {
             token: this.jwt
         }
-    }).then(response => {
-        if (response.statusCode === 404) {
-            return;
-        }
-
-        /* eslint-disable-next-line consistent-return */
-        return request({
-            url: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}/${this.command}`,
-            method: 'DELETE',
-            context: {
-                token: this.jwt
+    })
+        .then(() => {
+            return request({
+                url: `${this.instance}/${this.namespace}/commands/${this.commandNamespace}/${this.command}`,
+                method: 'DELETE',
+                context: {
+                    token: this.jwt
+                }
+            }).then(resp => {
+                Assert.equal(resp.statusCode, 204);
+            });
+        })
+        .catch(err => {
+            if (err.statusCode !== 404) {
+                throw err;
             }
-        }).then(resp => {
-            Assert.equal(resp.statusCode, 204);
         });
-    });
 });
 
 Given(

--- a/features/step_definitions/secrets.js
+++ b/features/step_definitions/secrets.js
@@ -29,7 +29,7 @@ When(/^a secret "foo" is added globally$/, function step() {
     return request({
         url: `${this.instance}/${this.namespace}/secrets`,
         method: 'POST',
-        body: {
+        json: {
             pipelineId: this.pipelineId,
             name: 'FOO',
             value: 'secrets',
@@ -120,8 +120,8 @@ Then(/^the user can not view the secret exists$/, function step() {
         context: {
             token: this.jwt
         }
-    }).then(response => {
-        Assert.equal(response.statusCode, 403);
+    }).catch(err => {
+        Assert.strictEqual(err.statusCode, 403);
     });
 });
 
@@ -143,14 +143,19 @@ After(
         tags: '@secrets'
     },
     function hook() {
-        return request({
-            url: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
-            method: 'DELETE',
-            context: {
-                token: this.jwt
-            }
-        }).then(response => {
-            Assert.equal(response.statusCode, 204);
-        });
+        if (this.secretId) {
+            return request({
+                url: `${this.instance}/${this.namespace}/secrets/${this.secretId}`,
+                method: 'DELETE',
+                context: {
+                    token: this.jwt
+                }
+            }).then(response => {
+                Assert.equal(response.statusCode, 204);
+            });
+        }
+
+        // eslint-disable-next-line consistent-return, no-useless-return
+        return;
     }
 );

--- a/features/step_definitions/server.js
+++ b/features/step_definitions/server.js
@@ -7,7 +7,7 @@ const { Given, When, Then } = require('cucumber');
 Given(/^a running API server$/, next => next());
 
 When(/^I access the status endpoint$/, function step() {
-    return request({ method: 'GET', url: `${this.instance}/v4/status` }).then(result => {
+    return request({ method: 'GET', url: `${this.instance}/v4/status`, responseType: 'text' }).then(result => {
         this.body = result ? result.body : null;
     });
 });

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -216,9 +216,13 @@ function CustomWorld({ attach, parameters }) {
             }
             // Actual login is accomplished through getJwt
         }).then(() =>
-            this.getJwt(apiToken).then(response => {
-                this.loginResponse = response;
-            })
+            this.getJwt(apiToken)
+                .then(response => {
+                    this.loginResponse = response;
+                })
+                .catch(err => {
+                    this.loginResponse = err;
+                })
         );
     this.getPipeline = pipelineId =>
         request({


### PR DESCRIPTION
## Context

Functional tests still failing with new request package changes:
```
19:00:40 2) Scenario: Revoke API Token (attempt 1, retried) # features/api-token.feature:38
19:00:40    ✔ Before # features/step_definitions/api-token.js:9
19:00:40    ✔ Given "calvin" is logged in # features/step_definitions/authorization.js:20
19:00:40    ✔ Given "calvin" owns an existing API token named "tiger" # features/step_definitions/api-token.js:71
19:00:40    ✔ When he revokes the token # features/step_definitions/api-token.js:165
19:00:40    ✖ And the token is used to log in # features/step_definitions/api-token.js:45
19:00:40        Error: 401 Reason "Bad token"
19:00:40            at throwError (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:14:17)
19:00:40            at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:56:28
19:00:40            at processTicksAndRejections (internal/process/task_queues.js:97:5)
19:00:40    - Then the login attempt fails # features/step_definitions/api-token.js:175
```

## Objective

This PR adds more handling of non-200 status codes for functional tests.

## References

https://github.com/screwdriver-cd/screwdriver/pull/2564
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
