### PR TITLE
fix: use hoek.clone for mutable config

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -27,7 +27,7 @@ function convertToBool(value) {
 }
 
 // Setup Authentication
-const authConfig = config.get('auth');
+const authConfig = hoek.clone(config.get('auth'));
 
 // Setup HTTPd
 const httpdConfig = config.get('httpd');
@@ -38,7 +38,7 @@ const shutdownConfig = config.get('shutdown');
 const webhooksConfig = config.get('webhooks');
 
 // Special urls for things like the UI
-const ecosystem = config.get('ecosystem');
+const ecosystem = hoek.clone(config.get('ecosystem'));
 
 ecosystem.api = httpdConfig.uri;
 
@@ -134,7 +134,7 @@ const pipelineFactory = Models.PipelineFactory.getInstance({
 });
 
 // Setup Executor
-const executorConfig = config.get('executor');
+const executorConfig = hoek.clone(config.get('executor'));
 
 executorConfig[executorConfig.plugin].options.pipelineFactory = pipelineFactory;
 const ExecutorPlugin = require(`screwdriver-executor-${executorConfig.plugin}`);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
new `config` version prohibits modification of config objects
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
use deepClone copy for config object that needs to be modified
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
