### PR TITLE
fix:Refactoring of the unzipArtifactsEnabled configuration part of api

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -141,9 +141,7 @@ module.exports = async config => {
             ecosystem: config.ecosystem,
             release: config.release,
             queueWebhook: config.queueWebhook,
-            feature: {
-                unzipArtifacts: config.unzipArtifactsEnabled
-            }
+            unzipArtifacts: config.unzipArtifactsEnabled
         };
 
         const bellConfigs = await config.auth.scm.getBellConfiguration();

--- a/plugins/builds/artifacts/unzip.js
+++ b/plugins/builds/artifacts/unzip.js
@@ -18,7 +18,7 @@ module.exports = config => ({
         },
 
         handler: async (req, h) => {
-            if (!req.server.app.feature.unzipArtifacts) {
+            if (!req.server.app.unzipArtifacts) {
                 const data = {
                     statusCode: 200,
                     message: "This function is not enabled and will do nothing."

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -208,9 +208,7 @@ describe('build plugin test', () => {
             userFactory: userFactoryMock,
             eventFactory: eventFactoryMock,
             bannerFactory: bannerFactoryMock,
-            feature: {
-                unzipArtifacts: true
-            }
+            unzipArtifacts: true
         };
         server.auth.scheme('custom', () => ({
             authenticate: (request, h) =>
@@ -5670,7 +5668,7 @@ describe('build plugin test', () => {
         });
 
         it('returns 200 when the feature is not enabled', () => {
-            server.app.feature.unzipArtifacts = false;
+            server.app.unzipArtifacts = false;
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The object structure of unzipArtifactsEnabled, which manages flags for the SD_ZIP_ARTIFACTS function on the API side, is stored in **server.app.feature**, while other flags are stored directly in **sever.app**. I have modified it because the object structure is different.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Changed structure from **server.app.feature.unzipArtifacts** to **server.app.unzipArtifacts**

## References
None
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
