### PR TITLE
fix(1500): Add admin user unzip

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 # Create our application directory
 RUN mkdir -p /usr/src/app

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "git@github.com:screwdriver-cd/screwdriver.git"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=12.0.0"
   },
   "greenkeeper": {
     "ignore": [


### PR DESCRIPTION
## Context
Enable the admin user to unzip manually.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Add `user` in scope
- Check if the sender has admin privileges when a request comes in with user scope
- Add test
- node version up 8 -> 12
  - Because [this problem](https://github.com/outmoded/sntp/issues/37) occurred when I build with node8.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/pull/2616#discussion_r771112502
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
