### PR TITLE
fix(2578): disallow blocked status update multiple times

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -207,6 +207,9 @@ module.exports = () => ({
                 });
             } else if (desiredStatus === 'QUEUED' && currentStatus !== 'QUEUED') {
                 throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);
+            } else if (desiredStatus === 'BLOCKED' && currentStatus === 'BLOCKED') {
+                // Queue-Service can call BLOCKED status update multiple times
+                throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);
             }
 
             let isFixed = Promise.resolve(false);

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1432,6 +1432,33 @@ describe('build plugin test', () => {
                 });
             });
 
+            it('does not allow updating to BLOCKED to BLOCKED', () => {
+                const status = 'BLOCKED';
+                const options = {
+                    method: 'PUT',
+                    url: `/builds/${id}`,
+                    auth: {
+                        credentials: {
+                            username: id,
+                            scope: ['build']
+                        },
+                        strategy: ['token']
+                    },
+                    payload: {
+                        status
+                    }
+                };
+
+                buildMock.status = 'BLOCKED';
+                buildMock.stats.blockedStartTime = Date.now();
+
+                return server.inject(options).then(reply => {
+                    assert.equal(reply.statusCode, 400);
+                    assert.calledWith(buildFactoryMock.get, id);
+                    assert.notCalled(buildMock.update);
+                });
+            });
+
             describe('workflow', () => {
                 const publishJobMock = {
                     id: publishJobId,


### PR DESCRIPTION
## Context

API to disallow BLOCKED build being updated again to BLOCKED status.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/issues/2578

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
