### PR TITLE
fix: Use non-readOnly DB to get latest build for join [2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "screwdriver-config-parser": "^7.4.0",
     "screwdriver-coverage-bookend": "^1.0.3",
     "screwdriver-coverage-sonar": "^3.3.3",
-    "screwdriver-data-schema": "^21.17.0",
+    "screwdriver-data-schema": "^21.22.2",
     "screwdriver-datastore-sequelize": "^7.2.7",
     "screwdriver-executor-base": "^8.4.0",
     "screwdriver-executor-docker": "^5.0.1",

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -412,7 +412,7 @@ function parseJobInfo({ joinObj = {}, current, nextJobName, nextPipelineId }) {
  */
 async function getFinishedBuilds(event, buildFactory) {
     // FIXME: buildFactory.getLatestBuilds doesn't return build model
-    const builds = await buildFactory.getLatestBuilds({ groupEventId: event.groupEventId });
+    const builds = await buildFactory.getLatestBuilds({ groupEventId: event.groupEventId, readOnly: false });
 
     builds.forEach(b => {
         try {


### PR DESCRIPTION
## Context

Seeing some `SequelizeUniqueConstraintError` as a result of `triggerNextJobInSamePipeline` for join logic in Screwdriver build index. This might be because the `readOnly` DB has a slight delay, causing `getLatestBuilds` call to not get the CREATED join job.

## Objective

This PR explicitly sets `readOnly` flag to `false` for `getLatestBuilds` in join logic.

## References

Blocked by https://github.com/screwdriver-cd/models/pull/530

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
