### PR TITLE
fix(1393) add a scenario into event.feature for the case of parent event

### DIFF
--- a/features/events.feature
+++ b/features/events.feature
@@ -38,6 +38,14 @@ Feature: Events
         And the "main" build succeeds
         And the "publish" build succeeds with the same eventId as the "main" build
 
+    Scenario: Create an event from the previous event when user restarts a job
+        And "calvin" is logged in
+        And the "main" job has a previous event
+        When the "main" job is restarted
+        Then an event is created with the parent event which is same as the previous event
+        And the "main" build succeeds
+        And the "publish" build succeeds with the same eventId as the "main" build
+
     @ignore
     Scenario: Create an event when a PR is opened
         When a pull request is opened

--- a/features/step_definitions/events.js
+++ b/features/step_definitions/events.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const Assert = require('chai').assert;
-const { Before, Given, Then } = require('cucumber');
+const { Before, Given, When, Then } = require('cucumber');
 const request = require('screwdriver-request');
+const sdapi = require('../support/sdapi');
 
 const TIMEOUT = 240 * 1000;
 
@@ -12,6 +13,7 @@ Before('@events', function hook() {
     // Reset shared information
     this.pipelineId = null;
     this.eventId = null;
+    this.previousEventId = null;
     this.jwt = null;
 });
 
@@ -21,6 +23,65 @@ Given(/^an existing pipeline with the workflow:$/, { timeout: TIMEOUT }, functio
 
 Given(/^"calvin" has admin permission to the pipeline$/, () => null);
 
+Given(/^the "main" job has a previous event$/, { timeout: TIMEOUT }, function step() {
+    const jobName = 'main';
+    return request({
+        url: `${this.instance}/${this.namespace}/events`,
+        method: 'POST',
+        json: {
+            pipelineId: this.pipelineId,
+            startFrom: jobName
+        },
+        context: {
+            token: this.jwt
+        }
+    })
+        .then(resp => {
+            Assert.equal(resp.statusCode, 201);
+            this.previousEventId = resp.body.id;
+        })
+        .then(() =>
+            sdapi.cleanupBuilds({
+                instance: this.instance,
+                pipelineId: this.pipelineId,
+                jobName,
+                jwt: this.jwt
+            })
+        );
+});
+
+When(/^the "main" job is restarted$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        url: `${this.instance}/${this.namespace}/events`,
+        method: 'POST',
+        json: {
+            pipelineId: this.pipelineId,
+            parentEventId: this.previousEventId,
+            startFrom: 'main'
+        },
+        context: {
+            token: this.jwt
+        }
+    })
+        .then(response => {
+            Assert.equal(response.statusCode, 201);
+            this.eventId = response.body.id;
+        })
+        .then(() =>
+            request({
+                url: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+                method: 'GET',
+                context: {
+                    token: this.jwt
+                }
+            })
+        )
+        .then(response => {
+            Assert.equal(response.statusCode, 200);
+            this.buildId = response.body[0].id;
+        });
+});
+
 Then(/^an event is created$/, { timeout: TIMEOUT }, function step() {
     return request({
         url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/events`,
@@ -29,6 +90,19 @@ Then(/^an event is created$/, { timeout: TIMEOUT }, function step() {
             token: this.jwt
         }
     }).then(response => Assert.equal(response.body[0].id, this.eventId));
+});
+
+Then(/^an event is created with the parent event which is same as the previous event$/, { timeout: TIMEOUT }, function step() {
+    return request({
+        url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}/events`,
+        method: 'GET',
+        context: {
+            token: this.jwt
+        }
+    }).then((response) => {
+        Assert.equal(response.body[0].id, this.eventId);
+        Assert.equal(response.body[0].parentEventId, this.previousEventId);
+    });
 });
 
 Then(/^the "main" build succeeds$/, { timeout: TIMEOUT }, function step() {


### PR DESCRIPTION
## Context
The current feature test for events doesn't have the scenario for restarting job from the existing event, but this is the common use case.

## Objective
This PR add a test scenario for the event that has a parentEventId into `event.feature` in functional-tests.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1393

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
