### PR TITLE
feat: Add restrict pr test [2] 

### DIFF
--- a/features/restrict-pr.feature
+++ b/features/restrict-pr.feature
@@ -10,76 +10,50 @@ Feature: Restrict-pr
         -- branch: Do not start PR build from same repository
         -- all: Do not start all PR build
 
-    Scenario: Create a pull request for restrict pr value is none from the same repository
+    Scenario: Create a pull request from the same repository
         Given an existing pipeline with the source directory "none" and with the workflow jobs:
             | job           | requires          |
             | main          | ~pr               |
+            And an existing pipeline with the source directory "fork" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "branch" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "all" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
         When a branch is created for test_branch on "screwdriver-cd-test" organization
-        And a new file is added to the "none" directory
-        And a pull request is opened from the "screwdriver-cd-test" organization
+            And a new file is added to the "none" directory
+            And a new file is added to the "fork" directory
+            And a new file is added to the "branch" directory
+            And a new file is added to the "all" directory
+            And a pull request is opened from the "screwdriver-cd-test" organization
         Then the PR job of "none" is triggered because it is not restricted
+            And the PR job of "fork" is triggered because it is not restricted
+            And the PR job of "branch" is not triggered because it is restricted
+            And the PR job of "all" is not triggered because it is restricted
 
-    Scenario: Create a pull request for restrict pr value is fork from the same repository
-        Given an existing pipeline with the source directory "fork" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd-test" organization
-        And a new file is added to the "fork" directory
-        And a pull request is opened from the "screwdriver-cd-test" organization
-        Then the PR job of "fork" is triggered because it is not restricted
-
-    Scenario: Create a pull request for restrict pr value is branch from the same repository
-        Given an existing pipeline with the source directory "branch" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd-test" organization
-        And a new file is added to the "branch" directory
-        And a pull request is opened from the "screwdriver-cd-test" organization
-        Then the PR job of "branch" is not triggered because it is restricted
-
-    Scenario: Create a pull request for restrict pr value is all from the same repository
-        Given an existing pipeline with the source directory "all" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd-test" organization
-        And a new file is added to the "all" directory
-        And a pull request is opened from the "screwdriver-cd-test" organization
-        Then the PR job of "all" is not triggered because it is restricted
-
-
-
-    Scenario: Create a pull request for restrict pr value is none from the forked repository
+    Scenario: Create a pull request from the forked repository
         Given an existing pipeline with the source directory "none" and with the workflow jobs:
             | job           | requires          |
             | main          | ~pr               |
+            And an existing pipeline with the source directory "fork" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "branch" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "all" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
         When a branch is created for test_branch on "screwdriver-cd" organization
-        And a new file is added to the "none" directory
-        And a pull request is opened from the "screwdriver-cd" organization
+            And a new file is added to the "none" directory
+            And a new file is added to the "fork" directory
+            And a new file is added to the "branch" directory
+            And a new file is added to the "all" directory
+            And a pull request is opened from the "screwdriver-cd" organization
         Then the PR job of "none" is triggered because it is not restricted
-
-    Scenario: Create a pull request for restrict pr value is fork from the forked repository
-        Given an existing pipeline with the source directory "fork" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd" organization
-        And a new file is added to the "fork" directory
-        And a pull request is opened from the "screwdriver-cd" organization
-        Then the PR job of "fork" is not triggered because it is restricted
-
-    Scenario: Create a pull request for restrict pr value is branch from the forked repository
-        Given an existing pipeline with the source directory "branch" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd" organization
-        And a new file is added to the "branch" directory
-        And a pull request is opened from the "screwdriver-cd" organization
-        Then the PR job of "branch" is triggered because it is not restricted
-
-    Scenario: Create a pull request for restrict pr value is all from the forked repository
-        Given an existing pipeline with the source directory "all" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd" organization
-        And a new file is added to the "all" directory
-        And a pull request is opened from the "screwdriver-cd" organization
-        Then the PR job of "all" is not triggered because it is restricted
+            And the PR job of "branch" is triggered because it is not restricted
+            And the PR job of "fork" is not triggered because it is restricted
+            And the PR job of "all" is not triggered because it is restricted

