### PR TITLE
fix: id schema for pipeline get latestBuild

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -4,7 +4,7 @@ const boom = require('@hapi/boom');
 const hoek = require('@hapi/hoek');
 const schema = require('screwdriver-data-schema');
 const joi = require('joi');
-const idSchema = schema.models.job.base.extract('id');
+const idSchema = schema.models.build.base.extract('id');
 const { getScmUri, getUserPermissions } = require('../helper');
 
 /**

--- a/plugins/pipelines/latestBuild.js
+++ b/plugins/pipelines/latestBuild.js
@@ -3,7 +3,7 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const idSchema = schema.models.job.base.extract('id');
+const idSchema = schema.models.pipeline.base.extract('id');
 const nameSchema = schema.models.job.base.extract('name');
 const statusSchema = schema.models.build.base.extract('status');
 


### PR DESCRIPTION
## Context

Description for `id` says "Identifier of this Job", should say "Identifier of this Pipeline".
<img width="1430" alt="Screen Shot 2022-10-03 at 4 40 42 PM" src="https://user-images.githubusercontent.com/3230529/193704799-ebbca60c-b109-4d67-acbd-28551460caee.png">

## Objective

This PR uses the correct schema for the pipelineId.

## References

NA
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
