### PR TITLE
fix: bump model version to 29.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "screwdriver-executor-queue": "^4.0.0",
     "screwdriver-executor-router": "^3.0.0",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-models": "^29.0.0",
+    "screwdriver-models": "^29.2.0",
     "screwdriver-notifications-email": "^3.0.0",
     "screwdriver-notifications-slack": "^4.0.0",
     "screwdriver-request": "^2.0.1",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Bump model version in screwdriver backend for https://github.com/screwdriver-cd/models/pull/574
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