--- a/features/restrict-pr.feature
+++ b/features/restrict-pr.feature
@@ -1,0 +1,59 @@
+@restrict-pr
+Feature: Restrict-pr
+
+    The user wants to control the execution of the PR job depending on the source and destination of the Pull Request.
+
+    Rules:
+        -　The restrict-pr setting allows the following controls
+        -- none: Start all PR build
+        -- fork: Do not start PR build from fork
+        -- branch: Do not start PR build form same repository
+        -- all: Do not start all PR build
+
+    Scenario: Create a pull request from the same repository
+        Given an existing pipeline with the source directory "none" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "fork" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "branch" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "all" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+        When a branch is created for test_branch on "screwdriver-cd-test" organization
+            And a new file is added to the "none" directory
+            And a new file is added to the "fork" directory
+            And a new file is added to the "branch" directory
+            And a new file is added to the "all" directory
+            And a pull request is opened from the "screwdriver-cd-test" organization
+        Then the PR job of "none" is triggered because it is not restricted
+            And the PR job of "fork" is triggered because it is not restricted
+            And the PR job of "branch" is not triggered because it is restricted
+            And the PR job of "all" is not triggered because it is restricted
+
+    Scenario: Create a pull request from the forked repository
+        Given an existing pipeline with the source directory "none" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "fork" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "branch" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+            And an existing pipeline with the source directory "all" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+        When a branch is created for test_branch on "screwdriver-cd" organization
+            And a new file is added to the "none" directory
+            And a new file is added to the "fork" directory
+            And a new file is added to the "branch" directory
+            And a new file is added to the "all" directory
+            And a pull request is opened from the "screwdriver-cd" organization
+        Then the PR job of "none" is triggered because it is not restricted
+            And the PR job of "branch" is triggered because it is not restricted
+            And the PR job of "fork" is not triggered because it is restricted
+            And the PR job of "all" is not triggered because it is restricted

--- a/features/restrict-pr.feature
+++ b/features/restrict-pr.feature
@@ -10,50 +10,76 @@ Feature: Restrict-pr
         -- branch: Do not start PR build from same repository
         -- all: Do not start all PR build
 
-    Scenario: Create a pull request from the same repository
+    Scenario: Create a pull request for restrict pr value is none from the same repository
         Given an existing pipeline with the source directory "none" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-            And an existing pipeline with the source directory "fork" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-            And an existing pipeline with the source directory "branch" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-            And an existing pipeline with the source directory "all" and with the workflow jobs:
             | job           | requires          |
             | main          | ~pr               |
         When a branch is created for test_branch on "screwdriver-cd-test" organization
-            And a new file is added to the "none" directory
-            And a new file is added to the "fork" directory
-            And a new file is added to the "branch" directory
-            And a new file is added to the "all" directory
-            And a pull request is opened from the "screwdriver-cd-test" organization
+        And a new file is added to the "none" directory
+        And a pull request is opened from the "screwdriver-cd-test" organization
         Then the PR job of "none" is triggered because it is not restricted
-            And the PR job of "fork" is triggered because it is not restricted
-            And the PR job of "branch" is not triggered because it is restricted
-            And the PR job of "all" is not triggered because it is restricted
 
-    Scenario: Create a pull request from the forked repository
+    Scenario: Create a pull request for restrict pr value is fork from the same repository
+        Given an existing pipeline with the source directory "fork" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+        When a branch is created for test_branch on "screwdriver-cd-test" organization
+        And a new file is added to the "fork" directory
+        And a pull request is opened from the "screwdriver-cd-test" organization
+        Then the PR job of "fork" is triggered because it is not restricted
+
+    Scenario: Create a pull request for restrict pr value is branch from the same repository
+        Given an existing pipeline with the source directory "branch" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+        When a branch is created for test_branch on "screwdriver-cd-test" organization
+        And a new file is added to the "branch" directory
+        And a pull request is opened from the "screwdriver-cd-test" organization
+        Then the PR job of "branch" is not triggered because it is restricted
+
+    Scenario: Create a pull request for restrict pr value is all from the same repository
+        Given an existing pipeline with the source directory "all" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+        When a branch is created for test_branch on "screwdriver-cd-test" organization
+        And a new file is added to the "all" directory
+        And a pull request is opened from the "screwdriver-cd-test" organization
+        Then the PR job of "all" is not triggered because it is restricted
+
+
+
+    Scenario: Create a pull request for restrict pr value is none from the forked repository
         Given an existing pipeline with the source directory "none" and with the workflow jobs:
             | job           | requires          |
             | main          | ~pr               |
