### PR TITLE
Revert "fix(2526): Restart failed build in join workflow should trigger join job"

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -270,7 +270,6 @@ async function createInternalBuild(config) {
     } else {
         job = await jobFactory.get(jobId);
     }
-
     const internalBuildConfig = {
         jobId: job.id,
         sha: event.sha,
@@ -410,6 +409,11 @@ function parseJobInfo({ joinObj = {}, current, nextJobName, nextPipelineId }) {
  * @return {Promise}                            All finished builds
  */
 async function getFinishedBuilds(event, buildFactory) {
+    if (!event.parentEventId) {
+        // FIXME: remove this flow to always use buildFactory.getLatestBuilds
+        return event.getBuilds();
+    }
+
     // FIXME: buildFactory.getLatestBuilds doesn't return build model
     const builds = await buildFactory.getLatestBuilds({ groupEventId: event.groupEventId });
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1642,26 +1642,11 @@ describe('build plugin test', () => {
                     state: 'ENABLED'
                 };
                 const jobC = { ...jobB, id: 3 };
-                let buildMocks;
                 let jobBconfig;
                 let jobCconfig;
                 let parentEventMock;
 
                 beforeEach(() => {
-                    buildMocks = [
-                        {
-                            jobId: 1,
-                            status: 'SUCCESS',
-                            id: 12345,
-                            eventId: '8888'
-                        },
-                        {
-                            jobId: 4,
-                            status: 'SUCCESS',
-                            id: 123456,
-                            eventId: '8888'
-                        }
-                    ];
                     parentEventMock = {
                         id: 456,
                         pipelineId,
@@ -1775,7 +1760,22 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
 
-                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
+                    const buildMocks = [
+                        {
+                            jobId: 1,
+                            status: 'SUCCESS',
+                            id: 12345,
+                            eventId: '8888'
+                        },
+                        {
+                            jobId: 4,
+                            status: 'SUCCESS',
+                            id: 123456,
+                            eventId: '8888'
+                        }
+                    ];
+
+                    eventMock.getBuilds.resolves(buildMocks);
 
                     const parentBuildsB = {
                         123: { eventId: '8888', jobs: { a: 12345 } }
@@ -1811,7 +1811,22 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
 
-                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
+                    const buildMocks = [
+                        {
+                            jobId: 1,
+                            status: 'SUCCESS',
+                            id: 12345,
+                            eventId: '8888'
+                        },
+                        {
+                            jobId: 4,
+                            status: 'SUCCESS',
+                            id: 123456,
+                            eventId: '8888'
+                        }
+                    ];
+
+                    eventMock.getBuilds.resolves(buildMocks);
 
                     const parentBuildsB = {
                         123: { eventId: '8888', jobs: { 'PR-15:a': 12345 } }
@@ -1887,7 +1902,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(buildC);
 
-                    buildMocks = [
+                    const buildMocks = [
                         {
                             jobId: 1,
                             status: 'SUCCESS',
@@ -1903,7 +1918,7 @@ describe('build plugin test', () => {
                         buildC
                     ];
 
-                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
+                    eventMock.getBuilds.resolves(buildMocks);
                     buildFactoryMock.get.withArgs(123456).resolves(buildMocks[1]);
                     buildFactoryMock.get.withArgs(123455).resolves(buildC);
 
@@ -1931,7 +1946,7 @@ describe('build plugin test', () => {
                         { src: 'b', dest: 'c', join: true }
                     ];
 
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    eventMock.getBuilds.resolves([
                         buildMock,
                         {
                             id: 222,
@@ -2410,7 +2425,7 @@ describe('build plugin test', () => {
                     });
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    eventMock.getBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -2538,7 +2553,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    externalEventMock.getBuilds.resolves([
                         {
                             jobId: 1,
                             status: 'SUCCESS'
@@ -2573,7 +2588,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
+                        assert.calledOnce(externalEventMock.getBuilds);
                         assert.calledTwice(buildC.update);
                         assert.calledOnce(updatedBuildC.start);
                     });
@@ -2674,7 +2689,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    eventMock.getBuilds.resolves([
                         {
                             jobId: 3,
                             status: 'SUCCESS'
@@ -2688,7 +2703,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
+                        assert.calledOnce(externalEventMock.getBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.calledWith(buildFactoryMock.create, jobCConfig);
                         assert.calledOnce(buildC.update);
@@ -2800,7 +2815,7 @@ describe('build plugin test', () => {
                         ]
                     };
                     buildMock.parentBuilds = {
-                        2: { eventId: '8887', jobs: { a: null } }
+                        2: { eventId: '8887', jobs: { a: 12345 } }
                     };
                     const buildC = {
                         jobId: 3,
@@ -2861,7 +2876,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    eventMock.getBuilds.resolves([
                         {
                             jobId: 1,
                             status: 'SUCCESS'
@@ -2877,7 +2892,8 @@ describe('build plugin test', () => {
                         {
                             jobId: 6,
                             status: 'ABORTED'
-                        }
+                        },
+                        buildC
                     ]);
                     jobBconfig.parentBuilds = {
                         123: {
@@ -2899,7 +2915,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
+                        assert.calledOnce(externalEventMock.getBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.notCalled(buildC.update);
                         assert.notCalled(updatedBuildC.start);
@@ -2937,7 +2953,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    eventMock.getBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -3004,7 +3020,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    eventMock.getBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -3431,23 +3447,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.getLatestBuilds.resolves([
-                        {
-                            id: 888,
-                            jobId: 1,
-                            status: 'SUCCESS'
-                        },
-                        {
-                            id: 999,
-                            parentBuilds: {
-                                123: {
-                                    eventId: '8888',
-                                    jobs: { a: 12345, c: 45678 }
-                                }
-                            },
-                            jobId: 3,
-                            status: 'FAILED'
-                        },
+                    eventMock.getBuilds.resolves([
                         {
                             jobId: 4,
                             status: 'SUCCESS'
@@ -3481,7 +3481,7 @@ describe('build plugin test', () => {
                     return newServer.inject(options).then(() => {
                         assert.calledOnce(eventFactoryMock.create);
                         assert.calledWith(eventFactoryMock.create, eventConfig);
-                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
+                        assert.calledOnce(externalEventMock.getBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.calledOnce(buildC.update);
                         assert.calledOnce(updatedBuildC.start);
@@ -3667,7 +3667,7 @@ describe('build plugin test', () => {
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
                     // job B failed
-                    buildFactoryMock.getLatestBuilds.resolves([
+                    eventMock.getBuilds.resolves([
                         {
                             jobId: 1,
                             eventId: '8888',


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#2611

Causing failures in trigger feature for functional test: https://cd.screwdriver.cd/pipelines/1/builds/757573/steps/test