### PR TITLE
fix: Simplify badges endpoint

### DIFF
--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1284,7 +1284,7 @@ describe('pipeline plugin test', () => {
             eventsPrMock = getEventsMocks(testEventsPr);
             eventsMock[0].getBuilds.resolves(getBuildMocks(testBuilds));
             eventsPrMock[0].getBuilds.resolves(getBuildMocks(testBuilds));
-            pipelineMock.getEvents.resolves(eventsMock);
+            eventFactoryMock.list.resolves(eventsMock);
         });
 
         it('returns 200 to for a valid build', () =>
@@ -1294,7 +1294,7 @@ describe('pipeline plugin test', () => {
             }));
 
         it('returns 200 to for a valid PR build', () => {
-            pipelineMock.getEvents.resolves(eventsPrMock);
+            eventFactoryMock.list.resolves(eventsPrMock);
 
             return server.inject(`/pipelines/${id}/badge`).then(reply => {
                 assert.equal(reply.statusCode, 200);
@@ -1312,7 +1312,7 @@ describe('pipeline plugin test', () => {
         });
 
         it('returns 200 to unknown for an event that does not exist', () => {
-            pipelineMock.getEvents.resolves([]);
+            eventFactoryMock.list.resolves([]);
 
             return server.inject(`/pipelines/${id}/badge`).then(reply => {
                 assert.equal(reply.statusCode, 200);


### PR DESCRIPTION
## Context

We are noticing the badges endpoint call often takes a long time.

## Objective

This PR attempts to simplify the endpoint to reduce the amount of time the endpoint takes.

Note: Previously, the badges endpoint fetched all pipeline events, then got builds for the latest event and checked if they exist. If not, it would iterate on the next event.
This enhancement only fetches the most recent event and creates a badge based off that event's builds. This should help reduce number of calls to API and size of responses.

## References
NA

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
