### PR TITLE
feat: [3] add redis cluster connection

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -262,6 +262,8 @@ executor:
   queue:
     enabled: EXECUTOR_QUEUE_ENABLED
     options:
+      # redis or redisCluster(beta)
+      connectionType: QUEUE_REDIS_TYPE
       # Configuration of the redis instance containing resque
       redisConnection:
         host: QUEUE_REDIS_HOST
@@ -270,6 +272,14 @@ executor:
           password: QUEUE_REDIS_PASSWORD
           tls: QUEUE_REDIS_TLS_ENABLED
         database: QUEUE_REDIS_DATABASE
+      redisClusterConnection:
+        hosts:
+          __name: QUEUE_REDIS_CLUSTER_HOSTS
+          __format: json
+        options:
+          password: QUEUE_REDIS_PASSWORD
+          tls: QUEUE_REDIS_TLS_ENABLED
+        slotsRefreshTimeout: QUEUE_REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT
 
 
 queueWebhook:
@@ -427,6 +437,8 @@ redisLock:
     retryJitter: REDLOCK_RETRY_JITTER
     # the maximum time in milliseconds living of a key that has a timeout
     ttl: REDLOCK_TTL
+    # redis or redisCluster(beta)
+    connectionType: REDLOCK_REDIS_TYPE
     # Configuration of the redis instance
     redisConnection:
       host: REDLOCK_REDIS_HOST
@@ -435,6 +447,14 @@ redisLock:
         password: REDLOCK_REDIS_PASSWORD
         tls: REDLOCK_REDIS_TLS_ENABLED
       database: REDLOCK_REDIS_DATABASE
+    redisClusterConnection:
+      hosts:
+        __name: REDLOCK_REDIS_CLUSTER_HOSTS
+        __format: json
+      options:
+        password: REDLOCK_REDIS_PASSWORD
+        tls: REDLOCK_REDIS_TLS_ENABLED
+      slotsRefreshTimeout: REDLOCK_REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT
 
 # environment release information
 release:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -181,6 +181,8 @@ executor:
   queue:
     enabled: true
     options:
+      # redis or redisCluster(beta)
+      connectionType: redis
       # Configuration of the redis instance containing resque
       redisConnection:
         host: "127.0.0.1"
@@ -189,6 +191,12 @@ executor:
           password: "THIS-IS-A-PASSWORD"
           tls: false
         database: 0
+      redisClusterConnection:
+        hosts: []
+        options:
+          password: a-secure-password
+          tls: false
+        slotsRefreshTimeout: 1000
 
 queueWebhook:
   # Enabled events from webhook queue or not
@@ -358,6 +366,8 @@ redisLock:
     retryJitter: 200
     # the maximum time in milliseconds living of a key that has a timeout
     ttl: 20000
+    # redis or redisCluster(beta)
+    connectionType: redis
     # Configuration of the redis instance
     redisConnection:
       host: "127.0.0.1"
@@ -366,3 +376,9 @@ redisLock:
         password: "THIS-IS-A-PASSWORD"
         tls: false
       database: 0
+    redisClusterConnection:
+      hosts: []
+      options:
+        password: "THIS-IS-A-PASSWORD"
+        tls: false
+      slotsRefreshTimeout: 1000

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "hapi-auth-jwt2": "^10.2.0",
     "hapi-rate-limit": "^5.0.1",
     "hapi-swagger": "^14.5.5",
-    "ioredis": "^4.28.0",
+    "ioredis": "^5.2.3",
     "joi": "^17.4.2",
     "js-yaml": "^3.14.1",
     "jsonwebtoken": "^8.5.1",

--- a/plugins/lock.js
+++ b/plugins/lock.js
@@ -32,7 +32,7 @@ class Lock {
         const redisLockConfig = config.get('redisLock.options');
         const connectionType = redisLockConfig.connectionType;
 
-        if (!connectionType || (connectionType !== 'redis' || connectionType !== 'redisCluster')) {
+        if (!connectionType || (connectionType !== 'redis' && connectionType !== 'redisCluster')) {
             throw new Error(
                 `'connectionType ${connectionType}' is not supported, use 'redis' or 'redisCluster' for the queue.connectionType setting`
             );

--- a/plugins/lock.js
+++ b/plugins/lock.js
@@ -32,9 +32,9 @@ class Lock {
         const redisLockConfig = config.get('redisLock.options');
         const connectionType = redisLockConfig.connectionType;
 
-        if (!connectionType && (connectionType !== 'redis' || connectionType !== 'redisCluster')) {
+        if (!connectionType || (connectionType !== 'redis' || connectionType !== 'redisCluster')) {
             throw new Error(
-                `'${connectionType}' is not supported in connectionType, 'redis' or 'redisCluster' can be set for the queue.connectionType setting`
+                `'connectionType ${connectionType}' is not supported, use 'redis' or 'redisCluster' for the queue.connectionType setting`
             );
         }
 

--- a/test/plugins/lock.test.js
+++ b/test/plugins/lock.test.js
@@ -257,4 +257,29 @@ describe('lock plugin test', () => {
             assert.strictEqual(redis.options.clusterRetryStrategy(), 100);
         });
     });
+
+    describe('other redis type is specified', () => {
+        before(() => {
+            process.env.REDLOCK_ENABLED = true;
+            process.env.REDLOCK_REDIS_TYPE = 'unknown';
+        });
+
+        after(() => {
+            delete process.env.REDLOCK_ENABLED;
+            delete process.env.REDLOCK_REDIS_TYPE;
+        });
+
+        it('occurs an error', () => {
+            try {
+                /* eslint-disable global-require */
+                require('../../plugins/lock');
+                /* eslint-enable global-require */
+            } catch (err) {
+                assert.equal(
+                    err.message,
+                    "'connectionType unknown' is not supported, use 'redis' or 'redisCluster' for the queue.connectionType setting"
+                );
+            }
+        });
+    });
 });

--- a/test/plugins/lock.test.js
+++ b/test/plugins/lock.test.js
@@ -13,6 +13,16 @@ class RedisMock {
     }
 }
 
