### PR TITLE
fix(1393): Add functional tests for user teardown steps

### DIFF
--- a/features/step_definitions/user-teardown-step.js
+++ b/features/step_definitions/user-teardown-step.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const Assert = require('chai').assert;
+const { Before, Given, Then } = require('cucumber');
+const request = require('screwdriver-request');
+
+const TIMEOUT = 240 * 1000;
+
+Before('@user-teardown-step', function hook() {
+    this.repoName = 'functional-user-teardown-step';
+    this.branchName = 'master';
+
+    this.buildId = null;
+    this.jwt = null;
+});
+
+Given(
+    /^an existing pipeline for user-teardown-step with the workflow:$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(table) {
+        return this.ensurePipelineExists({
+            repoName: this.repoName,
+            branch: this.branchName,
+            table,
+            shouldNotDeletePipeline: true
+        });
+    }
+);
+
+Then(
+    /^the job succeeded$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step() {
+        return this.waitForBuild(this.buildId).then(response => {
+            Assert.equal(response.statusCode, 200);
+            Assert.equal(response.body.status, 'SUCCESS');
+        });
+    }
+);
+
+Then(
+    /^the job failed$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step() {
+        return this.waitForBuild(this.buildId).then(response => {
+            Assert.equal(response.statusCode, 200);
+            Assert.equal(response.body.status, 'FAILURE');
+        });
+    }
+);
+
+Then(
+    /^the "([^"]*)" step succeeded$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(stepName) {
+        return request({
+            url: `${this.instance}/${this.namespace}/builds/${this.buildId}/steps/${stepName}`,
+            method: 'GET',
+            context: {
+                token: this.jwt
+            }
+        }).then(response => {
+            Assert.equal(response.statusCode, 200);
+            Assert.equal(response.body.code, 0);
+        });
+    }
+);
+
+Then(
+    /^the "([^"]*)" step failed$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(stepName) {
+        return request({
+            url: `${this.instance}/${this.namespace}/builds/${this.buildId}/steps/${stepName}`,
+            method: 'GET',
+            context: {
+                token: this.jwt
+            }
+        }).then(response => {
+            Assert.equal(response.statusCode, 200);
+            Assert.equal(response.body.code, 1);
+        });
+    }
+);
+
+Then(
+    /^the "([^"]*)" step skipped$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(stepName) {
+        return request({
+            url: `${this.instance}/${this.namespace}/builds/${this.buildId}/steps/${stepName}`,
+            method: 'GET',
+            context: {
+                token: this.jwt
+            }
+        }).then(response => {
+            Assert.equal(response.statusCode, 200);
+            Assert.isUndefined(response.body.code);
+        });
+    }
+);

--- a/features/user-teardown-step.feature
+++ b/features/user-teardown-step.feature
@@ -1,0 +1,28 @@
+@user-teardown-step
+Feature: User Teardown Steps
+
+    Users want to be able to define teardown steps which will be run regardless of whether
+    the build succeeds or fails.
+
+    Rules:
+        - Teardown steps needs to be at the end of the job
+        - Teardown step names should be prefixed with "teardown-"
+
+    Scenario: A Teardown step will be run when the build succeeds
+        Given an existing pipeline for user-teardown-step with the workflow:
+            | job     | requires |
+            | success | ~commit  |
+        When execute success job
+        Then the job succeeded
+        And the "main" step succeeded
+        And the "teardown-when-succeed" step succeeded
+
+    Scenario: A Teardown step will be run when the build fails
+        Given an existing pipeline for user-teardown-step with the workflow:
+            | job     | requires |
+            | failure | ~commit  |
+        When execute failure job
+        Then the job failed
+        And the "main" step failed
+        And the "not-executed" step skipped
+        And the "teardown-when-fail" step succeeded


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add some functional tests for [user teardown steps](https://docs.screwdriver.cd/user-guide/configuration/jobconfiguration.html#steps).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds some functional tests for user teardown steps.

To run these functional tests, please prepare the following repository.
The administrator of screwdriver should be ready please.

1. Create `functional-user-teardown-step` repository in [screwdriver-cd-test](https://github.com/screwdriver-cd-test).
2. Add following `screwdriver.yaml` to the `master` branch of `functional-user-teardown-step`.

`screwdriver.yaml`

```yaml
shared:
  image: node:14
jobs:
  success:
    requires: [ ~commit ]
    steps:
      - main: echo "main step"
      - teardown-when-succeed: echo "teardown-when-succeed step"
  failure:
    requires: [ ~commit ]
    steps:
      - main: exit 1
      - not-executed: echo "not-executed step"
      - teardown-when-fail: echo "teardown-when-fail step"
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue
  - https://github.com/screwdriver-cd/screwdriver/issues/1393

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
