### PR TITLE
fix(1500): [4] add a new endpoint for POST /builds/{id}/artifacts/unzip

### DIFF
--- a/plugins/builds/artifacts/unzip.js
+++ b/plugins/builds/artifacts/unzip.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const idSchema = schema.models.build.base.extract('id');
+
+module.exports = config => ({
+    method: 'POST',
+    path: '/builds/{id}/artifacts/unzip',
+    options: {
+        description: 'Extract a ZIP for build artifacts',
+        notes: 'Extract a specific ZIP for build artifacts',
+        tags: ['api', 'builds', 'artifacts'],
+        auth: {
+            strategies: ['token'],
+            scope: ['build']
+        },
+
+        handler: async (req, h) => {
+            const buildId = req.params.id;
+            const { username, scope } = req.auth.credentials;
+            const isBuild = scope.includes('build');
+            const { buildFactory } = req.server.app;
+
+            if (isBuild && username !== buildId) {
+                return boom.forbidden(`Credential only valid for ${username}`);
+            }
+
+            return buildFactory
+                .get(buildId)
+                .then(async buildModel => {
+                    if (!buildModel) {
+                        throw boom.notFound('Build does not exist');
+                    }
+                    await buildModel.unzipArtifacts();
+                    return h.response().code(202);
+                })
+                .catch(err => {
+                    throw err;
+                });
+        },
+        validate: {
+            params: joi.object({
+                id: idSchema
+            })
+        }
+    }
+});

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -11,6 +11,7 @@ const createRoute = require('./create');
 const stepGetRoute = require('./steps/get');
 const listStepsRoute = require('./steps/list');
 const artifactGetRoute = require('./artifacts/get');
+const artifactUnzipRoute = require('./artifacts/unzip');
 const stepUpdateRoute = require('./steps/update');
 const stepLogsRoute = require('./steps/logs');
 const listSecretsRoute = require('./listSecrets');
@@ -1106,7 +1107,8 @@ const buildsPlugin = {
             listSecretsRoute(),
             tokenRoute(),
             metricsRoute(),
-            artifactGetRoute(options)
+            artifactGetRoute(options),
+            artifactUnzipRoute(),
         ]);
     }
 };


### PR DESCRIPTION
## Context
To implement SD_ZIP_ARTIFACTS feature by [new design](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md)

Please refer the following for the progress of this feature.
https://github.com/screwdriver-cd/screwdriver/issues/1500#issuecomment-998382248

## Objective
This PR adds a new endpoint for `/builds/{id}/artifacts/unzip` to accept the `unzip` request from `artifacts-bookend` step in a build and to request for queue-service to unzip.

In the picture of design doc, this fix apply to the following area.

![image](https://user-images.githubusercontent.com/5774825/146849303-8aaefa87-02b8-4796-9485-b97c93f1c656.png)

## References
This PR depends on following PRs.
- https://github.com/screwdriver-cd/executor-base/pull/75
- https://github.com/screwdriver-cd/executor-queue/pull/97
- https://github.com/screwdriver-cd/models/pull/520

[design doc](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md#sd-api-api)

[issue](https://github.com/screwdriver-cd/screwdriver/issues/1500)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
