### PR TITLE
fix: functionalt-test build-cache, sd-cmd, trigger

### DIFF
--- a/features/build-cache.feature
+++ b/features/build-cache.feature
@@ -8,7 +8,7 @@ Feature: build-cache
 
     Scenario: Success cache is correctly created and cache exists
         Given an existing pipeline for build-cache
-        When start "creaet-cache" job
+        When start "create-cache" job
         And the "create-cache" build succeeded
         And the "check-event-and-pipeline" job is triggered
         Then the "check-event-and-pipeline" build succeeded

--- a/features/build-cache.feature
+++ b/features/build-cache.feature
@@ -1,4 +1,3 @@
-@ignore
 @parallel
 @build-cache
 
@@ -9,11 +8,11 @@ Feature: build-cache
 
     Scenario: Success cache is correctly created and cache exists
         Given an existing pipeline for build-cache
-        When the pipeline starts "create-cache" job
+        When start "creaet-cache" job
         And the "create-cache" build succeeded
         And the "check-event-and-pipeline" job is triggered
         Then the "check-event-and-pipeline" build succeeded
-        When the pipeline starts "check-job" job
+        When start "check-job" job
         And the "check-job" build succeeded
         Then start "check-job" job again and cache exists for job-level
 

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -40,7 +40,7 @@ Feature: Commands
         Then get list of explicit versions matching that range with comma separated tags next to applicable tags
 
     @ignore
-    Scenario Outline: Validate a template
+    Scenario Outline: Validate a command
         Then a pipeline "<status>" to validate the command in "<job>"
 
         Examples:

--- a/features/sd-cmd.feature
+++ b/features/sd-cmd.feature
@@ -39,7 +39,6 @@ Feature: Commands
         When execute "list"
         Then get list of explicit versions matching that range with comma separated tags next to applicable tags
 
-    @ignore
     Scenario Outline: Validate a command
         Then a pipeline "<status>" to validate the command in "<job>"
 
@@ -48,7 +47,6 @@ Feature: Commands
             | succeeds | validate-valid   |
             | fails    | validate-invalid |
 
-    @ignore
     Scenario Outline: Hold trust status after publish a command
         Given a "<command>" command
         And the command exists
@@ -62,7 +60,6 @@ Feature: Commands
             | test-trusted-command     | trusted    | publish-trusted    |
             | test-distrusted-command  | distrusted | publish-distrusted |
 
-    @ignore
     Scenario Outline: Publish a command by another pipeline
         Given a "test-trusted-command" command
         And the command exists

--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -140,7 +140,6 @@ Feature: Remote Trigger
       When a new file is added to the "directory1" directory of the "master" branch
       Then a new build from "job1" should be created to test that change
 
-    @ignore
     @require-or
     Scenario: require-or
         Given an existing pipeline on branch "master" with the workflow jobs:


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The following PR will allow you to run skipped functional tests.
https://github.com/screwdriver-cd/screwdriver/pull/2799
https://github.com/screwdriver-cd/screwdriver/pull/2800

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The cause was, in part, the omission of code necessary to execute the scenario.
I removed the @ignore pin while adding the necessary code

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- https://github.com/screwdriver-cd/screwdriver/pull/2795
- https://github.com/screwdriver-cd/screwdriver/pull/2799
- https://github.com/screwdriver-cd/screwdriver/pull/2800

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
