### PR TITLE
fix: Error code when parseUrl failed

### DIFF
--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -3,10 +3,10 @@
 const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
 const urlLib = require('url');
+const logger = require('screwdriver-logger');
 const { formatCheckoutUrl, sanitizeRootDir } = require('./helper');
 const { getUserPermissions } = require('../helper');
 const ANNOTATION_USE_DEPLOY_KEY = 'screwdriver.cd/useDeployKey';
-const logger = require('screwdriver-logger');
 
 module.exports = () => ({
     method: 'POST',

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1927,6 +1927,18 @@ describe('pipeline plugin test', () => {
                 assert.equal(reply.statusCode, 500);
             });
         });
+
+        it('catches and throws proper error object when parseUrl failed', () => {
+            const testError = new Error('ParseUrl Error');
+
+            testError.statusCode = 400;
+            pipelineFactoryMock.scm.parseUrl.rejects(testError);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 400);
+                assert.equal(reply.result.message, 'ParseUrl Error');
+            });
+        });
     });
 
     describe('PUT /pipelines/{id}', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The error status of parseUrl when creating a pipeline is only 500.

The following is an example. It is an error when the checkout URL is different from the logged-in SCM host.

<img width="1285" alt="beforeCheckoutUrlNotLoginHostのコピー" src="https://user-images.githubusercontent.com/32473622/156678013-6d5c051b-3c50-461a-8e64-275800ff36c8.png">

It is inappropriate for this error to have the code 500 (Internal Server Error).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The parseUrl error when creating the pipeline is correct.

- ex1: If creating a pipeline for a repository on a host different from the login SCM, 400 (Bad Request) is appropriate.
  - Error log after fixed:
  - <img width="1295" alt="checkoutUrlNotSupported" src="https://user-images.githubusercontent.com/32473622/156678092-e0e03df2-7150-484a-9e76-d6b6b63051e3.png">

- ex2: If trying to create a pipeline for a private repository that the user don't have permissions on, a 404 (Not Found) is appropriate.
  - Error log after fixed:
  - <img width="1290" alt="cannotFindRepo" src="https://user-images.githubusercontent.com/32473622/156678232-aa4dc9a6-2d19-463c-90fc-3b263ef227c0.png">


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
