### PR TITLE
feat: List pipelines by ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "screwdriver-executor-k8s-vm": "^4.3.2",
     "screwdriver-executor-queue": "^3.1.2",
     "screwdriver-executor-router": "^2.3.0",
-    "screwdriver-logger": "^1.1.0",
+    "screwdriver-logger": "^1.2.0",
     "screwdriver-models": "^28.20.0",
     "screwdriver-notifications-email": "^2.3.1",
     "screwdriver-notifications-slack": "^3.3.0",

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -33,6 +33,10 @@ server.register({
 
 `GET /pipelines?page={pageNumber}&count={countNumber}&configPipelineId={configPipelineId}&search={search}`
 
+Need to have array format for `ids` to only return pipelines with matching ids
+`GET /pipelines?search={search}&ids[]=12345&ids[]=55555`
+
+
 #### Get single pipeline
 
 `GET /pipelines/{id}`

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -393,6 +393,41 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 and all pipelines with matching ids', () => {
+            options.url = '/pipelines?ids[]=1&ids[]=2&ids[]=3&';
+            pipelineFactoryMock.list
+                .withArgs({
+                    params: {
+                        scmContext: 'github:github.com',
+                        id: [1, 2, 3]
+                    },
+                    paginate: {
+                        page: 1,
+                        count: 50
+                    },
+                    sort: 'descending'
+                })
+                .resolves(getPipelineMocks(testPipelines));
+            pipelineFactoryMock.list
+                .withArgs({
+                    params: {
+                        scmContext: 'gitlab:mygitlab',
+                        id: [1, 2, 3]
+                    },
+                    paginate: {
+                        page: 1,
+                        count: 50
+                    },
+                    sort: 'descending'
+                })
+                .resolves(getPipelineMocks(gitlabTestPipelines));
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testPipelines.concat(gitlabTestPipelines));
+            });
+        });
+
         it('returns 200 and filter private pipelines', () => {
             pipelineFactoryMock.scm.getScmContexts.returns(['github:github.com']);
             pipelineFactoryMock.list


### PR DESCRIPTION
## Context

Sometimes we might want to list specific pipelines by id.

## Objective

This PR adds `ids[]` query param to GET /pipelines so users can list specific pipelines.
 
## References

N/A

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
