### PR TITLE
feat(1769): [3] Modify webhook plugin to use queue webhook

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -50,6 +50,9 @@ const notificationConfig = config.get('notifications');
 // Multiple build cluster feature flag
 const multiBuildClusterEnabled = convertToBool(config.get('multiBuildCluster').enabled);
 
+// Queue Webhook feature flag
+const queueWebhookEnabled = convertToBool(config.get('queueWebhook').enabled);
+
 // Default cluster environment variable
 const clusterEnvConfig = config.get('build').environment; // readonly
 const clusterEnv = { ...clusterEnvConfig };
@@ -254,6 +257,10 @@ datastore.setup(datastoreConfig.ddlSyncEnabled).then(() =>
         validator: {
             externalJoin: true,
             notificationsValidationErr
+        },
+        queueWebhook: {
+            executor,
+            queueWebhookEnabled
         }
     })
         .then(instance => logger.info('Server running at %s', instance.info.uri))

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -271,6 +271,11 @@ executor:
           tls: QUEUE_REDIS_TLS_ENABLED
         database: QUEUE_REDIS_DATABASE
 
+
+queueWebhook:
+  # Enabled events from webhook queue or not
+  enabled: QUEUE_WEBHOOK_ENABLED
+
 scms:
   __name: SCM_SETTINGS
   __format: json

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -190,6 +190,10 @@ executor:
           tls: false
         database: 0
 
+queueWebhook:
+  # Enabled events from webhook queue or not
+  enabled: false
+
 scms: {}
 #   github:
 #     plugin: github

--- a/lib/server.js
+++ b/lib/server.js
@@ -136,7 +136,8 @@ module.exports = async config => {
             collectionFactory: config.collectionFactory,
             buildClusterFactory: config.buildClusterFactory,
             ecosystem: config.ecosystem,
-            release: config.release
+            release: config.release,
+            queueWebhook: config.queueWebhook
         };
 
         const bellConfigs = await config.auth.scm.getBellConfiguration();

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -88,7 +88,14 @@ const webhooksPlugin = {
                                 scope: ['sdapi']
                             });
 
-                            return await executor.enqueueWebhook(parsed);
+                            try {
+                                return await executor.enqueueWebhook(parsed);
+                            } catch (err) {
+                                // if enqueueWebhook is not implemented, an event starts without enqueuing
+                                if (err.message != 'Not implemented') {
+                                    throw err;
+                                }
+                            }
                         }
 
                         return await startHookEvent(request, h, parsed);

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -66,6 +66,7 @@ const webhooksPlugin = {
                     const { scm } = pipelineFactory;
                     const { executor, queueWebhookEnabled } = queueWebhook;
                     let message = 'Unable to process this kind of event';
+                    let hookId;
 
                     try {
                         const parsed = await scm.parseHook(request.headers, request.payload);
@@ -77,7 +78,8 @@ const webhooksPlugin = {
 
                         parsed.pluginOptions = pluginOptions;
 
-                        const { type, hookId } = parsed;
+                        const { type } = parsed;
+                        hookId = parsed.hookId;
 
                         request.log(['webhook', hookId], `Received event type ${type}`);
 

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -1361,6 +1361,16 @@ describe('webhooks plugin test', () => {
                 });
             });
 
+            it('returns 201 when executor.enqueueWebhook is not implemented', () => {
+                const err = new Error('Not implemented');
+                queueWebhookMock.queueWebhookEnabled = true;
+                queueWebhookMock.executor.enqueueWebhook.rejects(err);
+
+                return server.inject(options).then(reply => {
+                    assert.equal(reply.statusCode, 201);
+                });
+            });
+
             it('returns 500 when failed', () => {
                 eventFactoryMock.create.rejects(new Error('Failed to start'));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This is the implementation that follows https://github.com/screwdriver-cd/screwdriver/pull/2622.
I modify the webhook plugin to POST the webhook received from SCM to the queue service endpoint `/v1/queue/message?type=webhook` when `queueWebhookEnabled` is true.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Add `queueWebhookEnabled` to config so that users can choose whether or not to queue the webhook.
- Add an object `queueWebhook` to `server.app` so that the following items can be used from the plugins.
  - Whether or not to use the queueWebhook set in config.
  - An instance of the executor plugin.
- Make the `executor.enqueueWebhook` method to POST to `/v1/queue/message?type=webhook` to be executed according to the `queueWebhookEnabled` setting.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Please do not merge this PR until after the following PRs have been merged.
- https://github.com/screwdriver-cd/executor-base/pull/77
- https://github.com/screwdriver-cd/executor-queue/pull/99

https://github.com/screwdriver-cd/screwdriver/issues/1769#issuecomment-934107626

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
