### PR TITLE
feat(2853): Configure and perform auth checks (admins, whitelist) based on both SCM user ID and name

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -34,6 +34,10 @@ auth:
   admins:
     __name: SECRET_ADMINS
     __format: json
+  sdAdmins:
+    __name: SECRET_ADMINS
+    __format: json
+  adminCheckById: ADMIN_CHECK_BY_ID
   # Default session timeout (in minutes)
   sessionTimeout: SESSION_TIMEOUT
   # Oauth redirect uri, configure this if your app is not running at root under the host

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -31,13 +31,16 @@ auth:
   whitelist:
     __name: SECRET_WHITELIST
     __format: json
+  allowList:
+    __name: SECRET_ALLOW_LIST
+    __format: json
   admins:
     __name: SECRET_ADMINS
     __format: json
   sdAdmins:
-    __name: SECRET_ADMINS
+    __name: SECRET_SD_ADMINS
     __format: json
-  adminCheckById: ADMIN_CHECK_BY_ID
+  authCheckById: AUTH_CHECK_BY_ID
   # Default session timeout (in minutes)
   sessionTimeout: SESSION_TIMEOUT
   # Oauth redirect uri, configure this if your app is not running at root under the host

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -32,9 +32,17 @@ auth:
   https: false
   # A flag to set if you want guests to browse your pipelines
   allowGuestAccess: false
-  # Whitelist of users able to authenticate against the system
+  # Deprecated. Instead, use allowList which is more secure.
+  # List of users able to authenticate against the system
   # if empty, it allows everyone
+  # Values should follow '{scmDisplayName:scmUsername}' format
+  # Ex: ['github:john', 'bitbucket:john']
   whitelist: []
+  # list of users able to authenticate against the system
+  # if empty, it allows everyone
+  # Values should follow '{scmDisplayName:scmUsername:scmUserId}' format
+  # Ex: ['github:john:12345', 'bitbucket:john:{98fsa1ba-0b91-4e3c-95ee-55899e933b0}']
+  allowList: []
   # Deprecated. Instead, use sdAdmins which is more secure.
   # List of users who should be given screwdriver admin privileges
   # Values should follow '{scmDisplayName:scmUsername}' format
@@ -44,9 +52,13 @@ auth:
   # Values should follow '{scmDisplayName:scmUsername:scmUserId}' format
   # Ex: ['github:john:12345', 'bitbucket:john:{98fsa1ba-0b91-4e3c-95ee-55899e933b0}']
   sdAdmins: []
-  # When set to true, performs admin check using the users listed in 'sdAdmins'.
-  # When set to false, performs admin check using the users listed in 'admins'
-  adminCheckById: true
+  # When set to true
+  #  - grant admin privileges to the users listed in 'sdAdmins'
+  #  - only authenticate the users listed in 'allowList'
+  # When set to false, performs
+  #  - grant admin privileges to the users listed in 'admins'
+  #  - only authenticate the users listed in 'whitelist'
+  authCheckById: true
   # Default session timeout (in minutes)
   sessionTimeout: 120
   # SameSite Cookie Option

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -35,7 +35,18 @@ auth:
   # Whitelist of users able to authenticate against the system
   # if empty, it allows everyone
   whitelist: []
+  # Deprecated. Instead, use sdAdmins which is more secure.
+  # List of users who should be given screwdriver admin privileges
+  # Values should follow '{scmDisplayName:scmUsername}' format
+  # Ex: ['github:john', 'bitbucket:john']
   admins: []
+  # List of users who should be given screwdriver admin privileges
+  # Values should follow '{scmDisplayName:scmUsername:scmUserId}' format
+  # Ex: ['github:john:12345', 'bitbucket:john:{98fsa1ba-0b91-4e3c-95ee-55899e933b0}']
+  sdAdmins: []
+  # When set to true, performs admin check using the users listed in 'sdAdmins'.
+  # When set to false, performs admin check using the users listed in 'admins'
+  adminCheckById: true
   # Default session timeout (in minutes)
   sessionTimeout: 120
   # SameSite Cookie Option

