### PR TITLE
fix: List builds for job should be able to query by build status

### DIFF
--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -4,6 +4,7 @@ const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const jobIdSchema = schema.models.job.base.extract('id');
+const statusSchema = schema.models.build.base.extract('status');
 const buildListSchema = joi
     .array()
     .items(schema.models.build.get)
@@ -23,7 +24,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const factory = request.server.app.jobFactory;
-            const { sort, sortBy, page, count, fetchSteps, readOnly } = request.query;
+            const { sort, sortBy, page, count, fetchSteps, readOnly, status } = request.query;
 
             return factory
                 .get(request.params.id)
@@ -38,6 +39,10 @@ module.exports = () => ({
 
                     if (sortBy) {
                         config.sortBy = sortBy;
+                    }
+
+                    if (status) {
+                        config.status = status;
                     }
 
                     if (page || count) {
@@ -79,7 +84,8 @@ module.exports = () => ({
                         .boolean()
                         .truthy('true')
                         .falsy('false')
-                        .default(true)
+                        .default(true),
+                    status: statusSchema
                 })
             )
         }

--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -85,7 +85,8 @@ module.exports = () => ({
                         .truthy('true')
                         .falsy('false')
                         .default(true),
-                    status: statusSchema
+                    status: statusSchema,
+                    search: joi.forbidden() // we don't support search for list builds
                 })
             )
         }

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -369,7 +369,7 @@ describe('job plugin test', () => {
         });
 
         it('pass in the correct params to getBuilds with all params', () => {
-            options.url = `/jobs/${id}/builds?page=2&count=30&sort=ascending&sortBy=id`;
+            options.url = `/jobs/${id}/builds?page=2&count=30&sort=ascending&sortBy=id&status=RUNNING`;
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
@@ -379,7 +379,8 @@ describe('job plugin test', () => {
                         page: 2
                     },
                     sort: 'ascending',
-                    sortBy: 'id'
+                    sortBy: 'id',
+                    status: 'RUNNING'
                 });
                 assert.deepEqual(reply.result, testBuilds);
             });


### PR DESCRIPTION
## Context

Users might want to query the API to get a list of builds and filter by build status.

## Objective

This PR adds query option to filter by build status for `GET jobs/:jobid/builds`.

## References
NA

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
