### PR TITLE
fix(#2585): Make the API RedLock settings configurable by k8s environment

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -416,6 +416,8 @@ redisLock:
     retryDelay: REDLOCK_RETRY_DELAY
     # the maximum time in milliseconds randomly added to retries
     retryJitter: REDLOCK_RETRY_JITTER
+    # the maximum time in milliseconds living of a key that has a timeout
+    ttl: REDLOCK_TTL
     # Configuration of the redis instance
     redisConnection:
       host: REDLOCK_REDIS_HOST

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -348,6 +348,8 @@ redisLock:
     retryDelay: 500
     # the maximum time in milliseconds randomly added to retries
     retryJitter: 200
+    # the maximum time in milliseconds living of a key that has a timeout
+    ttl: 20000
     # Configuration of the redis instance
     redisConnection:
       host: "127.0.0.1"

--- a/plugins/lock.js
+++ b/plugins/lock.js
@@ -5,19 +5,36 @@ const Redlock = require('redlock');
 const config = require('config');
 const logger = require('screwdriver-logger');
 
+/**
+ * parse value to Boolean
+ * @method parseBool
+ * @param {(Boolean|String)} value
+ * @return {Boolean}
+ */
+function parseBool(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    // True values refers to https://yaml.org/type/bool.html
+    return ['on', 'true', 'yes', 'y'].includes(String(value).toLowerCase());
+}
+
 class Lock {
     /**
      * Constructor
      */
     constructor() {
-        if (config.get('redisLock.enabled')) {
+        if (parseBool(config.get('redisLock.enabled'))) {
             const redisLockConfig = config.get('redisLock.options');
             const connectionDetails = {
                 host: redisLockConfig.redisConnection.host,
                 options: {
                     password:
                         redisLockConfig.redisConnection.options && redisLockConfig.redisConnection.options.password,
-                    tls: redisLockConfig.redisConnection.options ? redisLockConfig.redisConnection.options.tls : false
+                    tls: redisLockConfig.redisConnection.options
+                        ? parseBool(redisLockConfig.redisConnection.options.tls)
+                        : false
                 },
                 port: redisLockConfig.redisConnection.port
             };
@@ -25,11 +42,12 @@ class Lock {
             try {
                 this.redis = new Redis(connectionDetails.port, connectionDetails.host, connectionDetails.options);
                 this.redlock = new Redlock([this.redis], {
-                    driftFactor: redisLockConfig.driftFactor,
-                    retryCount: redisLockConfig.retryCount,
-                    retryDelay: redisLockConfig.retryDelay,
-                    retryJitter: redisLockConfig.retryJitter
+                    driftFactor: parseFloat(redisLockConfig.driftFactor),
+                    retryCount: parseInt(redisLockConfig.retryCount, 10),
+                    retryDelay: parseFloat(redisLockConfig.retryDelay),
+                    retryJitter: parseFloat(redisLockConfig.retryJitter)
                 });
+                this.ttl = parseFloat(redisLockConfig.ttl);
             } catch (err) {
                 logger.error('Failed to initialize redlock', err);
             }
@@ -44,7 +62,7 @@ class Lock {
      * @param   {Number}      ttl           maximum lock duration in milliseconds
      * @returns {Promise}
      */
-    async lock(resource, ttl = 20000) {
+    async lock(resource, ttl = this.ttl) {
         if (this.redlock) {
             try {
                 const lock = await this.redlock.lock(resource, ttl);

--- a/test/plugins/lock.test.js
+++ b/test/plugins/lock.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const mockery = require('mockery');
+
+/* eslint max-classes-per-file: ["error", 2] */
+class RedisMock {
+    constructor(port, host, options) {
+        this.port = port;
+        this.host = host;
+        this.options = options;
+    }
+}
+
+class RedLockMock {
+    constructor(redisList, options) {
+        this.redisList = redisList;
+        this.options = options;
+    }
+}
+
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('lock plugin test', () => {
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+
+        mockery.registerMock('ioredis', RedisMock);
+        mockery.registerMock('redlock', RedLockMock);
+    });
+
+    afterEach(() => {
+        mockery.resetCache();
+    });
+
+    describe('disable redis lock test', () => {
+        it('default disable', () => {
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            assert.equal(plugin.redis, undefined);
+            assert.equal(plugin.redlock, undefined);
+        });
+
+        it('explicitly disable', () => {
+            process.env.REDLOCK_ENABLED = 'false';
+
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            assert.equal(plugin.redis, undefined);
+            assert.equal(plugin.redlock, undefined);
+        });
+    });
+
+    describe('enable redis lock test', () => {
+        it('enabled by boolean true', () => {
+            process.env.REDLOCK_ENABLED = true;
+
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            assert.instanceOf(plugin.redis, RedisMock);
+            assert.instanceOf(plugin.redlock, RedLockMock);
+        });
+
+        it('enabled by string true', () => {
+            process.env.REDLOCK_ENABLED = 'true';
+
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            assert.instanceOf(plugin.redis, RedisMock);
+            assert.instanceOf(plugin.redlock, RedLockMock);
+        });
+    });
+
+    describe('redis options test', () => {
+        before(() => {
+            process.env.REDLOCK_ENABLED = true;
+        });
+
+        it('default values test', () => {
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            const { redis, redlock } = plugin;
+
+            assert.strictEqual(redis.host, '127.0.0.1');
+            assert.strictEqual(redis.port, 9999);
+            assert.deepEqual(redis.options, {
+                password: 'THIS-IS-A-PASSWORD',
+                tls: false
+            });
+
+            assert.deepEqual(redlock.redisList, [redis]);
+            assert.deepEqual(redlock.options, {
+                driftFactor: 0.01,
+                retryCount: 200,
+                retryDelay: 500,
+                retryJitter: 200
+            });
+            assert.equal(plugin.ttl, 20000);
+        });
+
+        it('change options test', () => {
+            process.env.REDLOCK_REDIS_HOST = '127.0.0.2';
+            process.env.REDLOCK_REDIS_PORT = 9090;
+            process.env.REDLOCK_REDIS_PASSWORD = 'password';
+            process.env.REDLOCK_REDIS_TLS_ENABLED = true;
+
+            process.env.REDLOCK_DRIFT_FACTOR = 0.02;
+            process.env.REDLOCK_RETRY_COUNT = 100;
+            process.env.REDLOCK_RETRY_DELAY = 200;
+            process.env.REDLOCK_RETRY_JITTER = 300;
+            process.env.REDLOCK_TTL = 40000;
+
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            const { redis, redlock } = plugin;
+
+            assert.strictEqual(redis.host, '127.0.0.2');
+            assert.strictEqual(redis.port, '9090');
+            assert.deepEqual(redis.options, {
+                password: 'password',
+                tls: true
+            });
+
+            assert.deepEqual(redlock.redisList, [redis]);
+            assert.deepEqual(redlock.options, {
+                driftFactor: 0.02,
+                retryCount: 100,
+                retryDelay: 200,
+                retryJitter: 300
+            });
+            assert.equal(plugin.ttl, 40000);
+        });
+
+        it('string options parse test', () => {
+            process.env.REDLOCK_REDIS_TLS_ENABLED = 'true';
+
+            process.env.REDLOCK_DRIFT_FACTOR = '0.02';
+            process.env.REDLOCK_RETRY_COUNT = '100';
+            process.env.REDLOCK_RETRY_DELAY = '200';
+            process.env.REDLOCK_RETRY_JITTER = '300';
+            process.env.REDLOCK_TTL = '40000';
+
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            const { redis, redlock } = plugin;
+
+            assert.strictEqual(redis.options.tls, true);
+            assert.deepEqual(redlock.redisList, [redis]);
+            assert.deepEqual(redlock.options, {
+                driftFactor: 0.02,
+                retryCount: 100,
+                retryDelay: 200,
+                retryJitter: 300
+            });
+            assert.equal(plugin.ttl, 40000);
+        });
+    });
+});


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix the following issue
https://github.com/screwdriver-cd/screwdriver/issues/2585

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- I fix that the api deployment configuration file be applied to the actual redlock configuration.
- I fix that we can also set the TTL by `REDLOCK_TTL`.
- I add the test for lock.js

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- Issue
  - https://github.com/screwdriver-cd/screwdriver/issues/2585

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
