### PR TITLE
[1]  fix(1500): add feature flag for unzip artifacts

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -50,6 +50,9 @@ const notificationConfig = config.get('notifications');
 // Multiple build cluster feature flag
 const multiBuildClusterEnabled = convertToBool(config.get('multiBuildCluster').enabled);
 
+// Unzip artifacts feature flag
+const unzipArtifactsEnabled = convertToBool(config.get('unzipArtifacts').enabled);
+
 // Queue Webhook feature flag
 const queueWebhookEnabled = convertToBool(config.get('queueWebhook').enabled);
 
@@ -261,7 +264,8 @@ datastore.setup(datastoreConfig.ddlSyncEnabled).then(() =>
         queueWebhook: {
             executor,
             queueWebhookEnabled
-        }
+        },
+        unzipArtifactsEnabled
     })
         .then(instance => logger.info('Server running at %s', instance.info.uri))
         .catch(err => {

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -386,7 +386,7 @@ multiBuildCluster:
   enabled: MULTI_BUILD_CLUSTER_ENABLED
 
 unzipArtifacts:
-  # Enabled unzip a zip artifact feature or not
+  # Enabled unzip artifacts feature or not
   enabled: UNZIP_ARTIFACTS_ENABLED
 
 ecosystem:

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -385,6 +385,10 @@ multiBuildCluster:
   # Enabled multi build cluster feature or not
   enabled: MULTI_BUILD_CLUSTER_ENABLED
 
+unzipArtifacts:
+  # Enabled unzip a zip artifact feature or not
+  enabled: UNZIP_ARTIFACTS_ENABLED
+
 ecosystem:
   # URL for the User Interface
   ui: ECOSYSTEM_UI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -273,7 +273,7 @@ multiBuildCluster:
   enabled: false
 
 unzipArtifacts:
-  # Enabled unzip a zip artifact feature or not
+  # Enabled unzip artifacts feature or not
   enabled: false
 
 bookends:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -272,6 +272,10 @@ multiBuildCluster:
   # Enabled multi build cluster feature or not
   enabled: false
 
+unzipArtifacts:
+  # Enabled unzip a zip artifact feature or not
+  enabled: false
+
 bookends:
   # Plugins for build setup
   setup:

--- a/lib/server.js
+++ b/lib/server.js
@@ -79,6 +79,7 @@ function prettyPrintErrors(request, h) {
  * @param  {Object}      config.builds.ecosystem    List of hosts in the ecosystem
  * @param  {Object}      config.builds.authConfig   Configuration for auth
  * @param  {Object}      config.builds.externalJoin Flag to allow external join
+ * @param  {Object}      config.unzipArtifactsEnabled  Flag to allow unzip artifacts
  * @param  {Function}    callback                   Callback to invoke when server has started.
  * @return {http.Server}                            A listener: NodeJS http.Server object
  */

--- a/lib/server.js
+++ b/lib/server.js
@@ -137,7 +137,10 @@ module.exports = async config => {
             buildClusterFactory: config.buildClusterFactory,
             ecosystem: config.ecosystem,
             release: config.release,
-            queueWebhook: config.queueWebhook
+            queueWebhook: config.queueWebhook,
+            feature: {
+                unzipArtifacts: config.unzipArtifactsEnabled
+            }
         };
 
         const bellConfigs = await config.auth.scm.getBellConfiguration();

--- a/plugins/builds/artifacts/unzip.js
+++ b/plugins/builds/artifacts/unzip.js
@@ -18,6 +18,13 @@ module.exports = config => ({
         },
 
         handler: async (req, h) => {
+            if (!req.server.app.feature.unzipArtifacts) {
+                const data = {
+                    statusCode: 200,
+                    message: "This function is not enabled and will do nothing."
+                }
+                return h.response(data).code(200);
+            }
             const buildId = req.params.id;
             const { username, scope } = req.auth.credentials;
             const isBuild = scope.includes('build');

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -5443,7 +5443,7 @@ describe('build plugin test', () => {
         });
     });
 
-    describe.only('POST /builds/{id}/artifacts/unzip', () => {
+    describe('POST /builds/{id}/artifacts/unzip', () => {
         const id = 12345;
         const buildMock = {
             id,

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -105,6 +105,7 @@ class LockMockObj {
 
 const lockMock = new LockMockObj();
 
+/* eslint-disable max-lines-per-function */
 describe('build plugin test', () => {
     let buildFactoryMock;
     let stepFactoryMock;
@@ -205,7 +206,10 @@ describe('build plugin test', () => {
             jobFactory: jobFactoryMock,
             userFactory: userFactoryMock,
             eventFactory: eventFactoryMock,
-            bannerFactory: bannerFactoryMock
+            bannerFactory: bannerFactoryMock,
+            feature: {
+                unzipArtifacts: true
+            }
         };
         server.auth.scheme('custom', () => ({
             authenticate: (request, h) =>
@@ -326,6 +330,7 @@ describe('build plugin test', () => {
     describe('GET /builds/statuses?jobIds=&jobIds=&numBuilds=&offset=', () => {
         it('returns 200 when build statuses exist', () => {
             buildFactoryMock.getBuildStatuses.resolves(testBuildsStatuses);
+            server.unzipArtifactsEnabled = false;
 
             return server.inject('/builds/statuses?jobIds=1&jobIds=2&numBuilds=3&offset=0').then(reply => {
                 assert.calledWith(buildFactoryMock.getBuildStatuses, { jobIds: [1, 2], numBuilds: 3, offset: 0 });
@@ -5438,7 +5443,7 @@ describe('build plugin test', () => {
         });
     });
 
-    describe('POST /builds/{id}/artifacts/unzip', () => {
+    describe.only('POST /builds/{id}/artifacts/unzip', () => {
         const id = 12345;
         const buildMock = {
             id,
@@ -5459,6 +5464,14 @@ describe('build plugin test', () => {
                 }
             };
             buildFactoryMock.get.resolves(buildMock);
+        });
+
+        it('returns 200 when the feature is not enabled', () => {
+            server.app.feature.unzipArtifacts = false;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+            });
         });
 
         it('returns 202 for an unzip request', () => {


### PR DESCRIPTION
## Context
To implement SD_ZIP_ARTIFACTS feature by [new design](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md)
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Enable the unzip function to be managed by the feature flag.

The bookend PR is [here](https://github.com/screwdriver-cd/artifact-bookend/pull/38).
## Objective
- Add feature flag for unzip
- Add test
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
[design doc](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md#sd-api-api)
[issue](https://github.com/screwdriver-cd/screwdriver/issues/1500)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
