### PR TITLE
fix(1956): Do not get step info for event and job API

### DIFF
--- a/plugins/events/README.md
+++ b/plugins/events/README.md
@@ -32,6 +32,9 @@ server.register({
 #### Returns a list of builds associated with the event
 `GET /events/{id}/builds`
 
+`GET /events/{id}/builds?steps=true`
+
+
 #### Get build metrics for a single event
 `GET /events/{id}/metrics`
 

--- a/plugins/events/listBuilds.js
+++ b/plugins/events/listBuilds.js
@@ -24,14 +24,23 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { eventFactory } = request.server.app;
             const event = await eventFactory.get(request.params.id);
+            const { steps } = request.query;
 
             if (!event) {
                 throw boom.notFound('Event does not exist');
             }
 
-            const buildsModel = await event.getBuilds();
+            const buildsModel = await event.getBuilds({
+                readOnly: true
+            });
 
-            const data = await Promise.all(buildsModel.map(async buildModel => buildModel.toJsonWithSteps()));
+            let data;
+
+            if (steps) {
+                data = await Promise.all(buildsModel.map(async buildModel => buildModel.toJsonWithSteps()));
+            } else {
+                data = await Promise.all(buildsModel.map(async buildModel => buildModel.toJson()));
+            }
 
             return h.response(data);
         },
@@ -41,7 +50,16 @@ module.exports = () => ({
         validate: {
             params: joi.object({
                 id: eventIdSchema
-            })
+            }),
+            query: schema.api.pagination.concat(
+                joi.object({
+                    steps: joi
+                        .boolean()
+                        .truthy('true')
+                        .falsy('false')
+                        .default(false)
+                })
+            )
         }
     }
 });

--- a/plugins/jobs/README.md
+++ b/plugins/jobs/README.md
@@ -46,6 +46,8 @@ Example payload:
 #### Get list of builds for a single job
 `GET /jobs/{id}/builds`
 
+`GET /jobs/{id}/builds?steps=true`
+
 `GET /jobs/{id}/builds?page=2&count=30&sort=ascending`
 
 `GET /jobs/{id}/builds?page=2&count=30&sort=ascending&sortBy=id`

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -219,6 +219,7 @@ describe('event plugin test', () => {
         it('returns 200 for getting builds', () =>
             server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
+                assert.calledWith(event.getBuilds, { readOnly: true });
                 assert.deepEqual(reply.result, testBuilds);
             }));
     });

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -15,6 +15,7 @@ const decorateBuildMock = build => {
     const mock = hoek.clone(build);
 
     mock.toJsonWithSteps = sinon.stub().resolves(build);
+    mock.toJson = sinon.stub().resolves(build);
 
     return mock;
 };
@@ -331,7 +332,8 @@ describe('job plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.calledWith(job.getBuilds, {
                     sort: 'descending',
-                    sortBy: 'createTime'
+                    sortBy: 'createTime',
+                    readOnly: true
                 });
                 assert.deepEqual(reply.result, testBuilds);
             }));
@@ -347,7 +349,8 @@ describe('job plugin test', () => {
                         page: 2
                     },
                     sort: 'ascending',
-                    sortBy: 'createTime'
+                    sortBy: 'createTime',
+                    readOnly: true
                 });
                 assert.deepEqual(reply.result, testBuilds);
             });
@@ -364,7 +367,8 @@ describe('job plugin test', () => {
                         page: 2
                     },
                     sort: 'ascending',
-                    sortBy: 'id'
+                    sortBy: 'id',
+                    readOnly: true
                 });
                 assert.deepEqual(reply.result, testBuilds);
             });
@@ -381,7 +385,8 @@ describe('job plugin test', () => {
                         count: 30
                     },
                     sort: 'descending',
-                    sortBy: 'createTime'
+                    sortBy: 'createTime',
+                    readOnly: true
                 });
                 assert.deepEqual(reply.result, testBuilds);
             });


### PR DESCRIPTION
## Context

Some endpoints don't need to fetch step info for builds.

## Objective

This PR adds option to set query param `steps=true` if a user wants to fetch steps alongside build info for certain endpoints. Also uses readOnly DB to get build info.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1956

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