-            And an existing pipeline with the source directory "fork" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-            And an existing pipeline with the source directory "branch" and with the workflow jobs:
-            | job           | requires          |
-            | main          | ~pr               |
-            And an existing pipeline with the source directory "all" and with the workflow jobs:
+        When a branch is created for test_branch on "screwdriver-cd" organization
+        And a new file is added to the "none" directory
+        And a pull request is opened from the "screwdriver-cd" organization
+        Then the PR job of "none" is triggered because it is not restricted
+
+    Scenario: Create a pull request for restrict pr value is fork from the forked repository
+        Given an existing pipeline with the source directory "fork" and with the workflow jobs:
             | job           | requires          |
             | main          | ~pr               |
         When a branch is created for test_branch on "screwdriver-cd" organization
-            And a new file is added to the "none" directory
-            And a new file is added to the "fork" directory
-            And a new file is added to the "branch" directory
-            And a new file is added to the "all" directory
-            And a pull request is opened from the "screwdriver-cd" organization
-        Then the PR job of "none" is triggered because it is not restricted
-            And the PR job of "branch" is triggered because it is not restricted
-            And the PR job of "fork" is not triggered because it is restricted
-            And the PR job of "all" is not triggered because it is restricted
+        And a new file is added to the "fork" directory
+        And a pull request is opened from the "screwdriver-cd" organization
+        Then the PR job of "fork" is not triggered because it is restricted
+
+    Scenario: Create a pull request for restrict pr value is branch from the forked repository
+        Given an existing pipeline with the source directory "branch" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+        When a branch is created for test_branch on "screwdriver-cd" organization
+        And a new file is added to the "branch" directory
+        And a pull request is opened from the "screwdriver-cd" organization
+        Then the PR job of "branch" is triggered because it is not restricted
+
+    Scenario: Create a pull request for restrict pr value is all from the forked repository
+        Given an existing pipeline with the source directory "all" and with the workflow jobs:
+            | job           | requires          |
+            | main          | ~pr               |
+        When a branch is created for test_branch on "screwdriver-cd" organization
+        And a new file is added to the "all" directory
+        And a pull request is opened from the "screwdriver-cd" organization
+        Then the PR job of "all" is not triggered because it is restricted

--- a/features/restrict-pr.feature
+++ b/features/restrict-pr.feature
@@ -7,7 +7,7 @@ Feature: Restrict-pr
         -　The restrict-pr setting allows the following controls
         -- none: Start all PR build
         -- fork: Do not start PR build from fork
