### PR TITLE
fix: Remove search from pagination schema [skip ci]

### DIFF
--- a/plugins/commands/listTags.js
+++ b/plugins/commands/listTags.js
@@ -53,7 +53,11 @@ module.exports = () => ({
                 namespace: namespaceSchema,
                 name: nameSchema
             }),
-            query: schema.api.pagination
+            query: schema.api.pagination.concat(
+                joi.object({
+                    search: joi.forbidden() // we don't support search for Command list tag
+                })
+            )
         }
     }
 });

--- a/plugins/commands/listVersions.js
+++ b/plugins/commands/listVersions.js
@@ -60,7 +60,11 @@ module.exports = () => ({
                 namespace: namespaceSchema,
                 name: nameSchema
             }),
-            query: schema.api.pagination
+            query: schema.api.pagination.concat(
+                joi.object({
+                    search: joi.forbidden() // we don't support search for Command list versions
+                })
+            )
         }
     }
 });

--- a/plugins/events/listBuilds.js
+++ b/plugins/events/listBuilds.js
@@ -62,7 +62,8 @@ module.exports = () => ({
                         .boolean()
                         .truthy('true')
                         .falsy('false')
-                        .default(true)
+                        .default(true),
+                    search: joi.forbidden() // we don't support search for Event list builds
                 })
             )
         }

--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -86,7 +86,7 @@ module.exports = () => ({
                         .falsy('false')
                         .default(true),
                     status: statusSchema,
-                    search: joi.forbidden() // we don't support search for list builds
+                    search: joi.forbidden() // we don't support search for Job list builds
                 })
             )
         }

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -64,7 +64,8 @@ module.exports = () => ({
             query: schema.api.pagination.concat(
                 joi.object({
                     type: joi.string(),
-                    prNum: prNumSchema
+                    prNum: prNumSchema,
+                    search: joi.forbidden() // we don't support search for Pipeline list events
                 })
             )
         }

--- a/plugins/pipelines/listJobs.js
+++ b/plugins/pipelines/listJobs.js
@@ -67,7 +67,8 @@ module.exports = () => ({
                         .truthy('true')
                         .falsy('false')
                         .default(false),
-                    jobName: jobNameSchema
+                    jobName: jobNameSchema,
+                    search: joi.forbidden() // we don't support search for Pipeline list jobs
                 })
             )
         }

--- a/plugins/pipelines/listStages.js
+++ b/plugins/pipelines/listStages.js
@@ -87,7 +87,8 @@ module.exports = () => ({
             query: schema.api.pagination.concat(
                 joi.object({
                     eventId: pipelineIdSchema,
-                    groupEventId: pipelineIdSchema
+                    groupEventId: pipelineIdSchema,
+                    search: joi.forbidden() // we don't support search for Pipeline list stages
                 })
             )
         }

--- a/plugins/pipelines/metrics.js
+++ b/plugins/pipelines/metrics.js
@@ -102,7 +102,8 @@ module.exports = () => ({
                     endTime: joi.string().isoDate(),
                     aggregateInterval: joi.string().valid('none', 'day', 'week', 'month', 'year'),
                     'downtimeJobs[]': jobIdsSchema.optional(),
-                    'downtimeStatuses[]': statusesSchema.optional()
+                    'downtimeStatuses[]': statusesSchema.optional(),
+                    search: joi.forbidden() // we don't support search for Pipeline metrics
                 })
             )
         }

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -50,7 +50,11 @@ module.exports = () => ({
             params: joi.object({
                 name: nameSchema
             }),
-            query: schema.api.pagination
+            query: schema.api.pagination.concat(
+                joi.object({
+                    search: joi.forbidden() // we don't support search for Template list tags
+                })
+            )
         }
     }
 });

--- a/plugins/templates/listVersions.js
+++ b/plugins/templates/listVersions.js
@@ -57,7 +57,11 @@ module.exports = () => ({
             params: joi.object({
                 name: nameSchema
             }),
-            query: schema.api.pagination
+            query: schema.api.pagination.concat(
+                joi.object({
+                    search: joi.forbidden() // we don't support search for Template list versions
+                })
+            )
         }
     }
 });

--- a/plugins/templates/listVersionsWithMetric.js
+++ b/plugins/templates/listVersionsWithMetric.js
@@ -54,7 +54,11 @@ module.exports = () => ({
             params: joi.object({
                 name: nameSchema
             }),
-            query: schema.api.pagination
+            query: schema.api.pagination.concat(
+                joi.object({
+                    search: joi.forbidden() // we don't support search for Template list versions with metrics
+                })
+            )
         }
     }
 });


### PR DESCRIPTION
## Context

Can be confusing for users to see `search` field in Swagger docs when it is not actually supported.
<img width="1438" alt="Screen Shot 2022-11-16 at 1 47 15 PM" src="https://user-images.githubusercontent.com/3230529/202301670-8121ce7b-3bd2-42b2-8c64-1d75366b20d2.png">


## Objective

This PR removes `search` keyword from pagination schema when not in use.

## References

NA

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