+class RedisClusterMock {
+    constructor(hosts, options) {
+        this.hosts = hosts;
+        this.options = options;
+    }
+}
+
+RedisMock.Cluster = RedisClusterMock;
+
+/* eslint max-classes-per-file: ["error", 3] */
 class RedLockMock {
     constructor(redisList, options) {
         this.redisList = redisList;
@@ -86,6 +96,19 @@ describe('lock plugin test', () => {
     describe('redis options test', () => {
         before(() => {
             process.env.REDLOCK_ENABLED = true;
+        });
+
+        after(() => {
+            delete process.env.REDLOCK_ENABLED;
+            delete process.env.REDLOCK_REDIS_HOST;
+            delete process.env.REDLOCK_REDIS_PORT;
+            delete process.env.REDLOCK_REDIS_PASSWORD;
+            delete process.env.REDLOCK_REDIS_TLS_ENABLED;
+            delete process.env.REDLOCK_DRIFT_FACTOR;
+            delete process.env.REDLOCK_RETRY_COUNT;
+            delete process.env.REDLOCK_RETRY_DELAY;
+            delete process.env.REDLOCK_RETRY_JITTER;
+            delete process.env.REDLOCK_TTL;
         });
 
         it('default values test', () => {
@@ -171,6 +194,67 @@ describe('lock plugin test', () => {
                 retryJitter: 300
             });
             assert.equal(plugin.ttl, 40000);
+        });
+    });
+
+    describe('redis cluster options test', () => {
+        before(() => {
+            process.env.REDLOCK_ENABLED = true;
+            process.env.REDLOCK_REDIS_TYPE = 'redisCluster';
+        });
+
+        after(() => {
+            delete process.env.REDLOCK_ENABLED;
+            delete process.env.REDLOCK_REDIS_TYPE;
+            delete process.env.REDLOCK_REDIS_PASSWORD;
+            delete process.env.REDLOCK_REDIS_TLS_ENABLED;
+            delete process.env.REDIS_CLUSTER_HOSTS;
+            delete process.env.REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT;
+        });
+
+        it('default values test', () => {
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            const { redis } = plugin;
+
+            console.log('default value for tls', process.env.REDLOCK_REDIS_TLS_ENABLED);
+
+            assert.deepEqual(redis.hosts, []);
+            assert.deepEqual(redis.options.redisOptions, {
+                password: 'THIS-IS-A-PASSWORD',
+                tls: false
+            });
+            assert.strictEqual(redis.options.slotsRefreshTimeout, 1000);
+            assert.strictEqual(redis.options.clusterRetryStrategy(), 100);
+        });
+
+        it('change options test', () => {
+            process.env.REDLOCK_REDIS_CLUSTER_HOSTS = '["127.0.0.1:6379", "127.0.0.2:6379", "127.0.0.3:6379"]';
+            process.env.REDLOCK_REDIS_CLUSTER_SLOTS_REFRESH_TIMEOUT = 100;
+            process.env.REDLOCK_REDIS_PASSWORD = 'password';
+            process.env.REDLOCK_REDIS_TLS_ENABLED = true;
+
+            process.env.REDLOCK_DRIFT_FACTOR = 0.02;
+            process.env.REDLOCK_RETRY_COUNT = 100;
+            process.env.REDLOCK_RETRY_DELAY = 200;
+            process.env.REDLOCK_RETRY_JITTER = 300;
+            process.env.REDLOCK_TTL = 40000;
+
+            /* eslint-disable global-require */
+            const plugin = require('../../plugins/lock');
+            /* eslint-enable global-require */
+
+            const { redis } = plugin;
+
+            assert.deepEqual(redis.hosts, ['127.0.0.1:6379', '127.0.0.2:6379', '127.0.0.3:6379']);
+            assert.deepEqual(redis.options.redisOptions, {
+                password: 'password',
+                tls: true
+            });
+            assert.strictEqual(redis.options.slotsRefreshTimeout, 100);
+            assert.strictEqual(redis.options.clusterRetryStrategy(), 100);
         });
     });
 });


### PR DESCRIPTION
## Context

To support Redis Cluster integration

node-resque says it supports Redis Cluster since 7.1.0
https://github.com/actionhero/node-resque/releases/tag/v7.1.0

## Objective
This PR updates node-resque to support Redis Cluster instead of single Redis.
For more information on this change, see also the PR description below.
https://github.com/screwdriver-cd/queue-service/pull/57

## References

https://github.com/screwdriver-cd/screwdriver/issues/2667

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