-        -- branch: Do not start PR build form same repository
+        -- branch: Do not start PR build from same repository
         -- all: Do not start all PR build
 
     Scenario: Create a pull request from the same repository

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -45,7 +45,7 @@ Given(
 );
 
 When(
-    /^a branch is created for test_branch on "([^"]*)" organization$/,
+    /^a branch is created "([^"]*)" organization$/,
     {
         timeout: TIMEOUT
     },

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const Assert = require('chai').assert;
+const { Before, Given, When, Then, After } = require('cucumber');
+const github = require('../support/github');
+const sdapi = require('../support/sdapi');
+
+const TIMEOUT = 240 * 1000;
+
+Before(
+    {
+        tags: '@restrict-pr'
+    },
+    function hook() {
+        this.repoName = 'functional-restrict-pr';
+        this.repoOrg = this.testOrg;
+        this.targetBranch = 'master';
+        this.sourceOrg = null;
+        this.sourceBranch = null;
+        this.jobName = 'main';
+        this.pullRequestNumber = null;
+        this.sha = null;
+        this.pipelines = {};
+    }
+);
+
+Given(
+    /^an existing pipeline with the source directory "([^"]*)" and with the workflow jobs:$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(rootDir, table) {
+        await this.ensurePipelineExists({
+            repoName: this.repoName,
+            branch: this.targetBranch,
+            rootDir,
+            table,
+            shouldNotDeletePipeline: false
+        });
+
+        this.pipelines[rootDir] = {
+            pipelineId: this.pipelineId
+        };
+    }
+);
+
+When(
+    /^a branch is created "([^"]*)" organization$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(sourceOrg) {
+        const postfix = new Date().getTime().toString();
+        const sourceBranch = `test-branch-${postfix}`;
+
+        this.sourceOrg = sourceOrg;
+        this.sourceBranch = sourceBranch;
+
+        await github
+            .createBranch(this.sourceBranch, this.sourceOrg, this.repoName)
+            .catch(() => Assert.fail('Failed to create branch.'));
+    }
+);
+
+When(
+    /^a new file is added to the "([^"]*)" directory$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(rootDir) {
+        await github
+            .createFile(this.sourceBranch, this.sourceOrg, this.repoName, rootDir)
+            .catch(() => Assert.fail('Failed to create file.'));
+    }
+);
+
+When(
+    /^a pull request is opened from the "([^"]*)" organization$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(sourceOrg) {
+        await github
+            .createPullRequest(`${sourceOrg}:${this.sourceBranch}`, this.targetBranch, this.repoOrg, this.repoName)
+            .then(({ data }) => {
+                this.pullRequestNumber = data.number;
+                this.sha = data.head.sha;
+            })
+            .catch(() => Assert.fail('Failed to create the Pull Request.'));
+    }
+);
+
+Then(
+    /^the PR job of "([^"]*)" is triggered because it is not restricted$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(rootDir) {
+        const build = await sdapi.searchForBuild({
+            instance: this.instance,
+            pipelineId: this.pipelines[rootDir].pipelineId,
+            desiredSha: this.sha,
+            desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+            jobName: this.jobName,
+            pullRequestNumber: this.pullRequestNumber,
+            jwt: this.jwt
+        });
+
+        const jobs = await sdapi.findJobs({
+            instance: this.instance,
+            pipelineId: this.pipelines[rootDir].pipelineId,
+            jwt: this.jwt
+        });
+
+        const jobData = jobs.body;
+        const prJobName = `PR-${this.pullRequestNumber}:${this.jobName}`;
+        const job = jobData.find(j => j.name === prJobName);
+
+        Assert.equal(build.jobId, job.id);
+    }
+);
+
+Then(
+    /^the PR job of "([^"]*)" is not triggered because it is restricted$/,
+    {
+        timeout: TIMEOUT
+    },
+    async function step(rootDir) {
+        const build = await sdapi.findBuilds({
+            instance: this.instance,
+            pipelineId: this.pipelines[rootDir].pipelineId,
+            jobName: this.jobName,
+            pullRequestNumber: this.pullRequestNumber,
+            jwt: this.jwt
+        });
+
+        let result = build.body || [];
+
+        result = result.filter(item => item.sha === this.sha);
+
+        Assert.equal(result.length, 0, 'Unexpected job was triggered.');
+    }
+);
+
+After(
+    {
+        tags: '@restrict-pr'
+    },
+    function hook() {
+        github
+            .closePullRequest(this.repoOrg, this.repoName, this.pullRequestNumber)
+            .then(() => {
+                github.removeBranch(this.sourceOrg, this.repoName, this.sourceBranch);
+            })
+            .catch(() => {
+                Assert.fail('Failed to close Pull Request or remove branch.');
+            });
+    }
+);

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -122,6 +122,7 @@ Then(
         timeout: TIMEOUT
     },
     async function step(rootDir) {
+        // Wait 3 seconds for build trigger
         await sdapi.promiseToWait(3);
 
         const build = await sdapi.findBuilds(

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -125,16 +125,13 @@ Then(
         // Wait 3 seconds for build trigger
         await sdapi.promiseToWait(3);
 
-        const build = await sdapi.findBuilds(
-            {
-                instance: this.instance,
-                pipelineId: this.pipelines[rootDir].pipelineId,
-                jobName: this.jobName,
-                pullRequestNumber: this.pullRequestNumber,
-                jwt: this.jwt
-            },
-            1
-        );
+        const build = await sdapi.findBuilds({
+            instance: this.instance,
+            pipelineId: this.pipelines[rootDir].pipelineId,
+            jobName: this.jobName,
+            pullRequestNumber: this.pullRequestNumber,
+            jwt: this.jwt
+        });
 
         Assert.equal(build.body.length, 0, 'Unexpected job was triggered.');
     }

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -45,7 +45,7 @@ Given(
 );
 
 When(
-    /^a branch is created "([^"]*)" organization$/,
+    /^a branch is created for test_branch on "([^"]*)" organization$/,
     {
         timeout: TIMEOUT
     },


### PR DESCRIPTION
## Context
Add functional test for restrict pr since it was missing.
I have also submitted a PR to the `funtional-restrict-pr` repository of screwdriver-cd-test to get this test working.
https://github.com/screwdriver-cd-test/functional-restrict-pr/pull/1
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- PR from the same repository to pipelines with restrict pr set
- PR from the forked repository to the source repository with restrict pr set
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
