### PR TITLE
fix(1393): Make it easier to prepare template functional tests

### DIFF
--- a/features/step_definitions/templates.js
+++ b/features/step_definitions/templates.js
@@ -144,6 +144,7 @@ Given(
     function step(template, version, jobName) {
         this.template = template;
         this.jobName = jobName;
+        this.branchName = 'second';
 
         return request({
             url: `${this.instance}/${this.namespace}/templates/${this.templateNamespace}%2F${this.template}/${version}`,
@@ -225,7 +226,7 @@ When(
     },
     function step(permission, status, jobName) {
         if (permission === 'wrong') {
-            this.branchName = 'wrong-permission';
+            this.branchName = 'second';
         }
 
         return this.startJob(jobName).then(result => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To make preparing template functional tests added by this [PR](https://github.com/screwdriver-cd/screwdriver/pull/2593) easier.

This PR will be mergeable after following PRs are merged.
  - https://github.com/screwdriver-cd-test/functional-template/pull/1
  - https://github.com/screwdriver-cd-test/functional-template/pull/2

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I will move `use-template` and `custom-template` jobs from `master` branch to `wrong-permission` branch.
And rename `wrong-permission` branch to `second`.
Then we don't have to comment out and uncomment when [prepare pipelines](https://github.com/screwdriver-cd/screwdriver/pull/2593)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- PR
  - https://github.com/screwdriver-cd-test/functional-template/pull/1
  - https://github.com/screwdriver-cd-test/functional-template/pull/2
- Issue
  - https://github.com/screwdriver-cd/screwdriver/issues/1393

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
