### PR TITLE
fix(1393): Add sourcePath functional test

### DIFF
--- a/features/step_definitions/trigger.js
+++ b/features/step_definitions/trigger.js
@@ -27,6 +27,18 @@ Before(
     }
 );
 
+Before(
+    {
+        tags: '@sourcePath'
+    },
+    function hook() {
+        this.repoOrg = this.testOrg;
+        this.repoName = 'functional-sourcePath';
+        this.pipelineId = null;
+        this.builds = null;
+    }
+);
+
 Given(
     /^an existing pipeline on branch "([^"]*)" with the workflow jobs:$/,
     {
@@ -168,6 +180,18 @@ When(
         this.pipelines[branchName].eventId = build.eventId;
 
         Assert.equal(build.jobId, job.id);
+    }
+);
+
+When(
+    /^a new file is added to the "([^"]*)" directory of the "([^"]*)" branch$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(directoryName, branchName) {
+        github.createFile(branchName, this.repoOrg, this.repoName, directoryName).then(response => {
+            this.pipelines[branchName].sha = response.data.commit.sha;
+        });
     }
 );
 

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -141,7 +141,7 @@ function createBranch(branch, repoOwner, repoName) {
  * @param  {String}   directoryName     Name of the directory
  * @return {Promise}
  */
-function createFile(branch, repoOwner, repoName) {
+function createFile(branch, repoOwner, repoName, directoryName) {
     // eslint-disable-next-line new-cap
     const content = new Buffer.alloc(MAX_CONTENT_LENGTH, randomString(MAX_CONTENT_LENGTH));
     const filename = randomString(MAX_FILENAME_LENGTH);

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -138,6 +138,7 @@ function createBranch(branch, repoOwner, repoName) {
  * @param  {String}   branch            The branch to create the file in
  * @param  {String}   [repoOwner]       Owner of the repository
  * @param  {String}   [repoName]        Name of the repository
+ * @param  {String}   directoryName     Name of the directory
  * @return {Promise}
  */
 function createFile(branch, repoOwner, repoName) {
@@ -146,11 +147,12 @@ function createFile(branch, repoOwner, repoName) {
     const filename = randomString(MAX_FILENAME_LENGTH);
     const owner = repoOwner || 'screwdriver-cd-test';
     const repo = repoName || 'functional-git';
+    const filePath = directoryName || 'testfiles';
 
     return octokit.repos.createOrUpdateFileContents({
         owner,
         repo,
-        path: `testfiles/${filename}`,
+        path: `${filePath}/${filename}`,
         message: new Date().toString(), // commit message is the current time
         content: content.toString('base64'), // content needs to be transmitted in base64
         branch

--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -121,3 +121,14 @@ Feature: Remote Trigger
         And the "parallel2" build succeeded
         Then the "join" job is triggered from "parallel1" and "parallel2" on branch "external_trigger2"
         And that "join" build uses the same SHA as the "main" build on branch "external_trigger2"
+
+    @sourcePath
+    Scenario: sourcePath
+      Given an existing pipeline on branch "master" with the workflow jobs:
+            | job       | requires  |
+            | job1      | ~commit   |
+            | job2      | ~commit   |
+      When a new file is added to the "directory1" directory of the "master" branch
+      Then a new build from "job1" should be created to test that change
+      And a new build from "job2" should not be created to test that change
+


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR adds smallest functional tests to keep the quality  sourcePath.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds a new test for sourcePath. Details can be found in the feature file.

To run this functional test, please prepare the following repository and screwdriver.yaml.
The administrator of screwdriver should be ready.

1. Create a `functional-sourcePath` repository [here](https://github.com/screwdriver-cd-test)
2. Add `screwdriver.yaml` to the `master` branch of `functional-sourcePath`.

`screwdriver.yaml`:
```
shared:
  image: node:14
 
jobs:
  job1:
    requires: [ ~commit ]
    sourcePaths:
      - directory1/
    steps:
      - echo: echo "this is build1"

  job2:
    requires: [ ~commit ]
    sourcePaths:
      - directory2/
    steps:
      - echo: echo "this is build2"
```
<img width="554" alt="スクリーンショット 2021-10-29 9 43 16" src="https://user-images.githubusercontent.com/17828065/139354962-ff723c77-6653-42a4-bde3-f110391a8ffa.png">

## References
- Related Issue
- https://github.com/screwdriver-cd/screwdriver/issues/1393
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
