### PR TITLE
fix(2704): Disabled jobs are not triggered even in chainPR.

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -288,7 +288,21 @@ async function createInternalBuild(config) {
         baseBranch
     };
 
-    if (job.state === 'ENABLED') {
+    let jobState = job.state;
+
+    if (prRef) {
+        // Whether a job is enabled is determined by the state of the original job.
+        // If the original job does not exist, it will be enabled.
+        const originalJobName = job.parsePRJobName('job');
+        const originalJob = await jobFactory.get({
+            name: originalJobName,
+            pipelineId
+        });
+
+        jobState = originalJob ? originalJob.state : 'ENABLED';
+    }
+
+    if (jobState === 'ENABLED') {
         return buildFactory.create(internalBuildConfig);
     }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Disabled jobs are no longer executed in PR builds at https://github.com/screwdriver-cd/models/pull/537.
However, it is not working for jobs triggered after the second stage in chainPR.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Fix jobs in chainPR to reference the original state, as well as jobs triggered by `~pr`.
- According to the following fixes, the state should always refer to the original.
  - https://github.com/screwdriver-cd/ui/pull/795
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/models/pull/546

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
