### PR TITLE
fix: use new token for user sd-buildbot-functional for beta testing

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -54,6 +54,9 @@ jobs:
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
             - test: npm install && npm run functional-beta
+            - test: |
+                npm install
+                GIT_TOKEN=${GIT_TOKEN_BETA} npm run functional
         environment:
             K8S_CONTAINER: screwdriver-api
             K8S_IMAGE: screwdrivercd/screwdriver
@@ -68,7 +71,7 @@ jobs:
             # Access key for functional tests
             - SD_API_TOKEN
             # Git access token
-            - GIT_TOKEN
+            - GIT_TOKEN_BETA
             # Talking to Kubernetes
             - K8S_TOKEN
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -53,7 +53,6 @@ jobs:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
-            - test: npm install && npm run functional-beta
             - test: |
                 npm install
                 GIT_TOKEN=${GIT_TOKEN_BETA} npm run functional


### PR DESCRIPTION
## Context

Fn tests are failing due to Github rate limiting

## Objective

Added new secret GIT_TOKEN_BETA for usage in beta fn tests

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
