### PR TITLE
feat: Add functional tests sd-cmd require-or build-cache

### DIFF
--- a/features/build-cache.feature
+++ b/features/build-cache.feature
@@ -1,0 +1,18 @@
+@parallel
+@build-cache
+
+Feature: build-cache
+
+    Cache files and directories from a specific build.
+    This feature allows you to keep build artifacts and dependent libraries of a build as a cache.
+
+    Scenario: Success cache is correctly created and cache exists
+        Given an existing pipeline for build-cache
+        When the pipeline starts "create-cache" job
+        And the "create-cache" build succeeded
+        And the "check-event-and-pipeline" job is triggered
+        Then the "check-event-and-pipeline" build succeeded
+        When the pipeline starts "check-job" job
+        And the "check-job" build succeeded
+        Then start "check-job" job again and cache exists for job-level
+

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -38,3 +38,33 @@ Feature: Commands
     Scenario: Get list of explicit command versions
         When execute "list"
         Then get list of explicit versions matching that range with comma separated tags next to applicable tags
+
+    Scenario Outline: Validate a template
+        Then a pipeline "<status>" to validate the command in "<job>"
+
+        Examples:
+            | status   | job              |
+            | succeeds | validate-valid   |
+            | fails    | validate-invalid |
+
+    Scenario Outline: Hold trust status after publish a command
+        Given a "<command>" command
+        And the command exists
+        And the command is "<trust>"
+        When a pipeline with the "right" permission "succeeds" to publish the command in "<job>"
+        Then the command "is" stored
+        And the command is "<trust>"
+
+        Examples:
+            | command                  | trust      | job                |
+            | test-trusted-command     | trusted    | publish-trusted    |
+            | test-distrusted-command  | distrusted | publish-distrusted |
+
+    Scenario Outline: Publish a command by another pipeline
+        Given a "test-trusted-command" command
+        And the command exists
+        Then a pipeline with the "wrong" permission "fails" to publish the command in "<job>"
+
+        Examples:
+            | job             |
+            | publish-trusted |

--- a/features/step_definitions/build-cache.js
+++ b/features/step_definitions/build-cache.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const Assert = require('chai').assert;
+const { Before, Given, Then } = require('cucumber');
+const request = require('screwdriver-request');
+const sdapi = require('../support/sdapi');
+
+const TIMEOUT = 240 * 1000;
+
+Before(
+    {
+        tags: '@build-cache'
+    },
+    function hook() {
+        this.repoOrg = this.testOrg;
+        this.repoName = 'functional-build-cache';
+
+        return this.getJwt(this.apiToken).then(response => {
+            this.jwt = response.body.token;
+        });
+    }
+);
+Given(
+    /^an existing pipeline for build-cache$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step() {
+        return this.ensurePipelineExists({ repoName: this.repoName });
+    }
+);
+Then(
+    /^start "(.*)" job again and cache exists for job-level$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(job) {
+        return request({
+            url: `${this.instance}/${this.namespace}/events`,
+            method: 'POST',
+            json: {
+                pipelineId: this.pipelineId,
+                startFrom: job
+            },
+            context: {
+                token: this.jwt
+            }
+        })
+            .then(eventData => {
+                this.eventId = eventData.body.id;
+
+                return request({
+                    url: `${this.instance}/${this.namespace}/events/${this.eventId}/builds`,
+                    method: 'GET',
+                    context: {
+                        token: this.jwt
+                    }
+                });
+            })
+            .then(buildData => {
+                const buildId = buildData.body[0].id;
+
+                return this.waitForBuild(buildId);
+            })
+            .then(buildData => {
+                const stepName = 'check-cache';
+                const buildId = buildData.body.id;
+
+                return sdapi.findBuildStepLogs({
+                    instance: this.instance,
+                    stepName,
+                    buildId,
+                    jwt: this.jwt
+                });
+            })
+            .then(stepLogs => {
+                const regexMessage = /job-level-cache|job-level-cache-directory/;
+                const result = stepLogs.body.filter(message => message.m.match(regexMessage));
+
+                Assert.equal(result.length, 2);
+            });
+    }
+);

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -293,7 +293,7 @@ function cleanupBuilds(config) {
 }
 
 /**
- * Retrun specific build log
+ * Retrieve specific build logs
  *
  * @method findBuildStepLogs
  * @param  {Object}  config                     Configuration object

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -292,10 +292,36 @@ function cleanupBuilds(config) {
     });
 }
 
+/**
+ * Retrun specific build log
+ *
+ * @method findBuildStepLogs
+ * @param  {Object}  config                     Configuration object
+ * @param  {String}  config.instance            Screwdriver instance to test against
+ * @param  {String}  config.buildId             Build ID to find the build step logs
+ * @param  {String}  config.stepName            The stepName we're looking for
+ * @param  {String}  config.jwt                 JWT for authenticating
+ * @return {Promise}                            A promise that resolves to an array of build step logs that
+ *                                              fulfill the given criteria. If nothing is found, an
+ *                                              empty array is returned
+ */
+function findBuildStepLogs(config) {
+    const { instance, stepName, buildId, jwt } = config;
+
+    return request({
+        method: 'GET',
+        url: `${instance}/v4/builds/${buildId}/steps/${stepName}/logs`,
+        context: {
+            token: jwt
+        }
+    });
+}
+
 module.exports = {
     cleanupToken,
     cleanupBuilds,
     findBuilds,
+    findBuildStepLogs,
     findJobs,
     findEventBuilds,
     searchForBuild,

--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -139,3 +139,17 @@ Feature: Remote Trigger
             | job1      | ~commit   |
       When a new file is added to the "directory1" directory of the "master" branch
       Then a new build from "job1" should be created to test that change
+
+    @require-or
+    Scenario: require-or
+        Given an existing pipeline on branch "master" with the workflow jobs:
+            | job       | requires     |
+            | job1      |  ~commit     |
+            | job2      |  ~commit     |
+            | OR        | ~job1, ~job2 |
+        When start "job1" job
+        And the "job1" build succeeded
+        Then the "OR" job is triggered
+        When start "job2" job
+        And the "job2" build succeeded
+        Then the "OR" job is triggered


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR adds minimal functional testing to maintain the quality of the following features. 
1. require-or
2. sd-cmd
3. build-cache

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
In this PR, add the feature file and code for each feature.

### require-or
This test checks if the OR trigger is working.

Here are the repositories that actually work.
https://github.com/screwdriver-cd-test/functional-require-or

### build-cache
Testing cache functionality at the job, event, and pipeline levels.
Build log messages are used to determine the job level cache. 
Job-level scenarios are tested using build log messages. 

Here are the repositories that actually work.
https://github.com/screwdriver-cd-test/functional-build-cache

### sd-cmd
Add new Trusted command and validation functional tests.
The Trusted Command test is based on the [Trusted Template](https://github.com/screwdriver-cd/screwdriver/blob/99e19eec4d8eab0e77cafd7998eab4b7c761a084/features/templates.feature#L82-L93).
Trusted Command must be prepared before executing the functional test.

Here are the repositories that actually work.
https://github.com/screwdriver-cd-test/functional-build-cache
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
