### PR TITLE
fix(2671): The build parameter should not be polluted by another pipeline

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -422,8 +422,7 @@ async function createPREvents(options, request) {
         restrictPR,
         chainPR,
         ref,
-        releaseName,
-        meta
+        releaseName
     } = options;
     const { scm } = request.server.app.pipelineFactory;
     const { eventFactory, pipelineFactory, userFactory } = request.server.app;
@@ -525,7 +524,6 @@ async function createPREvents(options, request) {
                         changedFiles,
                         baseBranch: branch,
                         causeMessage: `Merged by ${username}`,
-                        meta,
                         releaseName,
                         ref,
                         subscribedEvent: true,
@@ -800,7 +798,6 @@ function pullRequestEvent(pluginOptions, request, h, parsed, token) {
         scmContext
     };
     const { restrictPR, chainPR } = pluginOptions;
-    const meta = createMeta(parsed);
 
     request.log(['webhook', hookId], `PR #${prNum} ${action} for ${fullCheckoutUrl}`);
 
@@ -842,8 +839,7 @@ function pullRequestEvent(pluginOptions, request, h, parsed, token) {
                 chainPR,
                 pipelines,
                 ref,
-                releaseName,
-                meta
+                releaseName
             };
 
             await batchUpdateAdmins({ userFactory, pipelines, username, scmContext, pipelineFactory });
@@ -887,7 +883,6 @@ async function createEvents(
     scmConfigFromHook
 ) {
     const { action, branch, sha, username, scmContext, changedFiles, type, releaseName, ref } = parsed;
-    const meta = createMeta(parsed);
 
     const pipelineTuples = await Promise.all(
         pipelines.map(async p => {
@@ -971,7 +966,7 @@ async function createEvents(
                     changedFiles,
                     baseBranch: branch,
                     causeMessage: `Merged by ${username}`,
-                    meta,
+                    meta: createMeta(parsed),
                     releaseName,
                     ref
                 };

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1088,6 +1088,17 @@ describe('startHookEvent test', () => {
                     ref: undefined,
                     meta: {}
                 });
+
+                const eventFactoryCreateArgs = [
+                    eventFactoryMock.create.getCall(0).args[0],
+                    eventFactoryMock.create.getCall(1).args[0],
+                    eventFactoryMock.create.getCall(2).args[0]
+                ];
+
+                assert.notStrictEqual(eventFactoryCreateArgs[0].meta, eventFactoryCreateArgs[1].meta);
+                assert.notStrictEqual(eventFactoryCreateArgs[1].meta, eventFactoryCreateArgs[2].meta);
+                assert.notStrictEqual(eventFactoryCreateArgs[2].meta, eventFactoryCreateArgs[0].meta);
+
                 assert.neverCalledWith(
                     eventFactoryMock.create,
                     sinon.match({
@@ -1171,6 +1182,14 @@ describe('startHookEvent test', () => {
                     ref: undefined,
                     meta: {}
                 });
+
+                const eventFactoryCreateArgs = [
+                    eventFactoryMock.create.getCall(0).args[0],
+                    eventFactoryMock.create.getCall(1).args[0]
+                ];
+
+                assert.notStrictEqual(eventFactoryCreateArgs[0].meta, eventFactoryCreateArgs[1].meta);
+
                 assert.neverCalledWith(
                     eventFactoryMock.create,
                     sinon.match({
@@ -1794,7 +1813,6 @@ describe('startHookEvent test', () => {
                         changedFiles,
                         releaseName: undefined,
                         ref: undefined,
-                        meta: {},
                         subscribedEvent: true,
                         subscribedSourceUrl: 'foo'
                     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Fix the following issue.

- https://github.com/screwdriver-cd/screwdriver/issues/2671

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR make `eventConfig.meta` instance independent for each event configs.

Currently, when multiple events triggered from a same webhook, we set same `meta` instance to `eventConfig` for each events.
Thus if we set `meta.parameters` in `eventFactory.create(eventConfig1)`, then `eventConfig2.meta.parameters` is set too.

### 1. event triggered by push, tag, release

Call `createMeta` function for each events.

### 2. event triggered by pull request

In PR event, [`createMeta`](https://github.com/screwdriver-cd/screwdriver/blob/4a049770e8f25013761dcb07dc6c453842442e5e/plugins/webhooks/helper.js#L727-L760) always returns empty object since webhook action is not "tag" and "release".
On the other hand, default value of `eventConfig.meta` is empty object ([ref](https://github.com/screwdriver-cd/models/blob/6ebcb56dd4a74dc5ca75f67f1361902568bce775/lib/eventFactory.js#L690)).
So I remove `meta` config from `eventFactory.create` arguments.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issues
- https://github.com/screwdriver-cd/screwdriver/issues/2671

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
