### PR TITLE
fix(2665): Enables to set sourceDirectory even if top dir was two characters or less

### DIFF
--- a/plugins/pipelines/helper.js
+++ b/plugins/pipelines/helper.js
@@ -37,7 +37,7 @@ const formatCheckoutUrl = checkoutUrl => {
  * @return {String}                 Root dir with no leading/trailing slashes
  */
 const sanitizeRootDir = (rootDir = '') => {
-    return rootDir.replace(/^(\/+|.\/|..\/)|\/+$/g, '');
+    return rootDir.replace(/^(\/+|\.\/|\.\.\/)|\/+$/g, '');
 };
 
 /**

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1851,6 +1851,51 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('formats the rootDir correctly when rootDir has ../PATH format', () => {
+            options.payload.rootDir = '../src/app/component///////////';
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
+
+            return server.inject(options).then(() => {
+                assert.calledWith(pipelineFactoryMock.scm.parseUrl, {
+                    scmContext,
+                    checkoutUrl: formattedCheckoutUrl,
+                    token,
+                    rootDir: 'src/app/component'
+                });
+                assert.calledWith(userMock.getPermissions, scmUri);
+            });
+        });
+
+        it('formats the rootDir correctly when top dir has single character format', () => {
+            options.payload.rootDir = 'a/app/component///////////';
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
+
+            return server.inject(options).then(() => {
+                assert.calledWith(pipelineFactoryMock.scm.parseUrl, {
+                    scmContext,
+                    checkoutUrl: formattedCheckoutUrl,
+                    token,
+                    rootDir: 'a/app/component'
+                });
+                assert.calledWith(userMock.getPermissions, scmUri);
+            });
+        });
+
+        it('formats the rootDir correctly when top dir has 2-character format', () => {
+            options.payload.rootDir = 'ab/app/component///////////';
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
+
+            return server.inject(options).then(() => {
+                assert.calledWith(pipelineFactoryMock.scm.parseUrl, {
+                    scmContext,
+                    checkoutUrl: formattedCheckoutUrl,
+                    token,
+                    rootDir: 'ab/app/component'
+                });
+                assert.calledWith(userMock.getPermissions, scmUri);
+            });
+        });
+
         it('returns 403 when the user does not have admin permissions', () => {
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix https://github.com/screwdriver-cd/screwdriver/issues/2665

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- This PR enables to create pipeline even if two characters or less top dir was set as rootDir like `aa/bb/cc`.
- This PR enables to change pipeline's rootDir even if two characters or less top dir was set.
- `/`, `./`, `../` are omitted as [originally intended](https://github.com/screwdriver-cd/screwdriver/issues/2665#issuecomment-1041982316).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2665

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