--- a/lib/server.js
+++ b/lib/server.js
@@ -201,7 +201,7 @@ module.exports = async config => {
         server.app.buildFactory.apiUri = server.info.uri;
         server.app.buildFactory.tokenGen = (buildId, metadata, scmContext, expiresIn, scope = ['temporal']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile(buildId, scmContext, scope, metadata),
+                server.plugins.auth.generateProfile(buildId, null, scmContext, scope, metadata),
                 expiresIn
             );
         server.app.buildFactory.executor.tokenGen = server.app.buildFactory.tokenGen;
@@ -209,7 +209,7 @@ module.exports = async config => {
         server.app.jobFactory.apiUri = server.info.uri;
         server.app.jobFactory.tokenGen = (username, metadata, scmContext, scope = ['user']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile(username, scmContext, scope, metadata)
+                server.plugins.auth.generateProfile(username, null, scmContext, scope, metadata)
             );
         server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
 

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -60,10 +60,11 @@ const AUTH_PLUGIN_SCHEMA = joi.object().keys({
     jwtPrivateKey: joi.string().required(),
     jwtPublicKey: joi.string().required(),
     jwtQueueServicePublicKey: joi.string().required(),
+    authCheckById: JOI_BOOLEAN.default(true),
     whitelist: joi.array().default([]),
+    allowList: joi.array().default([]),
     admins: joi.array().default([]),
     sdAdmins: joi.array().default([]),
-    adminCheckById: JOI_BOOLEAN.default(true),
     bell: joi.object().required(),
     scm: joi.object().required(),
     sessionTimeout: joi.number().integer().positive().default(120),
@@ -115,7 +116,7 @@ const authPlugin = {
                 const scmDisplayName = scm.getDisplayName({ scmContext });
 
                 // Check admin
-                if (pluginOptions.adminCheckById) {
+                if (pluginOptions.authCheckById) {
                     const user = `${scmDisplayName}:${username}:${scmUserId}`;
 
                     if (pluginOptions.sdAdmins.length > 0 && pluginOptions.sdAdmins.includes(user)) {

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -114,20 +114,14 @@ const authPlugin = {
             if (scmContext) {
                 const { scm } = pluginOptions;
                 const scmDisplayName = scm.getDisplayName({ scmContext });
+                const userDisplayName = pluginOptions.authCheckById
+                    ? `${scmDisplayName}:${username}:${scmUserId}`
+                    : `${scmDisplayName}:${username}`;
+                const admins = pluginOptions.authCheckById ? pluginOptions.sdAdmins : pluginOptions.admins;
 
                 // Check admin
-                if (pluginOptions.authCheckById) {
-                    const user = `${scmDisplayName}:${username}:${scmUserId}`;
-
-                    if (pluginOptions.sdAdmins.length > 0 && pluginOptions.sdAdmins.includes(user)) {
-                        profile.scope.push('admin');
-                    }
-                } else {
-                    const userDisplayName = `${scmDisplayName}:${username}`;
-
-                    if (pluginOptions.admins.length > 0 && pluginOptions.admins.includes(userDisplayName)) {
-                        profile.scope.push('admin');
-                    }
+                if (admins.length > 0 && admins.includes(userDisplayName)) {
+                    profile.scope.push('admin');
                 }
             }
 

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -32,7 +32,13 @@ function addGuestRoute(config) {
                     }
 
                     const username = `guest/${uuidv4()}`;
-                    const profile = request.server.plugins.auth.generateProfile(username, null, ['user', 'guest'], {});
+                    const profile = request.server.plugins.auth.generateProfile(
+                        username,
+                        null,
+                        null,
+                        ['user', 'guest'],
+                        {}
+                    );
 
                     // Log that the user has authenticated
                     request.log(['auth'], `${username} has logged in`);
@@ -82,8 +88,15 @@ function addOAuthRoutes(config) {
                 const { collectionFactory } = request.server.app;
                 const accessToken = request.auth.credentials.token;
                 const { username } = request.auth.credentials.profile;
+                const scmUserId = request.auth.credentials.profile.id;
 
-                const profile = request.server.plugins.auth.generateProfile(username, scmContext, ['user'], {});
+                const profile = request.server.plugins.auth.generateProfile(
+                    username,
+                    scmUserId,
+                    scmContext,
+                    ['user'],
+                    {}
+                );
                 const scmDisplayName = await userFactory.scm.getDisplayName({ scmContext });
                 const userDisplayName = `${scmDisplayName}:${username}`;
 

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -98,10 +98,13 @@ function addOAuthRoutes(config) {
                     {}
                 );
                 const scmDisplayName = await userFactory.scm.getDisplayName({ scmContext });
-                const userDisplayName = `${scmDisplayName}:${username}`;
+                const userDisplayName = config.authCheckById
+                    ? `${scmDisplayName}:${username}:${scmUserId}`
+                    : `${scmDisplayName}:${username}`;
+                const allowList = config.authCheckById ? config.allowList : config.whitelist;
 
                 // Check whitelist
-                if (config.whitelist.length > 0 && !config.whitelist.includes(userDisplayName)) {
+                if (allowList.length > 0 && !allowList.includes(userDisplayName)) {
                     return boom.forbidden(`User ${userDisplayName} is not allowed access`);
                 }
 

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -87,8 +87,7 @@ function addOAuthRoutes(config) {
                 const { userFactory } = request.server.app;
                 const { collectionFactory } = request.server.app;
                 const accessToken = request.auth.credentials.token;
-                const { username } = request.auth.credentials.profile;
-                const scmUserId = request.auth.credentials.profile.id;
+                const { username, id: scmUserId } = request.auth.credentials.profile;
 
                 const profile = request.server.plugins.auth.generateProfile(
                     username,

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -39,10 +39,12 @@ module.exports = () => ({
                 const job = await jobFactory.get(build.jobId);
                 const pipeline = pipelineFactory.get(job.pipelineId);
 
-                profile = request.server.plugins.auth.generateProfile(request.params.buildId, pipeline.scmContext, [
-                    'build',
-                    'impersonated'
-                ]);
+                profile = request.server.plugins.auth.generateProfile(
+                    request.params.buildId,
+                    null,
+                    pipeline.scmContext,
+                    ['build', 'impersonated']
+                );
                 profile.token = request.server.plugins.auth.generateToken(profile);
 
                 request.cookieAuth.set(profile);

--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -56,6 +56,7 @@ module.exports = () => ({
                     const token = request.server.plugins.auth.generateToken(
                         request.server.plugins.auth.generateProfile(
                             profile.username,
+                            null,
                             profile.scmContext,
                             ['build'],
                             jwtInfo

--- a/plugins/pipelines/caches/request.js
+++ b/plugins/pipelines/caches/request.js
@@ -36,7 +36,7 @@ async function invoke(request) {
     const { username, scmContext } = auth.credentials;
 
     const token = request.server.plugins.auth.generateToken(
-        request.server.plugins.auth.generateProfile(username, scmContext, ['sdapi'], { pipelineId })
+        request.server.plugins.auth.generateProfile(username, null, scmContext, ['sdapi'], { pipelineId })
     );
 
     const options = {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -5757,7 +5757,7 @@ describe('build plugin test', () => {
         it('returns 200 for a build that exists and can get token', () =>
             server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
-                assert.calledWith(generateProfileMock, '12345', 'github:github.com', ['build'], {
+                assert.calledWith(generateProfileMock, '12345', null, 'github:github.com', ['build'], {
                     isPR: false,
                     jobId: 1234,
                     pipelineId: 1,
@@ -5787,7 +5787,7 @@ describe('build plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
-                assert.calledWith(generateProfileMock, '12345', 'github:github.com', ['build'], {
+                assert.calledWith(generateProfileMock, '12345', null, 'github:github.com', ['build'], {
                     isPR: false,
                     jobId: 1234,
                     pipelineId: 1,


### PR DESCRIPTION
## Context
Username (/login) in SCM (Ex: Github) is mutable. In screwdriver, admin privileges are configured and determined based on SCM username of the logged in user.

If a user is configured as admin in Screwdriver and the user changes the username in SCM, the user will lose admin privileges.
If a new account is created in the SCM with the old username, the new user will acquire admin privileges.

## Objective
This PR deliver below changes
- Configure and grant admin privileges based on both SCM user ID and name

- Configure and authenticate allowed users based on both SCM user ID and name

**Old config (Now deprecated)**
```
# list of users able to authenticate against the system
# Ex: ['github:john', 'bitbucket:john']
  whitelist: []

# List of users who should be given screwdriver admin privileges
# Ex: ['github:john', 'bitbucket:john']
  admins: []
```

**New config**
```
# list of users able to authenticate against the system
# Ex: ['github:john:12345', 'bitbucket:john:{98fsa1ba-0b91-4e3c-95ee-55899e933b0}']
  allowList: []

# List of users who should be given screwdriver admin privileges
# Ex: ['github:john:12345', 'bitbucket:john:{98fsa1ba-0b91-4e3c-95ee-55899e933b0}']
  sdAdmins: []
```

**P.S.**
To continue to use old approach, you need set `authCheckById` to `false` in the config.
Support for old approach will soon be removed in the future release.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2853

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
