### PR TITLE
fix: Skip build-cache.feature tests

### DIFF
--- a/features/build-cache.feature
+++ b/features/build-cache.feature
@@ -1,3 +1,4 @@
+@ignore
 @parallel
 @build-cache
 


### PR DESCRIPTION
## Context

Looks like build-cache feature test step definitions are missing and are failing the pipeline.
```
17:51:17 Warnings:
17:51:17 
17:51:17 1) Scenario: Success cache is correctly created and cache exists # features/build-cache.feature:9
17:51:17    ✔ Before # features/step_definitions/build-cache.js:10
17:51:17    ✔ Given an existing pipeline for build-cache # features/step_definitions/build-cache.js:23
17:51:17    ? When the pipeline starts "create-cache" job
17:51:17        Undefined. Implement with the following snippet:
17:51:17 
17:51:17          When('the pipeline starts {string} job', function (string) {
17:51:17            // Write code here that turns the phrase above into concrete actions
17:51:17            return 'pending';
17:51:17          });
17:51:17 
17:51:17    - And the "create-cache" build succeeded # features/step_definitions/workflow.js:411
17:51:17    - And the "check-event-and-pipeline" job is triggered # features/step_definitions/workflow.js:151
17:51:17    - Then the "check-event-and-pipeline" build succeeded # features/step_definitions/workflow.js:411
17:51:17    ? When the pipeline starts "check-job" job
17:51:17        Undefined. Implement with the following snippet:
17:51:17 
17:51:17          When('the pipeline starts {string} job', function (string) {
17:51:17            // Write code here that turns the phrase above into concrete actions
17:51:17            return 'pending';
17:51:17          });
```
https://cd.screwdriver.cd/pipelines/1/builds/836676/steps/test

## Objective

This PR skips the build-cache feature test for now.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/2795

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
