### PR TITLE
fix(2526): Restart failed build in join workflow should trigger join job

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -410,11 +410,6 @@ function parseJobInfo({ joinObj = {}, current, nextJobName, nextPipelineId }) {
  * @return {Promise}                            All finished builds
  */
 async function getFinishedBuilds(event, buildFactory) {
-    if (!event.parentEventId) {
-        // FIXME: remove this flow to always use buildFactory.getLatestBuilds
-        return event.getBuilds();
-    }
-
     // FIXME: buildFactory.getLatestBuilds doesn't return build model
     const builds = await buildFactory.getLatestBuilds({ groupEventId: event.groupEventId });
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1643,11 +1643,26 @@ describe('build plugin test', () => {
                     state: 'ENABLED'
                 };
                 const jobC = { ...jobB, id: 3 };
+                let buildMocks;
                 let jobBconfig;
                 let jobCconfig;
                 let parentEventMock;
 
                 beforeEach(() => {
+                    buildMocks = [
+                        {
+                            jobId: 1,
+                            status: 'SUCCESS',
+                            id: 12345,
+                            eventId: '8888'
+                        },
+                        {
+                            jobId: 4,
+                            status: 'SUCCESS',
+                            id: 123456,
+                            eventId: '8888'
+                        }
+                    ];
                     parentEventMock = {
                         id: 456,
                         pipelineId,
@@ -1761,21 +1776,7 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
 
-                    const buildMocks = [
-                        {
-                            jobId: 1,
-                            status: 'SUCCESS',
-                            id: 12345,
-                            eventId: '8888'
-                        },
-                        {
-                            jobId: 4,
-                            status: 'SUCCESS',
-                            id: 123456,
-                            eventId: '8888'
-                        }
-                    ];
-
+                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
                     eventMock.getBuilds.resolves(buildMocks);
 
                     const parentBuildsB = {
@@ -1787,7 +1788,9 @@ describe('build plugin test', () => {
 
                     buildFactoryMock.create.onCall(0).returns({ ...buildMock, parentBuilds: parentBuildsB });
                     // jobC is created without starting, so status is not QUEUED
-                    buildFactoryMock.create.onCall(1).returns({ ...buildMock, status: 'CREATED', parentBuilds: parentBuildsC });
+                    buildFactoryMock.create
+                        .onCall(1)
+                        .returns({ ...buildMock, status: 'CREATED', parentBuilds: parentBuildsC });
 
                     return server.inject(options).then(() => {
                         // create the builds
@@ -1815,21 +1818,7 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
 
-                    const buildMocks = [
-                        {
-                            jobId: 1,
-                            status: 'SUCCESS',
-                            id: 12345,
-                            eventId: '8888'
-                        },
-                        {
-                            jobId: 4,
-                            status: 'SUCCESS',
-                            id: 123456,
-                            eventId: '8888'
-                        }
-                    ];
-
+                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
                     eventMock.getBuilds.resolves(buildMocks);
 
                     const parentBuildsB = {
@@ -1848,7 +1837,9 @@ describe('build plugin test', () => {
 
                     buildFactoryMock.create.onCall(0).returns({ ...buildMock, parentBuilds: parentBuildsB });
                     // jobC is created without starting, so status is not QUEUED
-                    buildFactoryMock.create.onCall(1).returns({ ...buildMock, status: 'CREATED', parentBuilds: parentBuildsC });
+                    buildFactoryMock.create
+                        .onCall(1)
+                        .returns({ ...buildMock, status: 'CREATED', parentBuilds: parentBuildsC });
 
                     // for chainPR settings
                     pipelineMock.chainPR = true;
@@ -1909,7 +1900,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(buildC);
 
-                    const buildMocks = [
+                    buildMocks = [
                         {
                             jobId: 1,
                             status: 'SUCCESS',
@@ -1925,7 +1916,7 @@ describe('build plugin test', () => {
                         buildC
                     ];
 
-                    eventMock.getBuilds.resolves(buildMocks);
+                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
                     buildFactoryMock.get.withArgs(123456).resolves(buildMocks[1]);
                     buildFactoryMock.get.withArgs(123455).resolves(buildC);
 
@@ -1953,7 +1944,7 @@ describe('build plugin test', () => {
                         { src: 'b', dest: 'c', join: true }
                     ];
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         buildMock,
                         {
                             id: 222,
@@ -2432,7 +2423,7 @@ describe('build plugin test', () => {
                     });
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -2500,7 +2491,7 @@ describe('build plugin test', () => {
                     });
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -2628,7 +2619,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    externalEventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             status: 'SUCCESS'
@@ -2663,7 +2654,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledTwice(buildC.update);
                         assert.calledOnce(updatedBuildC.start);
                     });
@@ -2764,7 +2755,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 3,
                             status: 'SUCCESS'
@@ -2778,7 +2769,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.calledWith(buildFactoryMock.create, jobCConfig);
                         assert.calledOnce(buildC.update);
@@ -2890,7 +2881,7 @@ describe('build plugin test', () => {
                         ]
                     };
                     buildMock.parentBuilds = {
-                        2: { eventId: '8887', jobs: { a: 12345 } }
+                        2: { eventId: '8887', jobs: { a: null } }
                     };
                     const buildC = {
                         jobId: 3,
@@ -2951,7 +2942,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             status: 'SUCCESS'
@@ -2967,8 +2958,7 @@ describe('build plugin test', () => {
                         {
                             jobId: 6,
                             status: 'ABORTED'
-                        },
-                        buildC
+                        }
                     ]);
                     jobBconfig.parentBuilds = {
                         123: {
@@ -2990,7 +2980,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.notCalled(buildC.update);
                         assert.notCalled(updatedBuildC.start);
@@ -3028,7 +3018,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -3095,7 +3085,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -3365,7 +3355,7 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
                     parentEventMock.workflowGraph.edges = eventMock.workflowGraph.edges;
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             id: 5,
                             jobId: 1,
@@ -3522,7 +3512,23 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
+                        {
+                            id: 888,
+                            jobId: 1,
+                            status: 'SUCCESS'
+                        },
+                        {
+                            id: 999,
+                            parentBuilds: {
+                                123: {
+                                    eventId: '8888',
+                                    jobs: { a: 12345, c: 45678 }
+                                }
+                            },
+                            jobId: 3,
+                            status: 'FAILED'
+                        },
                         {
                             jobId: 4,
                             status: 'SUCCESS'
@@ -3556,7 +3562,7 @@ describe('build plugin test', () => {
                     return newServer.inject(options).then(() => {
                         assert.calledOnce(eventFactoryMock.create);
                         assert.calledWith(eventFactoryMock.create, eventConfig);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.calledOnce(buildC.update);
                         assert.calledOnce(updatedBuildC.start);
@@ -3628,7 +3634,7 @@ describe('build plugin test', () => {
                         { src: 'c', dest: 'd', join: true }
                     ];
                     parentEventMock.workflowGraph.edges = eventMock.workflowGraph.edges;
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             id: 5,
                             jobId: 1,
@@ -3695,7 +3701,7 @@ describe('build plugin test', () => {
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
                     // job B is not done
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             eventId: '8888',
@@ -3742,7 +3748,7 @@ describe('build plugin test', () => {
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
                     // job B failed
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             eventId: '8888',
@@ -3812,7 +3818,7 @@ describe('build plugin test', () => {
                     buildC.update = sinon.stub().resolves(updatedBuildC);
                     buildE.update = sinon.stub().resolves(updatedBuildE);
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,


### PR DESCRIPTION
## Context

When a build fails in a join workflow, restarting that job should trigger join successfully. Note: need to test in beta

## Objective

This PR removes duplicate logic to get latest builds.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2526

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
