### PR TITLE
fix: return 403 or 404 error when mismatch scm host

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -131,10 +131,7 @@ module.exports = () => ({
             try {
                 permissions = await user.getPermissions(scmUri);
             } catch (err) {
-                const statusCode = (!pipeline.scmRepo || !pipeline.scmRepo.private) ? 403 : 404;
-                throw boom.boomify(err, {
-                    statusCode: err.status || statusCode
-                });
+                throw boom.boomify(err, { statusCode: err.statusCode });
             }
 
             // Update admins

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -193,8 +193,8 @@ module.exports = () => ({
                 // User has good permissions, create an event
                 sha = await scm.getCommitSha(scmConfig);
             } catch (err) {
-                if (err.status) {
-                    throw boom.boomify(err, { statusCode: err.status });
+                if (err.statusCode) {
+                    throw boom.boomify(err, { statusCode: err.statusCode });
                 }
             }
 

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -126,7 +126,16 @@ module.exports = () => ({
             const scmUri = await getScmUri({ pipeline, pipelineFactory });
 
             // Check the user's permission
-            const permissions = await user.getPermissions(scmUri);
+            let permissions;
+
+            try {
+                permissions = await user.getPermissions(scmUri);
+            } catch (err) {
+                const statusCode = (!pipeline.scmRepo || !pipeline.scmRepo.private) ? 403 : 404;
+                throw boom.boomify(err, {
+                    statusCode: err.status || statusCode
+                });
+            }
 
             // Update admins
             if (!prNum) {

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -115,6 +115,10 @@ module.exports = () => ({
                 userFactory.get({ username, scmContext })
             ]);
 
+            if (!pipeline) {
+                throw boom.notFound();
+            }
+
             payload.scmContext = pipeline.scmContext;
 
             // In pipeline scope, check if the token is allowed to the pipeline
@@ -131,6 +135,9 @@ module.exports = () => ({
             try {
                 permissions = await user.getPermissions(scmUri);
             } catch (err) {
+                if (err.statusCode === 403 && (pipeline.scmRepo && pipeline.scmRepo.private)) {
+                    throw boom.notFound();
+                }
                 throw boom.boomify(err, { statusCode: err.statusCode });
             }
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -666,6 +666,14 @@ describe('event plugin test', () => {
             });
         });
 
+        it('returns 404 when it fails to get the pipeline', () => {
+            pipelineFactoryMock.get.resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
         it(
             'returns 403 when it fails to creates a PR event when ' +
                 'PR author only has permission to run PR and restrictPR is on',
@@ -689,14 +697,27 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 403 when user does not have repository permission', () => {
+        it('returns 403 when user does not have permission for public repository', () => {
             const err = new Error('Error message');
+
             err.statusCode = 403;
             userMock.getPermissions.rejects(err);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, err.statusCode);
                 assert.strictEqual(reply.result.message, err.message);
+            });
+        });
+
+        it('returns 404 when user does not have permission for private repository', () => {
+            const err = new Error('Error message');
+
+            err.statusCode = 403;
+            userMock.getPermissions.rejects(err);
+            pipelineMock.scmRepo = {private: true};
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When scm host that user logged in does not match pipeline's scm host, the 500 error is returned.
However, since this is an authorization error caused by users, the 403(or 404 when private) error should be returned.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Add error handling for [this error](https://github.com/screwdriver-cd/scm-github/blob/a12f1e0bd9bd24b1d03c55cb6dbfe220d109f347/index.js#L254-L257).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- https://github.com/screwdriver-cd/scm-github/pull/202

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
