### PR TITLE
fix: return 404 in openPr branch not found

### DIFF
--- a/plugins/pipelines/openPr.js
+++ b/plugins/pipelines/openPr.js
@@ -54,10 +54,6 @@ module.exports = () => ({
                                                 );
                                             }
                                         })
-                                        .catch(error => {
-                                            // 404 error throws, if branch name is incorrect
-                                            throw boom.boomify(error, { statusCode: error.statusCode });
-                                        })
                                         .then(() => {
                                             let scmUrl = checkoutUrl;
 
@@ -74,6 +70,10 @@ module.exports = () => ({
                                                 title,
                                                 message
                                             });
+                                        })
+                                        .catch(error => {
+                                            // 404 error throws, if branch name is incorrect
+                                            throw boom.boomify(error, { statusCode: error.statusCode });
                                         })
                                 );
                         })

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -3549,15 +3549,17 @@ describe('pipeline plugin test', () => {
         });
 
         it('returns 404 when branch name is incorrect', () => {
-            const testError = new Error('Not Found');
+            const testError = new Error('Branch not found');
 
             testError.statusCode = 404;
+
+            userFactoryMock.scm.openPr.rejects(testError);
 
             userMock.getPermissions.withArgs(scmUri).rejects(testError);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
-                assert.equal(reply.result.message, 'Not Found');
+                assert.equal(reply.result.message, 'Branch not found');
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In [previous PR](https://github.com/screwdriver-cd/screwdriver/pull/2691), 500 error of `openPr` could not be solved, because of the wrong position of catch statement.

Github API 404 error occurs in [this method](https://github.com/screwdriver-cd/screwdriver/blob/b8e783c271b4b60e5f0c7ad1754f32eb4aebc4e4/plugins/pipelines/openPr.js#L69).

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix position of the catch statement.

Here is the log message of my local api component after fixed codes.

`POST /pipelines/{id}/openPr`
```
"status":404,"url":"https://yyy.xxxx/api/v3/repos/repoName/sd-tmp-test-6/branches/aaaaaaaa"},"stack":"HttpError: Branch not found\n    at /usr/src/app/node_modules/@octokit/request/dist-node/index.js:86:21\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:97:5)","status":404,"statusCode":404,"timestamp":"2022-04-12T06:59:14.586Z"}
220412/065914.587, (1649746754201:sdapi-88b5cbb9-66gkc:20:l1vqguwo:20117) [request,server,error] data: HttpError: Branch not found
    at /usr/src/app/node_modules/@octokit/request/dist-node/index.js:86:21
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
220412/065914.201, (1649746754201:sdapi-88b5cbb9-66gkc:20:l1vqguwo:20117) [response,api,pipelines] https://api-cd.xxxx: post /v4/pipelines/16/openPr {} 404
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- [previous PR](https://github.com/screwdriver-cd/screwdriver/pull/2691)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
