### PR TITLE
fix: correct logged value on create event error

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -376,7 +376,7 @@ async function startEvents(eventConfigs, eventFactory) {
             if (result.value) events.push(result.value);
         } else {
             errorCount += 1;
-            logger.error(`pipeline:${eventConfigs[i].pipelineId} error in starting event`, result.value);
+            logger.error(`pipeline:${eventConfigs[i].pipelineId} error in starting event`, result.reason);
         }
     });
 


### PR DESCRIPTION
## Context

Wrong value was being logged on error

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
