### PR TITLE
[3] feat(2763): enable to switch different bookends for each build cluster. BREAKING CHANGE: change config file structure

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -116,8 +116,7 @@ const bookend = new Bookend(
         'screwdriver-coverage-bookend': coverage,
         'screwdriver-cache-bookend': cache
     },
-    bookends.setup || [], // plugins required for the setup- steps
-    bookends.teardown || [] // plugins required for the teardown-steps
+    bookends
 );
 
 // Setup Pipeline Factory for Executor

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -360,7 +360,7 @@ webhooks:
   maxBytes: WEBHOOK_MAX_BYTES
 
 bookends:
-  # Object keyed by cluster name with setup/teardown bookend in each.
+  # Object keyed by cluster name with value setup/teardown bookend.
   # Value of setup/teardown is list of module names, or objects { name, config } for instantiation to use in sd-setup/sd-teardown.
   # Example:
   # {

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -360,14 +360,21 @@ webhooks:
   maxBytes: WEBHOOK_MAX_BYTES
 
 bookends:
-  # List of module names, or objects { name, config } for instantiation to use in sd-setup
-  setup:
-    __name: BOOKENDS_SETUP
-    __format: json
-  # List of module names, or objects { name, config } for instantiation to use in sd-teardown
-  teardown:
-    __name: BOOKENDS_TEARDOWN
-    __format: json
+  # Object keyed by cluster name with setup/teardown bookend in each.
+  # Value of setup/teardown is list of module names, or objects { name, config } for instantiation to use in sd-setup/sd-teardown.
+  # Example:
+  # {
+  #   "default": {
+  #       "setup": ["scm", "screwdriver-cache-bookend", "foo"],
+  #       "teardown": ["screwdriver-artifact-bookend", "screwdriver-cache-bookend"]
+  #   },
+  #   "clusterA": {
+  #       "setup": ["scm", "screwdriver-cache-bookend", "foo", "bar"],
+  #       "teardown": ["screwdriver-cache-bookend", {"name": "baz", "config": {}, "alias": "qux"}]
+  #   }
+  # }
+  __name: BOOKENDS
+  __format: json
 
 notifications:
   __name: NOTIFICATIONS

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -286,12 +286,13 @@ unzipArtifacts:
 
 bookends:
   # Plugins for build setup
-  setup:
-    - scm
-    - screwdriver-cache-bookend
-  teardown:
-    - screwdriver-artifact-bookend
-    - screwdriver-cache-bookend
+  default:
+    setup:
+      - scm
+      - screwdriver-cache-bookend
+    teardown:
+      - screwdriver-artifact-bookend
+      - screwdriver-cache-bookend
 
 notifications:
   options:

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "prom-client": "^12.0.0",
     "redlock": "^4.1.0",
     "screwdriver-artifact-bookend": "^1.2.0",
-    "screwdriver-build-bookend": "^2.4.0",
+    "screwdriver-build-bookend": "^3.0.0",
     "screwdriver-cache-bookend": "^2.0.2",
     "screwdriver-command-validator": "^2.1.0",
     "screwdriver-config-parser": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-api",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "API server for the Screwdriver.cd service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Different bookends can be executed on different build cluster.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR changes the config file structure to allows bookends to be switched for each build cluster.

And support the following PR change.

https://github.com/screwdriver-cd/build-bookend/pull/18

**NOTICE**
This PR has breaking changes. The message `BREAKING CHANGE: xxx` must be in the footer of the commit.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issues
  - https://github.com/screwdriver-cd/screwdriver/issues/2763

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
