### PR TITLE
fix(1500): Ignore zip artifacts functional test

### DIFF
--- a/features/artifacts.feature
+++ b/features/artifacts.feature
@@ -21,7 +21,7 @@ Feature: Artifacts
         And the "main" build succeeds
         And artifacts were found in the build
 
-    @zip-artifacts
+    @ignore
     Scenario: Verify that the artifacts have been saved with zipping enabled.
         And "calvin" is logged in
         When the "zipped" job is started

--- a/features/artifacts.feature
+++ b/features/artifacts.feature
@@ -21,6 +21,7 @@ Feature: Artifacts
         And the "main" build succeeds
         And artifacts were found in the build
 
+    @zip-artifacts
     Scenario: Verify that the artifacts have been saved with zipping enabled.
         And "calvin" is logged in
         When the "zipped" job is started

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",
     "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
-    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and (not @zip-artifacts)' --retry 2 --fail-fast --exit",
+    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",
     "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
-    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
+    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and (not @artifacts)' --retry 2 --fail-fast --exit",
     "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",
     "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
-    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and (not @artifacts)' --retry 2 --fail-fast --exit",
+    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and (not @zip-artifacts)' --retry 2 --fail-fast --exit",
     "functional-dev": "cucumber-js --format=./node_modules/cucumber-pretty --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",
     "diagrams": "find ./design/diagrams -type f -name \\*.puml -print0 | xargs -0 -n 1 -I DIAGRAM puml generate DIAGRAM -o DIAGRAM.png",


### PR DESCRIPTION
## Context
~The beta doesn't have aws lamda, so I can't unzip it.~
~However. I think it's expensive to add aws lamda to beta for functional test of artifacts, so I'll set beta to ignore functional test.~
OSSD does not have aws lamda, so ignore the SD_ZIP_ARTIFACTS function test.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Added a setting  to ignore functional tests in artifacts.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
#1500 

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
