### PR TITLE
fix: Update promster hapi version

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@hapi/hoek": "^9.1.1",
     "@hapi/inert": "^6.0.4",
     "@hapi/vision": "^6.1.0",
-    "@promster/hapi": "^4.2.1",
+    "@promster/hapi": "^6.1.0",
     "async": "^3.2.2",
     "badge-maker": "^3.3.1",
     "config": "^1.31.0",

--- a/plugins/metrics.js
+++ b/plugins/metrics.js
@@ -16,7 +16,7 @@ module.exports = {
         server.route({
             method: 'GET',
             path: '/metrics',
-            handler: (_, h) => h.response(getSummary()),
+            handler: async (_, h) => h.response(await getSummary()),
             config: {
                 plugins: {
                     'hapi-rate-limit': {


### PR DESCRIPTION
## Context
Version 4.1.2 of `promster/hapi` contains minimist which contains a vulnerability.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We update `promster/hapi` to the 6.1 series which is not vulnerable and supports node 12.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/tdeekens/promster/blob/main/packages/hapi/CHANGELOG.md
https://github.com/tdeekens/promster/tree/%40promster/hapi%406.1.3
https://sca.analysiscenter.veracode.com/vulnerability-database/vulnerabilities/34731
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
