### PR TITLE
feat: Add support for opt-in git deploy keys

### DIFF
--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -5,6 +5,7 @@ const schema = require('screwdriver-data-schema');
 const urlLib = require('url');
 const { formatCheckoutUrl, sanitizeRootDir } = require('./helper');
 const { getUserPermissions } = require('../helper');
+const ANNOTATION_USE_DEPLOY_KEY = 'screwdriver.cd/useDeployKey';
 
 module.exports = () => ({
     method: 'POST',
@@ -89,7 +90,10 @@ module.exports = () => ({
 
                 await defaultCollection.update();
             }
-            if (autoKeysGeneration) {
+            // check if pipeline has deploy key annotation then create secrets
+            const deployKeyAnnotation = pipeline.annotations && pipeline.annotations[ANNOTATION_USE_DEPLOY_KEY]
+      
+            if (autoKeysGeneration || deployKeyAnnotation) {
                 const privateDeployKey = await pipelineFactory.scm.addDeployKey({
                     scmContext,
                     checkoutUrl,

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -152,7 +152,7 @@ module.exports = () => ({
 
                 if (!deploySecret) {
                     const privateDeployKey = await pipelineFactory.scm.addDeployKey({
-                        scmContext : oldPipeline.scmContext,
+                        scmContext: oldPipeline.scmContext,
                         checkoutUrl: formattedCheckoutUrl,
                         token
                     });

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -6,6 +6,7 @@ const schema = require('screwdriver-data-schema');
 const idSchema = schema.models.pipeline.base.extract('id');
 const { formatCheckoutUrl, sanitizeRootDir } = require('./helper');
 const { getUserPermissions } = require('../helper');
+const ANNOTATION_USE_DEPLOY_KEY = 'screwdriver.cd/useDeployKey';
 
 /**
  * Get user permissions on old pipeline
@@ -45,10 +46,11 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { checkoutUrl, rootDir, settings } = request.payload;
             const { id } = request.params;
-            const { pipelineFactory, userFactory } = request.server.app;
+            const { pipelineFactory, userFactory, secretFactory } = request.server.app;
             const { scmContext, username } = request.auth.credentials;
             const scmContexts = pipelineFactory.scm.getScmContexts();
             const { isValidToken } = request.server.plugins.pipelines;
+            const deployKeySecret = 'SD_SCM_DEPLOY_KEY';
 
             if (!isValidToken(id, request.auth.credentials)) {
                 return boom.unauthorized('Token does not have permission to this pipeline');
@@ -83,12 +85,15 @@ module.exports = () => ({
                 throw boom.forbidden(`User ${user.getFullDisplayName()} does not have admin permission for this repo`);
             }
 
+            let token;
+            let formattedCheckoutUrl;
+
             if (checkoutUrl || rootDir) {
-                const formattedCheckoutUrl = formatCheckoutUrl(request.payload.checkoutUrl);
+                formattedCheckoutUrl = formatCheckoutUrl(request.payload.checkoutUrl);
                 const sanitizedRootDir = sanitizeRootDir(request.payload.rootDir);
 
                 // get the user token
-                const token = await user.unsealToken();
+                token = await user.unsealToken();
                 // get the scm URI
                 const scmUri = await pipelineFactory.scm.parseUrl({
                     scmContext,
@@ -135,6 +140,32 @@ module.exports = () => ({
 
             // update pipeline
             const updatedPipeline = await oldPipeline.update();
+
+            // check if pipeline has deploy key annotation then create secrets
+            const deployKeyAnnotation = oldPipeline.annotations && oldPipeline.annotations[ANNOTATION_USE_DEPLOY_KEY]
+
+            if (deployKeyAnnotation) {
+                const deploySecret = await secretFactory.get({
+                    pipelineId: oldPipeline.id,
+                    name: deployKeySecret,
+                })
+
+                if (!deploySecret) {
+                    const privateDeployKey = await pipelineFactory.scm.addDeployKey({
+                        scmContext : oldPipeline.scmContext,
+                        checkoutUrl: formattedCheckoutUrl,
+                        token
+                    });
+                    const privateDeployKeyB64 = Buffer.from(privateDeployKey).toString('base64');
+
+                    await secretFactory.create({
+                        pipelineId: oldPipeline.id,
+                        name: deployKeySecret,
+                        value: privateDeployKeyB64,
+                        allowInPR: true
+                    });
+                }
+            }
 
             await updatedPipeline.addWebhooks(`${request.server.info.uri}/v4/webhooks`);
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1715,7 +1715,7 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 201 and correct pipeline dat with deployKey when annotations set', () => {
+        it('returns 201 and correct pipeline data with deployKey when annotations set', () => {
             const pipelineMockLocal = {
                 ...pipelineMock, annotations: {
                     "screwdriver.cd/useDeployKey": true

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1715,6 +1715,64 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 201 and correct pipeline dat with deployKey when annotations set', () => {
+            const pipelineMockLocal = {
+                ...pipelineMock, annotations: {
+                    "screwdriver.cd/useDeployKey": true
+                }
+            }
+
+            pipelineFactoryMock.create.resolves(pipelineMockLocal);
+
+            let expectedLocation;
+            const testDefaultCollection = Object.assign(testCollection, { type: 'default' });
+
+            collectionFactoryMock.list
+                .withArgs({
+                    params: {
+                        userId,
+                        type: 'default'
+                    }
+                })
+                .resolves([getCollectionMock(testDefaultCollection)]);
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/${testId}`
+                };
+                assert.deepEqual(reply.result, testPipeline);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledWith(pipelineFactoryMock.create, {
+                    admins: {
+                        [username]: true
+                    },
+                    scmUri,
+                    scmContext
+                });
+                assert.calledWith(collectionFactoryMock.list, {
+                    params: {
+                        userId,
+                        type: 'default'
+                    }
+                });
+                assert.calledWith(pipelineFactoryMock.scm.addDeployKey,{
+                    scmContext,
+                    checkoutUrl: formattedCheckoutUrl,
+                    token
+                })
+                assert.calledWith(secretFactoryMock.create, {
+                    pipelineId: 123,
+                    name: 'SD_SCM_DEPLOY_KEY',
+                    value: privateKeyB64,
+                    allowInPR: true
+                });
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
         it('formats the checkout url correctly', () => {
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
 
@@ -1883,6 +1941,8 @@ describe('pipeline plugin test', () => {
             name: 'screwdriver-cd/screwdriver',
             url: 'https://github.com/screwdriver-cd/data-model/tree/master'
         };
+        const privateKey = 'testkey';
+        const privateKeyB64 = Buffer.from(privateKey).toString('base64');
         let pipelineMock;
         let updatedPipelineMock;
         let userMock;
@@ -1914,6 +1974,8 @@ describe('pipeline plugin test', () => {
             updatedPipelineMock = hoek.clone(pipelineMock);
             updatedPipelineMock.addWebhooks.resolves(null);
 
+            secretFactoryMock.get.resolves(null);
+
             pipelineFactoryMock.get.withArgs({ id }).resolves(pipelineMock);
             pipelineFactoryMock.get.withArgs({ scmUri }).resolves(null);
             pipelineMock.update.resolves(updatedPipelineMock);
@@ -1922,6 +1984,7 @@ describe('pipeline plugin test', () => {
             pipelineFactoryMock.scm.parseUrl.resolves(scmUri);
             pipelineFactoryMock.scm.decorateUrl.resolves(scmRepo);
             pipelineFactoryMock.scm.getScmContexts.returns(['github:github.com', 'gitlab:mygitlab']);
+            pipelineFactoryMock.scm.addDeployKey.resolves(privateKey);
         });
 
         it('returns 200 and correct pipeline data', () =>
@@ -1963,6 +2026,63 @@ describe('pipeline plugin test', () => {
                 });
                 assert.calledOnce(pipelineMock.update);
                 assert.calledOnce(updatedPipelineMock.addWebhooks);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 200 and creates deployKey if it doesn\'t exist', () => {
+            const pipelineMockLocal = {
+                ...pipelineMock, annotations: {
+                    "screwdriver.cd/useDeployKey": true
+                }
+            }
+            pipelineFactoryMock.get.withArgs({ id }).resolves(pipelineMockLocal);
+            secretFactoryMock.get.resolves(null)
+
+            return server.inject(options).then(reply => {
+                assert.calledWith(pipelineFactoryMock.scm.parseUrl, {
+                    scmContext,
+                    checkoutUrl: formattedCheckoutUrl,
+                    token,
+                    rootDir: ''
+                });
+                assert.calledOnce(pipelineMockLocal.update);
+                assert.calledOnce(updatedPipelineMock.addWebhooks);
+                assert.calledWith(pipelineFactoryMock.scm.addDeployKey,{
+                    scmContext,
+                    checkoutUrl: formattedCheckoutUrl,
+                    token
+                })
+                assert.calledWith(secretFactoryMock.create, {
+                    pipelineId: 123,
+                    name: 'SD_SCM_DEPLOY_KEY',
+                    value: privateKeyB64,
+                    allowInPR: true
+                });
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 200 and does not create deployKey if it already exists', () => {
+            const pipelineMockLocal = {
+                ...pipelineMock, annotations: {
+                    "screwdriver.cd/useDeployKey": true
+                }
+            }
+            pipelineFactoryMock.get.withArgs({ id }).resolves(pipelineMockLocal);
+            secretFactoryMock.get.resolves({})
+
+            return server.inject(options).then(reply => {
+                assert.calledWith(pipelineFactoryMock.scm.parseUrl, {
+                    scmContext,
+                    checkoutUrl: formattedCheckoutUrl,
+                    token,
+                    rootDir: ''
+                });
+                assert.calledOnce(pipelineMockLocal.update);
+                assert.calledOnce(updatedPipelineMock.addWebhooks);
+                assert.notCalled(pipelineFactoryMock.scm.addDeployKey);
+                assert.notCalled(secretFactoryMock.create);
                 assert.equal(reply.statusCode, 200);
             });
         });


### PR DESCRIPTION
## Context

Screwdriver needs to support user configuration for using deploy keys for `git checkout`

## Objective

This PR allows users to opt-in for using git deploy keys and creates them on pipeline creation /update

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
