### PR TITLE
fix(2640): errors in individual event processing should not affect rest of event creation

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -355,9 +355,15 @@ async function triggeredPipelines(
  * @return {Promise<Array>}  Array of created events
  */
 async function startEvents(eventConfigs, eventFactory) {
+    const events = [];
+    let errorCount = 0;
+    let eventsCount = 0;
+
     const results = await Promise.allSettled(
         eventConfigs.map(eventConfig => {
             if (eventConfig && eventConfig.configPipelineSha) {
+                eventsCount += 1;
+
                 return eventFactory.create(eventConfig);
             }
 
@@ -365,15 +371,19 @@ async function startEvents(eventConfigs, eventFactory) {
         })
     );
 
-    const events = [];
-
     results.forEach((result, i) => {
         if (result.status === 'fulfilled') {
             if (result.value) events.push(result.value);
         } else {
+            errorCount += 1;
             logger.error(`pipeline:${eventConfigs[i].pipelineId} error in starting event`, result.value);
         }
     });
+
+    if (errorCount && errorCount === eventsCount) {
+        // preserve current behavior of returning 500 on error
+        throw new Error('Failed to start eny events');
+    }
 
     return events;
 }

--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -382,7 +382,7 @@ async function startEvents(eventConfigs, eventFactory) {
 
     if (errorCount && errorCount === eventsCount) {
         // preserve current behavior of returning 500 on error
-        throw new Error('Failed to start eny events');
+        throw new Error('Failed to start any events');
     }
 
     return events;

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -25,7 +25,7 @@ const PARSED_CONFIG = require('./data/github.parsedyaml.json');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('webhooks plugin test', () => {
+describe.only('webhooks plugin test', () => {
     let jobFactoryMock;
     let buildFactoryMock;
     let pipelineFactoryMock;

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -25,7 +25,7 @@ const PARSED_CONFIG = require('./data/github.parsedyaml.json');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe.only('webhooks plugin test', () => {
+describe('webhooks plugin test', () => {
     let jobFactoryMock;
     let buildFactoryMock;
     let pipelineFactoryMock;


### PR DESCRIPTION
## Context

Ensure that all individual event creations gets processed. `Promise.all` fails on first failure, however we do want to ensure that all events are processed. We might have to look and fix similar patterns across codebase. 

## Objective

1. Use `Promise.allSettled` to ensure that all Promises are processed. 
2. Log errors for event creation failure

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
