### PR TITLE
fix(2526): Restart failed build in join workflow should trigger join job

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -410,11 +410,6 @@ function parseJobInfo({ joinObj = {}, current, nextJobName, nextPipelineId }) {
  * @return {Promise}                            All finished builds
  */
 async function getFinishedBuilds(event, buildFactory) {
-    if (!event.parentEventId) {
-        // FIXME: remove this flow to always use buildFactory.getLatestBuilds
-        return event.getBuilds();
-    }
-
     // FIXME: buildFactory.getLatestBuilds doesn't return build model
     const builds = await buildFactory.getLatestBuilds({ groupEventId: event.groupEventId });
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1650,11 +1650,26 @@ describe('build plugin test', () => {
                     state: 'ENABLED'
                 };
                 const jobC = { ...jobB, id: 3 };
+                let buildMocks;
                 let jobBconfig;
                 let jobCconfig;
                 let parentEventMock;
 
                 beforeEach(() => {
+                    buildMocks = [
+                        {
+                            jobId: 1,
+                            status: 'SUCCESS',
+                            id: 12345,
+                            eventId: '8888'
+                        },
+                        {
+                            jobId: 4,
+                            status: 'SUCCESS',
+                            id: 123456,
+                            eventId: '8888'
+                        }
+                    ];
                     parentEventMock = {
                         id: 456,
                         pipelineId,
@@ -1768,21 +1783,7 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
 
-                    const buildMocks = [
-                        {
-                            jobId: 1,
-                            status: 'SUCCESS',
-                            id: 12345,
-                            eventId: '8888'
-                        },
-                        {
-                            jobId: 4,
-                            status: 'SUCCESS',
-                            id: 123456,
-                            eventId: '8888'
-                        }
-                    ];
-
+                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
                     eventMock.getBuilds.resolves(buildMocks);
 
                     const parentBuildsB = {
@@ -1824,21 +1825,7 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
 
-                    const buildMocks = [
-                        {
-                            jobId: 1,
-                            status: 'SUCCESS',
-                            id: 12345,
-                            eventId: '8888'
-                        },
-                        {
-                            jobId: 4,
-                            status: 'SUCCESS',
-                            id: 123456,
-                            eventId: '8888'
-                        }
-                    ];
-
+                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
                     eventMock.getBuilds.resolves(buildMocks);
 
                     const parentBuildsB = {
@@ -1920,7 +1907,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(buildC);
 
-                    const buildMocks = [
+                    buildMocks = [
                         {
                             jobId: 1,
                             status: 'SUCCESS',
@@ -1936,7 +1923,7 @@ describe('build plugin test', () => {
                         buildC
                     ];
 
-                    eventMock.getBuilds.resolves(buildMocks);
+                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
                     buildFactoryMock.get.withArgs(123456).resolves(buildMocks[1]);
                     buildFactoryMock.get.withArgs(123455).resolves(buildC);
 
@@ -1964,7 +1951,7 @@ describe('build plugin test', () => {
                         { src: 'b', dest: 'c', join: true }
                     ];
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         buildMock,
                         {
                             id: 222,
@@ -2443,7 +2430,7 @@ describe('build plugin test', () => {
                     });
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -2511,7 +2498,7 @@ describe('build plugin test', () => {
                     });
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -2639,7 +2626,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    externalEventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             status: 'SUCCESS'
@@ -2674,7 +2661,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledTwice(buildC.update);
                         assert.calledOnce(updatedBuildC.start);
                     });
@@ -2775,7 +2762,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 3,
                             status: 'SUCCESS'
@@ -2789,7 +2776,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.calledWith(buildFactoryMock.create, jobCConfig);
                         assert.calledOnce(buildC.update);
@@ -2901,7 +2888,7 @@ describe('build plugin test', () => {
                         ]
                     };
                     buildMock.parentBuilds = {
-                        2: { eventId: '8887', jobs: { a: 12345 } }
+                        2: { eventId: '8887', jobs: { a: null } }
                     };
                     const buildC = {
                         jobId: 3,
@@ -2962,7 +2949,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             status: 'SUCCESS'
@@ -2978,8 +2965,7 @@ describe('build plugin test', () => {
                         {
                             jobId: 6,
                             status: 'ABORTED'
-                        },
-                        buildC
+                        }
                     ]);
                     jobBconfig.parentBuilds = {
                         123: {
@@ -3001,7 +2987,7 @@ describe('build plugin test', () => {
 
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.notCalled(buildC.update);
                         assert.notCalled(updatedBuildC.start);
@@ -3039,7 +3025,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -3106,7 +3092,7 @@ describe('build plugin test', () => {
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,
@@ -3376,7 +3362,7 @@ describe('build plugin test', () => {
                         { src: 'd', dest: 'c', join: true }
                     ];
                     parentEventMock.workflowGraph.edges = eventMock.workflowGraph.edges;
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             id: 5,
                             jobId: 1,
@@ -3533,7 +3519,23 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
+                        {
+                            id: 888,
+                            jobId: 1,
+                            status: 'SUCCESS'
+                        },
+                        {
+                            id: 999,
+                            parentBuilds: {
+                                123: {
+                                    eventId: '8888',
+                                    jobs: { a: 12345, c: 45678 }
+                                }
+                            },
+                            jobId: 3,
+                            status: 'FAILED'
+                        },
                         {
                             jobId: 4,
                             status: 'SUCCESS'
@@ -3567,7 +3569,7 @@ describe('build plugin test', () => {
                     return newServer.inject(options).then(() => {
                         assert.calledOnce(eventFactoryMock.create);
                         assert.calledWith(eventFactoryMock.create, eventConfig);
-                        assert.calledOnce(externalEventMock.getBuilds);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.calledOnce(buildC.update);
                         assert.calledOnce(updatedBuildC.start);
@@ -3639,7 +3641,7 @@ describe('build plugin test', () => {
                         { src: 'c', dest: 'd', join: true }
                     ];
                     parentEventMock.workflowGraph.edges = eventMock.workflowGraph.edges;
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             id: 5,
                             jobId: 1,
@@ -3706,7 +3708,7 @@ describe('build plugin test', () => {
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
                     // job B is not done
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             eventId: '8888',
@@ -3753,7 +3755,7 @@ describe('build plugin test', () => {
                     buildC.update = sinon.stub().resolves(updatedBuildC);
 
                     // job B failed
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             eventId: '8888',
@@ -3823,7 +3825,7 @@ describe('build plugin test', () => {
                     buildC.update = sinon.stub().resolves(updatedBuildC);
                     buildE.update = sinon.stub().resolves(updatedBuildE);
 
-                    eventMock.getBuilds.resolves([
+                    buildFactoryMock.getLatestBuilds.resolves([
                         {
                             jobId: 1,
                             id: 12345,


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#2636

to be merged after https://github.com/screwdriver-cd/datastore-sequelize/pull/87