### PR TITLE
feat: Add functional tests for branch specific job

### DIFF
--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -79,7 +79,7 @@ Given(
         return github
             .createBranch(branch, this.repoOrg, this.repoName)
             .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-            .then(() => github.createPullRequest(branch, this.repoOrg, this.repoName))
+            .then(() => github.createPullRequest(branch, 'master', this.repoOrg, this.repoName))
             .then(({ data }) => {
                 this.pullRequestNumber = data.number;
                 this.sha = data.head.sha;
@@ -121,7 +121,7 @@ When(/^a pull request is opened$/, { timeout: TIMEOUT }, function step() {
     return github
         .createBranch(branch, this.repoOrg, this.repoName)
         .then(() => github.createFile(branch, this.repoOrg, this.repoName))
-        .then(() => github.createPullRequest(branch, this.repoOrg, this.repoName))
+        .then(() => github.createPullRequest(branch, 'master', this.repoOrg, this.repoName))
         .then(({ data }) => {
             this.pullRequestNumber = data.number;
             this.sha = data.head.sha;

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -168,7 +168,7 @@ function createFile(branch, repoOwner, repoName, directoryName) {
  * @param  {String}   repoName          Name of the repository
  * @return {Promise}
  */
- function createPullRequest(sourceBranch, targetBranch, repoOwner, repoName) {
+function createPullRequest(sourceBranch, targetBranch, repoOwner, repoName) {
     return octokit.pulls.create({
         owner: repoOwner,
         repo: repoName,
@@ -177,7 +177,6 @@ function createFile(branch, repoOwner, repoName, directoryName) {
         base: targetBranch
     });
 }
-
 
 /**
  * Creates a lightweight tag.

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -162,20 +162,22 @@ function createFile(branch, repoOwner, repoName, directoryName) {
 /**
  * Creates a pull request.
  * @method createPullRequest
- * @param  {String}   branch            The branch to create the file in
+ * @param  {String}   sourceBranch      The branch to create the file in
+ * @param  {String}   targetBranch      The base branch
  * @param  {String}   repoOwner         Owner of the repository
  * @param  {String}   repoName          Name of the repository
  * @return {Promise}
  */
-function createPullRequest(branch, repoOwner, repoName) {
+ function createPullRequest(sourceBranch, targetBranch, repoOwner, repoName) {
     return octokit.pulls.create({
         owner: repoOwner,
         repo: repoName,
         title: '[DNM] testing',
-        head: branch,
-        base: 'master'
+        head: sourceBranch,
+        base: targetBranch
     });
 }
+
 
 /**
  * Creates a lightweight tag.

--- a/features/workflow.feature
+++ b/features/workflow.feature
@@ -70,26 +70,30 @@ Feature: Workflow
 
     Scenario: Branch filtering (the master branch is committed)
         Given an existing pipeline on "master" branch with the workflow jobs:
-            | job       | requires          |
-            | SIMPLE    | ~commit           |
-            | STAGING   | ~commit:staging   |
-            | REGEX     | ~commit:/^.*$/    |
+            | job           | requires              |
+            | SIMPLE        | ~commit               |
+            | STAGING       | ~commit:staging       |
+            | REGEX         | ~commit:/^.*$/        |
+            | UNMATCH-REGEX | ~commit:/^unmatch$/   |
         When a new commit is pushed to "master" branch
         Then the "SIMPLE" job is triggered
         And the "REGEX" job is triggered
         And the "STAGING" job is not triggered
+        And the "UNMATCH-REGEX" job is not triggered
         And that "REGEX" build uses the same SHA as the "SIMPLE" build
 
     Scenario: Branch filtering (the staging branch is committed)
         Given an existing pipeline on "master" branch with the workflow jobs:
-            | job       | requires          |
-            | SIMPLE    | ~commit           |
-            | STAGING   | ~commit:staging   |
-            | REGEX     | ~commit:/^.*$/    |
+            | job           | requires              |
+            | SIMPLE        | ~commit               |
+            | STAGING       | ~commit:staging       |
+            | REGEX         | ~commit:/^.*$/        |
+            | UNMATCH-REGEX | ~commit:/^unmatch$/   |
         When a new commit is pushed to "staging" branch
         Then the "STAGING" job is triggered
         And the "REGEX" job is triggered
         And the "SIMPLE" job is not triggered
+        And the "UNMATCH-REGEX" job is not triggered
         And that "REGEX" build uses the same SHA as the "STAGING" build
 
     @workflow-chainPR
@@ -106,51 +110,41 @@ Feature: Workflow
         And that "AFTER-SIMPLE" PR build uses the same SHA as the "SIMPLE" PR build
         And the "AFTER-SIMPLE" PR build succeeded
 
-    @ignore
+    @workflow
+    @workflow-PR
     Scenario: Branch filtering (a pull request is opened to the master branch)
         Given an existing pipeline on "master" branch with the workflow jobs:
-            | job       | requires      |
-            | SIMPLE    | ~pr           |
-            | STAGING   | ~pr:staging   |
-            | REGEX     | ~pr:/^.*$/    |
-            | MASTER-PR | ~pr:master    |
+            | job               | requires          |
+            | SIMPLE            | ~pr               |
+            | STAGING           | ~pr:staging       |
+            | REGEX             | ~pr:/^.*$/        |
+            | UNMATCH-REGEX     | ~pr:/^unmatch$/   |
+            | MASTER-PR         | ~pr:master        |
+            | AFTER-MASTER-PR   | MASTER-PR         |
         When a pull request is opened to "master" branch
-        Then the "SIMPLE" job is triggered
-        And the "REGEX" job is triggered
-        And the "MASTER-PR" job is triggered
-        And the "STAGINNG" job is not triggered
-        And that "REGEX" build uses the same SHA as the "SIMPLE" build
-        And that "MASTER-PR" build uses the same SHA as the "SIMPLE" build
+        Then the "SIMPLE" PR job is triggered
+        And the "STAGING" PR job is not triggered
+        And the "REGEX" PR job is triggered
+        And the "UNMATCH-REGEX" PR job is not triggered
+        And the "MASTER-PR" PR job is triggered
+        And the "AFTER-MASTER-PR" PR job is not triggered
+        And that "REGEX" PR build uses the same SHA as the "SIMPLE" PR build
+        And that "MASTER-PR" PR build uses the same SHA as the "SIMPLE" PR build
 
-    @ignore
-    Scenario: Branch filtering (pr and filtered pr workflow)
-        Given an existing pipeline on "master" branch with the workflow jobs:
-            | job               | requires      |
-            | SIMPLE            | ~pr           |
-            | PARALLEL1         | SIMPLE        |
-            | MASTER-PR         | ~pr:master    |
-            | AFTER-MASTER-PR   | MASTER-PR     |
-        When a pull request is opened to "master" branch
-        Then the "SIMPLE" job is triggered
-        And the "MASTER-PR" job is triggered
-        And that "MASTER-PR" build uses the same SHA as the "SIMPLE" build
-        Then the "SIMPLE" build succeeded
-        And the "MASTER-PR" build succeeded
-        Then the "PARALLEL1" job is not triggered
-        And the "AFTER-MASTER-PR" job is triggered from "MASTER-PR"
-        And that "AFTER-MASTER-PR" build uses the same SHA as the "SIMPLE" build
-
-    @ignore
+    @workflow
+    @workflow-PR
     Scenario: Branch filtering (a pull request is opened to the staging branch)
         Given an existing pipeline on "master" branch with the workflow jobs:
-            | job       | requires      |
-            | SIMPLE    | ~pr           |
-            | STAGING   | ~pr:staging   |
-            | REGEX     | ~pr:/^.*$/    |
-            | MASTER-PR | ~pr:master    |
-        When a pull request is opened to staging branch
-        Then the "STAGING" job is triggered
-        And the "REGEX" job is triggered
-        And the "SIMPLE" job is not triggered
-        And the "MASTER-PR" job is not triggered
-        And that "REGEX" build uses the same SHA as the "STAGING" build
+            | job           | requires          |
+            | SIMPLE        | ~pr               |
+            | STAGING       | ~pr:staging       |
+            | REGEX         | ~pr:/^.*$/        |
+            | UNMATCH-REGEX | ~pr:/^unmatch$/   |
+            | MASTER-PR     | ~pr:master        |
+        When a pull request is opened to "staging" branch
+        Then the "STAGING" PR job is triggered
+        And the "REGEX" PR job is triggered
+        And the "UNMATCH-REGEX" PR job is not triggered
+        And the "SIMPLE" PR job is not triggered
+        And the "MASTER-PR" PR job is not triggered
+        And that "REGEX" PR build uses the same SHA as the "STAGING" PR build


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add missing tests to check the functionality of branch specific jobs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Add assertion to ensure job is not triggered if regular expression does not match in the following scenarios.
  - Branch filtering (the master branch is committed)
  - Branch filtering (the staging branch is committed)
- Added two scenarios to ensure that branch specific jobs work correctly in PR builds.
  - Branch filtering (a pull request is opened to the master branch)
  - Branch filtering (a pull request is opened to the staging branch)
- Implement processes to check the added assertions.
  - Add `When /^a pull request is opened to "(.*)" branch$/`.
  - Add `Then /^the "(.*)" PR job is not triggered$/`.
  - Modified `createPullRequest` function to allow specifying a target other than the master branch.
  - Modify `After tags` to delete created PRs and branches after testing PR builds.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
The functional test will not work correctly until a job is added to verify that the regular expression does not match in the following PR.
https://github.com/screwdriver-cd-test/functional-workflow/pull/5

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
