### PR TITLE
fix: Handle no scope case for audit logs

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -164,24 +164,27 @@ module.exports = async config => {
         if (config.log && config.log.audit.enabled) {
             server.ext('onCredentials', (request, h) => {
                 const { username, scope, pipelineId } = request.auth.credentials;
-                const validScope = config.log.audit.scope.filter(s => scope.includes(s));
 
-                if (Array.isArray(validScope) && validScope.length > 0) {
-                    let context;
+                if (scope) {
+                    const validScope = config.log.audit.scope.filter(s => scope.includes(s));
 
-                    if (validScope.includes('admin')) {
-                        context = `Admin ${username}`;
-                    } else if (validScope.includes('user')) {
-                        context = `User ${username}`;
-                    } else if (validScope.includes('build') || validScope.includes('temporal')) {
-                        context = `Build ${username}`;
-                    } else if (validScope.includes('pipeline')) {
-                        context = `Pipeline ${pipelineId}`;
-                    } else {
-                        context = `Guest ${username}`;
+                    if (Array.isArray(validScope) && validScope.length > 0) {
+                        let context;
+
+                        if (validScope.includes('admin')) {
+                            context = `Admin ${username}`;
+                        } else if (validScope.includes('user')) {
+                            context = `User ${username}`;
+                        } else if (validScope.includes('build') || validScope.includes('temporal')) {
+                            context = `Build ${username}`;
+                        } else if (validScope.includes('pipeline')) {
+                            context = `Pipeline ${pipelineId}`;
+                        } else {
+                            context = `Guest ${username}`;
+                        }
+
+                        logger.info(`[Login] ${context} ${request.method} ${request.path}`);
                     }
-
-                    logger.info(`[Login] ${context} ${request.method} ${request.path}`);
                 }
 
                 return h.continue;


### PR DESCRIPTION
## Context

When a user has not logged in yet, there is no scope.
Will get this error `{"statusCode":500,"error":"Internal Server Error","message":"Cannot read property 'includes' of undefined"}`.

## Objective

This PR handles no scope case for audit logs.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2784

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
