### PR TITLE
fix: Try different username for functional tests

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -62,7 +62,7 @@ jobs:
             SD_API_HOST: beta.api.screwdriver.cd
             K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
             K8S_ENV_VALUE: beta_rc2_
-            TEST_USERNAME: sd-buildbot
+            TEST_USERNAME: sd-buildbot-functional
             TEST_ORG: screwdriver-cd-test
         secrets:
             # Access key for functional tests


### PR DESCRIPTION
## Context

Beta functional tests are running into GitHub API rate limiting issues.
```
20:13:51    ✖ After # features/step_definitions/workflow.js:468
20:13:51        Error: 403 Reason "API rate limit exceeded for user ID 20604138."
20:13:51            at throwError (/sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:14:17)
20:13:51            at /sd/workspace/src/github.com/screwdriver-cd/screwdriver/node_modules/screwdriver-request/index.js:56:28
20:13:51            at runMicrotasks (<anonymous>)
20:13:51            at processTicksAndRejections (internal/process/task_queues.js:97:5)
20:13:51    ✔ After # features/step_definitions/workflow.js:452
```
https://cd.screwdriver.cd/pipelines/1/builds/838655/steps/test

## Objective

This PR swaps functional test user to sd-buildbot-functional to see if that passes beta functional tests.
Already added sd-buildbot-functional to the beta whitelist and logged in to beta SD via UI.

## References
NA

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
