### PR TITLE
fix: Error fix in removeJoinBuilds

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -719,10 +719,8 @@ const buildsPlugin = {
                         buildConfig.jobId = nextJob.id;
                         if (!isExternal) {
                             buildConfig.eventId = event.id;
-                        } else if (hoek.reach(pipelineJoinData[pid], 'event')) {
-                            buildConfig.eventId = pipelineJoinData[pid].event.id;
                         } else {
-                            buildConfig.envetId = undefined;
+                            buildConfig.eventId = hoek.reach(pipelineJoinData[pid], 'event.id');
                         }
 
                         if (buildConfig.eventId) {

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -718,11 +718,15 @@ const buildsPlugin = {
                         buildConfig.jobId = nextJob.id;
                         if (!isExternal) {
                             buildConfig.eventId = event.id;
-                        } else {
+                        } else if (Object.prototype.hasOwnProperty.call(pipelineJoinData[pid], 'event')) {
                             buildConfig.eventId = pipelineJoinData[pid].event.id;
+                        } else {
+                            buildConfig.envetId = undefined;
                         }
 
-                        deletePromises.push(deleteBuild(buildConfig, buildFactory));
+                        if (buildConfig.eventId) {
+                            deletePromises.push(deleteBuild(buildConfig, buildFactory));
+                        }
                     } catch (err) {
                         logger.error(
                             `Error in removeJoinBuilds:${nextJobName} from pipeline:${current.pipeline.id}-${current.job.name}-event:${current.event.id} `,

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -4,6 +4,7 @@ const logger = require('screwdriver-logger');
 const workflowParser = require('screwdriver-workflow-parser');
 const merge = require('lodash.mergewith');
 const schema = require('screwdriver-data-schema');
+const hoek = require('@hapi/hoek');
 const getRoute = require('./get');
 const getBuildStatusesRoute = require('./getBuildStatuses');
 const updateRoute = require('./update');
@@ -718,7 +719,7 @@ const buildsPlugin = {
                         buildConfig.jobId = nextJob.id;
                         if (!isExternal) {
                             buildConfig.eventId = event.id;
-                        } else if (Object.prototype.hasOwnProperty.call(pipelineJoinData[pid], 'event')) {
+                        } else if (hoek.reach(pipelineJoinData[pid], 'event')) {
                             buildConfig.eventId = pipelineJoinData[pid].event.id;
                         } else {
                             buildConfig.envetId = undefined;

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2009,8 +2009,6 @@ describe('pipeline plugin test', () => {
 
         it('returns 200 and updates settings only', () => {
             const expectedSetting = {
-                showEventTriggers: false,
-                groupedEvents: false,
                 metricsDowntimeJobs: [123, 456],
                 public: true
             };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If the Remote Join feature is used in an unsupported method, as shown in the following image, an error will occur.
<img width="670" alt="remote-join" src="https://user-images.githubusercontent.com/17828065/157792069-2ca65c2e-4108-40ad-9e72-0b01ec296f50.png">



`Error Message`:
```
Error in removeJoinBuilds:main from pipeline:<pipelineId>-event:<event> Cannot read property 'id' of undefined
```

Subsequent builds are not created, so no real harm is done, but it will result in a 500 error and noise for monitoring.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Verify that the key exists correctly for the event you want to remove.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- [Remote Join](https://docs.screwdriver.cd/user-guide/configuration/workflow#remote-join)
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
