### PR TITLE
fix(2853): Refactor - Auth profile generation to take config object i…

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -201,7 +201,7 @@ module.exports = async config => {
         server.app.buildFactory.apiUri = server.info.uri;
         server.app.buildFactory.tokenGen = (buildId, metadata, scmContext, expiresIn, scope = ['temporal']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile(buildId, null, scmContext, scope, metadata),
+                server.plugins.auth.generateProfile({ username: buildId, scmContext, scope, metadata }),
                 expiresIn
             );
         server.app.buildFactory.executor.tokenGen = server.app.buildFactory.tokenGen;
@@ -209,7 +209,7 @@ module.exports = async config => {
         server.app.jobFactory.apiUri = server.info.uri;
         server.app.jobFactory.tokenGen = (username, metadata, scmContext, scope = ['user']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile(username, null, scmContext, scope, metadata)
+                server.plugins.auth.generateProfile({ username, scmContext, scope, metadata })
             );
         server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
 

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -97,14 +97,16 @@ const authPlugin = {
         /**
          * Generates a profile for storage in cookie and jwt
          * @method generateProfile
-         * @param  {String}        username   Username of the person
-         * @param  {String}        scmUserId  User ID in the SCM
-         * @param  {String}        scmContext Scm to which the person logged in belongs
-         * @param  {Array}         scope      Scope for this profile (usually build or user)
-         * @param  {Object}        metadata   Additonal information to tag along with the login
-         * @return {Object}                   The profile to be stored in jwt and/or cookie
+         * @param  {Object}   config            Configuration object
+         * @param  {String}   config.username   Username of the person
+         * @param  {String}   config.scmUserId  User ID in the SCM
+         * @param  {String}   config.scmContext Scm to which the person logged in belongs
+         * @param  {Array}    config.scope      Scope for this profile (usually build or user)
+         * @param  {Object}   config.metadata   Additional information to tag along with the login
+         * @return {Object}                     The profile to be stored in jwt and/or cookie
          */
-        server.expose('generateProfile', (username, scmUserId, scmContext, scope, metadata) => {
+        server.expose('generateProfile', config => {
+            const { username, scmUserId, scmContext, scope, metadata } = config;
             const profile = { username, scmContext, scope, ...(metadata || {}) };
 
             if (pluginOptions.jwtEnvironment) {

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -32,13 +32,11 @@ function addGuestRoute(config) {
                     }
 
                     const username = `guest/${uuidv4()}`;
-                    const profile = request.server.plugins.auth.generateProfile(
+                    const profile = request.server.plugins.auth.generateProfile({
                         username,
-                        null,
-                        null,
-                        ['user', 'guest'],
-                        {}
-                    );
+                        scope: ['user', 'guest'],
+                        metadata: {}
+                    });
 
                     // Log that the user has authenticated
                     request.log(['auth'], `${username} has logged in`);
@@ -89,13 +87,13 @@ function addOAuthRoutes(config) {
                 const accessToken = request.auth.credentials.token;
                 const { username, id: scmUserId } = request.auth.credentials.profile;
 
-                const profile = request.server.plugins.auth.generateProfile(
+                const profile = request.server.plugins.auth.generateProfile({
                     username,
                     scmUserId,
                     scmContext,
-                    ['user'],
-                    {}
-                );
+                    scope: ['user'],
+                    metadata: {}
+                });
                 const scmDisplayName = await userFactory.scm.getDisplayName({ scmContext });
                 const userDisplayName = config.authCheckById
                     ? `${scmDisplayName}:${username}:${scmUserId}`

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -39,12 +39,11 @@ module.exports = () => ({
                 const job = await jobFactory.get(build.jobId);
                 const pipeline = pipelineFactory.get(job.pipelineId);
 
-                profile = request.server.plugins.auth.generateProfile(
-                    request.params.buildId,
-                    null,
-                    pipeline.scmContext,
-                    ['build', 'impersonated']
-                );
+                profile = request.server.plugins.auth.generateProfile({
+                    username: request.params.buildId,
+                    scmContext: pipeline.scmContext,
+                    scope: ['build', 'impersonated']
+                });
                 profile.token = request.server.plugins.auth.generateToken(profile);
 
                 request.cookieAuth.set(profile);

--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -54,13 +54,12 @@ module.exports = () => ({
                     }
 
                     const token = request.server.plugins.auth.generateToken(
-                        request.server.plugins.auth.generateProfile(
-                            profile.username,
-                            null,
-                            profile.scmContext,
-                            ['build'],
-                            jwtInfo
-                        ),
+                        request.server.plugins.auth.generateProfile({
+                            username: profile.username,
+                            scmContext: profile.scmContext,
+                            scope: ['build'],
+                            metadata: jwtInfo
+                        }),
                         parseInt(buildTimeout, 10)
                     );
 

--- a/plugins/pipelines/caches/request.js
+++ b/plugins/pipelines/caches/request.js
@@ -36,7 +36,12 @@ async function invoke(request) {
     const { username, scmContext } = auth.credentials;
 
     const token = request.server.plugins.auth.generateToken(
-        request.server.plugins.auth.generateProfile(username, null, scmContext, ['sdapi'], { pipelineId })
+        request.server.plugins.auth.generateProfile({
+            username,
+            scmContext,
+            scope: ['sdapi'],
+            metadata: { pipelineId }
+        })
     );
 
     const options = {

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -291,7 +291,12 @@ describe('auth plugin test', () => {
                     }
                 })
                 .then(() => {
-                    const profile = server.plugins.auth.generateProfile('batman', 'github:github.com', ['user'], {});
+                    const profile = server.plugins.auth.generateProfile({
+                        username: 'batman',
+                        scmContext: 'github:github.com',
+                        scope: ['user'],
+                        metadata: {}
+                    });
 
                     expect(profile.environment).to.equal('beta');
                 });
@@ -321,7 +326,13 @@ describe('auth plugin test', () => {
             });
 
             it('adds admin scope for admins', () => {
-                const profile = server.plugins.auth.generateProfile('batman', 1312, 'github:github.com', ['user'], {});
+                const profile = server.plugins.auth.generateProfile({
+                    username: 'batman',
+                    scmUserId: 1312,
+                    scmContext: 'github:github.com',
+                    scope: ['user'],
+                    metadata: {}
+                });
 
                 expect(profile.username).to.contain('batman');
                 expect(profile.scmContext).to.contain('github:github.com');
@@ -331,7 +342,12 @@ describe('auth plugin test', () => {
             });
 
             it('does not add admin scope for non-admins', () => {
-                const profile = server.plugins.auth.generateProfile('robin', null, 'github:mygithub.com', ['user'], {});
+                const profile = server.plugins.auth.generateProfile({
+                    username: 'robin',
+                    scmContext: 'github:mygithub.com',
+                    scope: ['user'],
+                    metadata: {}
+                });
 
                 expect(profile.username).to.contain('robin');
                 expect(profile.scmContext).to.contain('github:mygithub.com');
@@ -341,13 +357,12 @@ describe('auth plugin test', () => {
             });
 
             it('does not add admin scope for admins without SCM user id', () => {
-                const profile = server.plugins.auth.generateProfile(
-                    'batman',
-                    null,
-                    'github:mygithub.com',
-                    ['user'],
-                    {}
-                );
+                const profile = server.plugins.auth.generateProfile({
+                    username: 'batman',
+                    scmContext: 'github:mygithub.com',
+                    scope: ['user'],
+                    metadata: {}
+                });
 
                 expect(profile.username).to.contain('batman');
                 expect(profile.scmContext).to.contain('github:mygithub.com');
@@ -381,7 +396,13 @@ describe('auth plugin test', () => {
             });
 
             it('adds admin scope for admins', () => {
-                const profile = server.plugins.auth.generateProfile('batman', 1312, 'github:github.com', ['user'], {});
+                const profile = server.plugins.auth.generateProfile({
+                    username: 'batman',
+                    scmUserId: 1312,
+                    scmContext: 'github:github.com',
+                    scope: ['user'],
+                    metadata: {}
+                });
 
                 expect(profile.username).to.contain('batman');
                 expect(profile.scmContext).to.contain('github:github.com');
@@ -391,7 +412,12 @@ describe('auth plugin test', () => {
             });
 
             it('does not add admin scope for non-admins', () => {
-                const profile = server.plugins.auth.generateProfile('robin', null, 'github:mygithub.com', ['user'], {});
+                const profile = server.plugins.auth.generateProfile({
+                    username: 'robin',
+                    scmContext: 'github:mygithub.com',
+                    scope: ['user'],
+                    metadata: {}
+                });
 
                 expect(profile.username).to.contain('robin');
                 expect(profile.scmContext).to.contain('github:mygithub.com');
@@ -401,13 +427,12 @@ describe('auth plugin test', () => {
             });
 
             it('adds admin scope for admins without SCM user id', () => {
-                const profile = server.plugins.auth.generateProfile(
-                    'batman',
-                    null,
-                    'github:mygithub.com',
-                    ['user'],
-                    {}
-                );
+                const profile = server.plugins.auth.generateProfile({
+                    username: 'batman',
+                    scmContext: 'github:mygithub.com',
+                    scope: ['user'],
+                    metadata: {}
+                });
 
                 expect(profile.username).to.contain('batman');
                 expect(profile.scmContext).to.contain('github:mygithub.com');

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -5757,12 +5757,17 @@ describe('build plugin test', () => {
         it('returns 200 for a build that exists and can get token', () =>
             server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
-                assert.calledWith(generateProfileMock, '12345', null, 'github:github.com', ['build'], {
-                    isPR: false,
-                    jobId: 1234,
-                    pipelineId: 1,
-                    eventId: 777,
-                    configPipelineId: 123
+                assert.calledWith(generateProfileMock, {
+                    username: '12345',
+                    scmContext: 'github:github.com',
+                    scope: ['build'],
+                    metadata: {
+                        isPR: false,
+                        jobId: 1234,
+                        pipelineId: 1,
+                        eventId: 777,
+                        configPipelineId: 123
+                    }
                 });
                 assert.calledWith(
                     generateTokenMock,
@@ -5787,13 +5792,18 @@ describe('build plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
-                assert.calledWith(generateProfileMock, '12345', null, 'github:github.com', ['build'], {
-                    isPR: false,
-                    jobId: 1234,
-                    pipelineId: 1,
-                    eventId: 777,
-                    configPipelineId: 123,
-                    prParentJobId: 1000
+                assert.calledWith(generateProfileMock, {
+                    username: '12345',
+                    scmContext: 'github:github.com',
+                    scope: ['build'],
+                    metadata: {
+                        isPR: false,
+                        jobId: 1234,
+                        pipelineId: 1,
+                        eventId: 777,
+                        configPipelineId: 123,
+                        prParentJobId: 1000
+                    }
                 });
                 assert.calledWith(
                     generateTokenMock,


### PR DESCRIPTION
## Context

Minor refactor for the code changes pushed in https://github.com/screwdriver-cd/screwdriver/pull/2854

Change method signature to pass parameters as an object instead of individual arguments
https://github.com/screwdriver-cd/screwdriver/pull/2854#discussion_r1159152169

## Objective



## References

https://github.com/screwdriver-cd/screwdriver/issues/2853

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
