### PR TITLE
feat(2700): Add audit log of operations on the Options page

### DIFF
--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -67,6 +67,7 @@ module.exports = () => ({
                 scmUri
             };
 
+            logger.info(`[Audit] user ${user.username}:${scmContext} creates the pipeline for ${scmUri}.`);
             pipeline = await pipelineFactory.create(pipelineConfig);
 
             const collections = await collectionFactory.list({

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -68,11 +68,11 @@ module.exports = () => ({
                                 throw boom.boomify(error, { statusCode: error.statusCode });
                             })
                             // user has good permissions, remove the pipeline
-                            .then(() => {
+                            .then(async () => {
                                 logger.info(
                                     `[Audit] user ${user.username}:${scmContext} deletes the pipeline pipelineId:${request.params.id}, scmUri:${pipeline.scmUri}.`
                                 );
-                                pipeline.remove();
+                                await pipeline.remove();
                             })
                             .then(() => h.response().code(204))
                     );

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -69,7 +69,9 @@ module.exports = () => ({
                             })
                             // user has good permissions, remove the pipeline
                             .then(() => {
-                                logger.info(`[Audit] user ${user.username}:${scmContext} deletes the pipeline pipelineId:${request.params.id}, scmUri:${pipeline.scmUri}.`);
+                                logger.info(
+                                    `[Audit] user ${user.username}:${scmContext} deletes the pipeline pipelineId:${request.params.id}, scmUri:${pipeline.scmUri}.`
+                                );
                                 pipeline.remove();
                             })
                             .then(() => h.response().code(204))

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const idSchema = schema.models.pipeline.base.extract('id');
 
 module.exports = () => ({
@@ -67,7 +68,10 @@ module.exports = () => ({
                                 throw boom.boomify(error, { statusCode: error.statusCode });
                             })
                             // user has good permissions, remove the pipeline
-                            .then(() => pipeline.remove())
+                            .then(() => {
+                                logger.info(`[Audit] user ${user.username}:${scmContext} deletes the pipeline pipelineId:${request.params.id}, scmUri:${pipeline.scmUri}.`);
+                                pipeline.remove();
+                            })
                             .then(() => h.response().code(204))
                     );
                 })

--- a/plugins/pipelines/tokens/create.js
+++ b/plugins/pipelines/tokens/create.js
@@ -53,7 +53,9 @@ module.exports = () => ({
                 throw boom.conflict(`Token ${match.name} already exists`);
             }
 
-            logger.info(`[Audit] user ${username}:${scmContext} creates the token name:${request.payload.name} for pipelineId:${pipelineId}.`);
+            logger.info(
+                `[Audit] user ${username}:${scmContext} creates the token name:${request.payload.name} for pipelineId:${pipelineId}.`
+            );
             const token = await tokenFactory.create({
                 name: request.payload.name,
                 description: request.payload.description,

--- a/plugins/pipelines/tokens/create.js
+++ b/plugins/pipelines/tokens/create.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const urlLib = require('url');
 const pipelineIdSchema = schema.models.pipeline.base.extract('id');
 const tokenCreateSchema = schema.models.token.create;
@@ -52,6 +53,7 @@ module.exports = () => ({
                 throw boom.conflict(`Token ${match.name} already exists`);
             }
 
+            logger.info(`[Audit] user ${username}:${scmContext} creates the token name:${request.payload.name} for pipelineId:${pipelineId}.`);
             const token = await tokenFactory.create({
                 name: request.payload.name,
                 description: request.payload.description,

--- a/plugins/pipelines/tokens/refresh.js
+++ b/plugins/pipelines/tokens/refresh.js
@@ -53,7 +53,9 @@ module.exports = () => ({
                 throw boom.forbidden('Pipeline does not own token');
             }
 
-            logger.info(`[Audit] user ${username}:${scmContext} refreshes the token name:${token.name} for pipelineId:${pipelineId}.`);
+            logger.info(
+                `[Audit] user ${username}:${scmContext} refreshes the token name:${token.name} for pipelineId:${pipelineId}.`
+            );
             const refreshed = await token.refresh();
 
             return h.response(refreshed.toJson()).code(200);

--- a/plugins/pipelines/tokens/refresh.js
+++ b/plugins/pipelines/tokens/refresh.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const tokenIdSchema = schema.models.token.base.extract('id');
 const pipelineIdSchema = schema.models.pipeline.base.extract('id');
 const { getUserPermissions, getScmUri } = require('../../helper');
@@ -52,6 +53,7 @@ module.exports = () => ({
                 throw boom.forbidden('Pipeline does not own token');
             }
 
+            logger.info(`[Audit] user ${username}:${scmContext} refreshes the token name:${token.name} for pipelineId:${pipelineId}.`);
             const refreshed = await token.refresh();
 
             return h.response(refreshed.toJson()).code(200);

--- a/plugins/pipelines/tokens/remove.js
+++ b/plugins/pipelines/tokens/remove.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const tokenIdSchema = schema.models.token.base.extract('id');
 const pipelineIdSchema = schema.models.pipeline.base.extract('id');
 const { getUserPermissions, getScmUri } = require('../../helper');
@@ -52,6 +53,7 @@ module.exports = () => ({
                 throw boom.forbidden('Pipeline does not own token');
             }
 
+            logger.info(`[Audit] user ${username}:${scmContext} deletes the token name:${token.name} for pipelineId:${pipeline.id}.`);
             return token.remove().then(() => h.response().code(204));
         },
         validate: {

--- a/plugins/pipelines/tokens/remove.js
+++ b/plugins/pipelines/tokens/remove.js
@@ -53,7 +53,10 @@ module.exports = () => ({
                 throw boom.forbidden('Pipeline does not own token');
             }
 
-            logger.info(`[Audit] user ${username}:${scmContext} deletes the token name:${token.name} for pipelineId:${pipeline.id}.`);
+            logger.info(
+                `[Audit] user ${username}:${scmContext} deletes the token name:${token.name} for pipelineId:${pipeline.id}.`
+            );
+
             return token.remove().then(() => h.response().code(204));
         },
         validate: {

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -139,8 +139,10 @@ module.exports = () => ({
                 oldPipeline.settings = { ...oldPipeline.settings, ...settings };
             }
 
-            if(checkoutUrl || rootDir){
-                logger.info(`[Audit] user ${user.username}:${scmContext} updates the scmUri for pipelineID:${id} to ${oldPipeline.scmUri}.`);
+            if (checkoutUrl || rootDir) {
+                logger.info(
+                    `[Audit] user ${user.username}:${scmContext} updates the scmUri for pipelineID:${id} to ${oldPipeline.scmUri}.`
+                );
             }
 
             // update pipeline

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const idSchema = schema.models.pipeline.base.extract('id');
 const { formatCheckoutUrl, sanitizeRootDir } = require('./helper');
 const { getUserPermissions } = require('../helper');
@@ -136,6 +137,10 @@ module.exports = () => ({
 
             if (settings) {
                 oldPipeline.settings = { ...oldPipeline.settings, ...settings };
+            }
+
+            if(checkoutUrl || rootDir){
+                logger.info(`[Audit] user ${user.username}:${scmContext} updates the scmUri for pipelineID:${id} to ${oldPipeline.scmUri}.`);
             }
 
             // update pipeline

--- a/plugins/secrets/create.js
+++ b/plugins/secrets/create.js
@@ -57,7 +57,9 @@ module.exports = () => ({
                 throw boom.conflict(`Secret already exists with the ID: ${secret.id}`);
             }
 
-            logger.info(`[Audit] user ${user.username}:${scmContext} creates the secret key:${request.payload.name} for pipelineId:${request.payload.pipelineId}.`);
+            logger.info(
+                `[Audit] user ${user.username}:${scmContext} creates the secret key:${request.payload.name} for pipelineId:${request.payload.pipelineId}.`
+            );
             const newSecret = await secretFactory.create(request.payload);
 
             const location = urlLib.format({

--- a/plugins/secrets/create.js
+++ b/plugins/secrets/create.js
@@ -2,6 +2,7 @@
 
 const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const urlLib = require('url');
 const { getUserPermissions, getScmUri } = require('../helper');
 
@@ -56,6 +57,7 @@ module.exports = () => ({
                 throw boom.conflict(`Secret already exists with the ID: ${secret.id}`);
             }
 
+            logger.info(`[Audit] user ${user.username}:${scmContext} creates the secret key:${request.payload.name} for pipelineId:${request.payload.pipelineId}.`);
             const newSecret = await secretFactory.create(request.payload);
 
             const location = urlLib.format({

--- a/plugins/secrets/remove.js
+++ b/plugins/secrets/remove.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const idSchema = schema.models.secret.base.extract('id');
 
 module.exports = () => ({
@@ -32,7 +33,10 @@ module.exports = () => ({
 
                     // Make sure that user has permission before deleting
                     return canAccess(credentials, secret, 'admin', request.server.app)
-                        .then(() => secret.remove())
+                    .then(() => { 
+                        logger.info(`[Audit] user ${credentials.username}:${credentials.scmContext} deletes the secret key:${secret.name} from pipelineId:${secret.pipelineId}.`);
+                        secret.remove();
+                    })
                         .then(() => h.response().code(204));
                 })
                 .catch(err => {

--- a/plugins/secrets/remove.js
+++ b/plugins/secrets/remove.js
@@ -33,11 +33,11 @@ module.exports = () => ({
 
                     // Make sure that user has permission before deleting
                     return canAccess(credentials, secret, 'admin', request.server.app)
-                        .then(() => {
+                        .then(async () => {
                             logger.info(
                                 `[Audit] user ${credentials.username}:${credentials.scmContext} deletes the secret key:${secret.name} from pipelineId:${secret.pipelineId}.`
                             );
-                            secret.remove();
+                            await secret.remove();
                         })
                         .then(() => h.response().code(204));
                 })

--- a/plugins/secrets/remove.js
+++ b/plugins/secrets/remove.js
@@ -33,10 +33,12 @@ module.exports = () => ({
 
                     // Make sure that user has permission before deleting
                     return canAccess(credentials, secret, 'admin', request.server.app)
-                    .then(() => { 
-                        logger.info(`[Audit] user ${credentials.username}:${credentials.scmContext} deletes the secret key:${secret.name} from pipelineId:${secret.pipelineId}.`);
-                        secret.remove();
-                    })
+                        .then(() => {
+                            logger.info(
+                                `[Audit] user ${credentials.username}:${credentials.scmContext} deletes the secret key:${secret.name} from pipelineId:${secret.pipelineId}.`
+                            );
+                            secret.remove();
+                        })
                         .then(() => h.response().code(204));
                 })
                 .catch(err => {

--- a/plugins/secrets/update.js
+++ b/plugins/secrets/update.js
@@ -37,7 +37,10 @@ module.exports = () => ({
                                 secret[key] = request.payload[key];
                             });
 
-                            logger.info(`[Audit] user ${credentials.username}:${credentials.scmContext} updates the secret key:${secret.name} for pipelineId:${secret.pipelineId}.`);
+                            logger.info(
+                                `[Audit] user ${credentials.username}:${credentials.scmContext} updates the secret key:${secret.name} for pipelineId:${secret.pipelineId}.`
+                            );
+
                             return secret.update();
                         })
                         .then(() => {

--- a/plugins/secrets/update.js
+++ b/plugins/secrets/update.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
 const idSchema = schema.models.secret.base.extract('id');
 
 module.exports = () => ({
@@ -36,6 +37,7 @@ module.exports = () => ({
                                 secret[key] = request.payload[key];
                             });
 
+                            logger.info(`[Audit] user ${credentials.username}:${credentials.scmContext} updates the secret key:${secret.name} for pipelineId:${secret.pipelineId}.`);
                             return secret.update();
                         })
                         .then(() => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
There is no way to verify who performed the operations on the Options page.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Audit logs are outputted in such cases.

- Users Create/Delete pipeline
- Users Update checkout URL/Source Directory
- Users Create/Update/Delete Secrets
- Users Create/Refresh/Delete Pipeline token

Example output:
`{"level":"info","message":"[Audit] user foo:github:github.com creates the pipeline for github.com:12345:main.","timestamp":"2022-09-09T02:40:41.609Z"}`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[[Feature Request] Audit log of operations on the Options page #2700](https://github.com/screwdriver-cd/screwdriver/issues/2700)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
