### PR TITLE
fix(1961): Retry with new request package

### DIFF
--- a/features/support/world.js
+++ b/features/support/world.js
@@ -14,9 +14,9 @@ const { ID } = require('./constants');
  * @param  {Function}   retryWithMergedOptions
  * @return {Object}     Build response
  */
-function buildRetryStrategy(response, retryWithMergedOptions) {
+function buildRetryStrategy(response) {
     if (response.body.status === 'QUEUED' || response.body.status === 'RUNNING') {
-        retryWithMergedOptions({});
+        throw new Error('Retry limit reached');
     }
 
     return response;
@@ -196,7 +196,8 @@ function CustomWorld({ attach, parameters }) {
         request({
             url: `${this.instance}/${this.namespace}/builds/${buildID}`,
             method: 'GET',
-            retryOptions: {
+            retry: {
+                statusCodes: [200],
                 limit: 25,
                 calculateDelay: ({ computedValue }) => (computedValue ? 15000 : 0)
             },

--- a/features/workflow.feature
+++ b/features/workflow.feature
@@ -105,7 +105,7 @@ Feature: Workflow
         Then the PR job of "AFTER-SIMPLE" is triggered from PR job of "SIMPLE"
         And that "AFTER-SIMPLE" PR build uses the same SHA as the "SIMPLE" PR build
         And the "AFTER-SIMPLE" PR build succeeded
-    
+
     @ignore
     Scenario: Branch filtering (a pull request is opened to the master branch)
         Given an existing pipeline on "master" branch with the workflow jobs:

--- a/plugins/pipelines/caches/request.js
+++ b/plugins/pipelines/caches/request.js
@@ -12,9 +12,9 @@ const RETRY_LIMIT = 3;
  * @param   {Function}  retryWithMergedOptions
  * @return  {Object}    Response
  */
-const retryStrategyFn = (response, retryWithMergedOptions) => {
+const retryStrategyFn = response => {
     if (Math.floor(response.statusCode / 100) !== 2) {
-        retryWithMergedOptions({});
+        throw new Error('Retry limit reached');
     }
 
     return response;
@@ -78,19 +78,19 @@ async function invoke(request) {
     }
 
     if (retryStrategyFn) {
-        const retryOptions = {
+        const retry = {
             limit: RETRY_LIMIT,
             calculateDelay: ({ computedValue }) => (computedValue ? RETRY_DELAY * 1000 : 0) // in ms
         };
 
         if (method === 'POST') {
-            Object.assign(retryOptions, {
+            Object.assign(retry, {
                 methods: ['POST']
             });
         }
 
         Object.assign(options, {
-            retryOptions,
+            retry,
             hooks: {
                 afterResponse: [retryStrategyFn]
             }


### PR DESCRIPTION
## Context

Retry was not working as expected in functional tests.
```
21:29:18 1) Scenario: Create an event when user starts a job (attempt 3) # features/events.feature:34
21:29:18    ✔ Before # features/step_definitions/events.js:9
21:29:18    ✔ Given an existing pipeline with the workflow: # features/step_definitions/events.js:18
21:29:18        | job  | triggers |
21:29:18        | main | publish  |
21:29:18    ✔ And "calvin" has admin permission to the pipeline # features/step_definitions/events.js:22
21:29:18    ✔ And "calvin" is logged in # features/step_definitions/authorization.js:20
21:29:18    ✔ When the "main" job is started # features/step_definitions/secrets.js:48
21:29:18    ✔ Then an event is created # features/step_definitions/events.js:24
21:29:18    ✖ And the "main" build succeeds # features/step_definitions/events.js:34
21:29:18        AssertionError: expected 'QUEUED' to equal 'SUCCESS'
21:29:18            at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/features/step_definitions/events.js:36:16
21:29:18            at runMicrotasks (<anonymous>)
21:29:18            at processTicksAndRejections (internal/process/task_queues.js:97:5)
21:29:18    - And the "publish" build succeeds with the same eventId as the "main" build # features/step_definitions/events.js:41
```
## Objective

This PR:
- renames from `retryOptions` => `retry`
- throws error in retry strategy in `afterResponse` hook to correctly trigger retries
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
