### PR TITLE
feat(2862): Add a new API to delete a specific version of a template

### DIFF
--- a/plugins/templates/README.md
+++ b/plugins/templates/README.md
@@ -117,6 +117,20 @@ Deleting a template will delete a template and all of its associated tags and ve
 
 * `name` - Name of the template
 
+##### Delete a version
+
+Delete the template version and all of its associated tags.
+If the deleted version was the last published, the API would set the `latest` attribute of the previous version to `true`.
+
+`DELETE /templates/{name}/versions/{version}`
+
+###### Arguments
+
+'name', 'version'
+
+* `name` - Name of the template
+* `version` - Version of the template
+
 #### Template Tag
 Template tag allows fetching on template version by tag. For example, tag `mytemplate@1.1.0` as `stable`.
 

--- a/plugins/templates/index.js
+++ b/plugins/templates/index.js
@@ -10,6 +10,7 @@ const listVersionsRoute = require('./listVersions');
 const listVersionsWithMetricsRouter = require('./listVersionsWithMetric');
 const removeRoute = require('./remove');
 const removeTagRoute = require('./removeTag');
+const removeVersionRoute = require('./removeVersion');
 const updateTrustedRoute = require('./updateTrusted');
 const getTemplateByIdRoute = require('./getTemplateById');
 
@@ -84,6 +85,7 @@ const templatesPlugin = {
             listVersionsWithMetricsRouter(),
             removeRoute(),
             removeTagRoute(),
+            removeVersionRoute(),
             updateTrustedRoute(),
             getTemplateByIdRoute()
         ]);

--- a/plugins/templates/removeVersion.js
+++ b/plugins/templates/removeVersion.js
@@ -37,13 +37,18 @@ module.exports = () => ({
                     return canRemove(credentials, template, 'admin', request.server.app)
                         .then(() => {
                             shouldUpdateLatest = template.latest;
-                            const templatePromises = [template.remove()];
-                            const tagPromises = tags.map(tag => tag.remove());
+                            const removeTemplatePromise = template.remove();
+                            const removeTagPromises = tags.map(tag => tag.remove());
 
-                            return Promise.all(templatePromises.concat(tagPromises)).then(() => {
+                            return Promise.all([removeTemplatePromise, ...removeTagPromises]).then(() => {
                                 if (shouldUpdateLatest) {
                                     return templateFactory
-                                        .list({ params: { name }, sort: 'descending', sortBy: 'createTime' })
+                                        .list({
+                                            params: { name },
+                                            sort: 'descending',
+                                            sortBy: 'createTime',
+                                            paginate: { count: 1 }
+                                        })
                                         .then(templates => {
                                             if (templates.length > 0) {
                                                 const newLatestTemplate = templates[0];

--- a/plugins/templates/removeVersion.js
+++ b/plugins/templates/removeVersion.js
@@ -4,7 +4,7 @@ const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const nameSchema = schema.models.template.base.extract('name');
-const versionSchema = schema.models.template.base.extract('version');
+const exactVersionSchema = schema.config.template.exactVersion;
 
 module.exports = () => ({
     method: 'DELETE',
@@ -74,7 +74,7 @@ module.exports = () => ({
         validate: {
             params: joi.object({
                 name: nameSchema,
-                version: versionSchema
+                version: exactVersionSchema
             })
         }
     }

--- a/plugins/templates/removeVersion.js
+++ b/plugins/templates/removeVersion.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const nameSchema = schema.models.template.base.extract('name');
+const versionSchema = schema.models.template.base.extract('version');
+
+module.exports = () => ({
+    method: 'DELETE',
+    path: '/templates/{name}/versions/{version}',
+    options: {
+        description: 'Delete the specified version of template and the tags associated with it',
+        notes: 'Returns null if successful',
+        tags: ['api', 'templates'],
+        auth: {
+            strategies: ['token'],
+            scope: ['build', 'user', '!guest']
+        },
+
+        handler: async (request, h) => {
+            const { name, version } = request.params;
+            const { credentials } = request.auth;
+            const { templateFactory, templateTagFactory } = request.server.app;
+            const { canRemove } = request.server.plugins.templates;
+            let shouldUpdateLatest = false;
+
+            return Promise.all([
+                templateFactory.get({ name, version }),
+                templateTagFactory.list({ params: { name, version } })
+            ])
+                .then(([template, tags]) => {
+                    if (!template) {
+                        throw boom.notFound(`Template ${name} with version ${version} does not exist`);
+                    }
+
+                    return canRemove(credentials, template, 'admin', request.server.app)
+                        .then(() => {
+                            shouldUpdateLatest = template.latest;
+                            const templatePromises = [template.remove()];
+                            const tagPromises = tags.map(tag => tag.remove());
+
+                            return Promise.all(templatePromises.concat(tagPromises)).then(() => {
+                                if (shouldUpdateLatest) {
+                                    return templateFactory
+                                        .list({ params: { name }, sort: 'descending', sortBy: 'createTime' })
+                                        .then(templates => {
+                                            if (templates.length > 0) {
+                                                const newLatestTemplate = templates[0];
+
+                                                newLatestTemplate.latest = true;
+
+                                                return newLatestTemplate.update();
+                                            }
+
+                                            return Promise.resolve();
+                                        });
+                                }
+
+                                return Promise.resolve();
+                            });
+                        })
+                        .then(() => h.response().code(204));
+                })
+                .catch(err => {
+                    throw err;
+                });
+        },
+        validate: {
+            params: joi.object({
+                name: nameSchema,
+                version: versionSchema
+            })
+        }
+    }
+});

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -1293,7 +1293,8 @@ describe('template plugin test', () => {
                 .withArgs({
                     params: { name: `${templateNameSpace}/${templateName}` },
                     sort: 'descending',
-                    sortBy: 'createTime'
+                    sortBy: 'createTime',
+                    paginate: { count: 1 }
                 })
                 .resolves([testTemplateV2]);
 

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -990,7 +990,7 @@ describe('template plugin test', () => {
             });
         });
 
-        it('returns 403 when pipelineId does not match', () => {
+        it('returns 403 when build credential is from a PR', () => {
             options.auth.credentials.isPR = true;
 
             return server.inject(options).then(reply => {

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -1193,6 +1193,22 @@ describe('template plugin test', () => {
             templateTagFactoryMock.list.resolves([testTemplateTag]);
         });
 
+        it('returns 400 when template version is invalid', () => {
+            const error = {
+                statusCode: 400,
+                error: 'Bad Request',
+                message: 'Invalid request params input'
+            };
+
+            options.url = `/templates/${templateNameSpace}%2F${templateName}/versions/1.0`;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, error.statusCode);
+                assert.deepEqual(reply.result, error);
+                assert.isFalse(templateFactoryMock.get.called);
+            });
+        });
+
         it('returns 404 when template version does not exist', () => {
             const error = {
                 statusCode: 404,
@@ -1203,7 +1219,7 @@ describe('template plugin test', () => {
             templateFactoryMock.get.withArgs({ name: 'test-namespace/test-template', version: '1.0.0' }).resolves(null);
 
             return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 404);
+                assert.equal(reply.statusCode, error.statusCode);
                 assert.deepEqual(reply.result, error);
                 assert.calledWith(templateFactoryMock.get, { name: 'test-namespace/test-template', version: '1.0.0' });
             });
@@ -1219,7 +1235,7 @@ describe('template plugin test', () => {
             userFactoryMock.get.withArgs({ username, scmContext }).resolves(null);
 
             return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 404);
+                assert.equal(reply.statusCode, error.statusCode);
                 assert.deepEqual(reply.result, error);
             });
         });
@@ -1234,7 +1250,7 @@ describe('template plugin test', () => {
             pipelineFactoryMock.get.withArgs(templatePipelineId).resolves(null);
 
             return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 404);
+                assert.equal(reply.statusCode, error.statusCode);
                 assert.deepEqual(reply.result, error);
             });
         });
@@ -1249,7 +1265,7 @@ describe('template plugin test', () => {
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
 
             return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 403);
+                assert.equal(reply.statusCode, error.statusCode);
                 assert.deepEqual(reply.result, error);
             });
         });

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -1134,6 +1134,223 @@ describe('template plugin test', () => {
         });
     });
 
+    describe('DELETE /templates/{name}/versions/{version}', () => {
+        const scmUri = 'github.com:12345:branchName';
+        const username = 'myself';
+        const scmContext = 'github@github.com';
+        const templateNameSpace = 'test-namespace';
+        const templateName = 'test-template';
+        const templatePipelineId = 123;
+        const anotherPipelineId = 678;
+        const templateVersion1 = '1.0.0';
+        const templateVersion2 = '2.0.0';
+        let pipeline;
+        let options;
+        let userMock;
+        let testTemplateV1;
+        let testTemplateTag;
+
+        beforeEach(() => {
+            options = {
+                method: 'DELETE',
+                url: `/templates/${templateNameSpace}%2F${templateName}/versions/${templateVersion1}`,
+                auth: {
+                    credentials: {
+                        username,
+                        scmContext,
+                        scope: ['user', '!guest']
+                    },
+                    strategy: ['token']
+                }
+            };
+            testTemplateV1 = decorateObj({
+                id: 1,
+                namespace: templateNameSpace,
+                name: templateName,
+                version: templateVersion1,
+                tag: 'stable',
+                pipelineId: templatePipelineId,
+                latest: false,
+                remove: sinon.stub().resolves(null)
+            });
+            testTemplateTag = decorateObj({
+                id: 1,
+                name: 'testtemplate',
+                tag: 'stable',
+                remove: sinon.stub().resolves(null)
+            });
+
+            userMock = getUserMock({ username, scmContext });
+            userFactoryMock.get.withArgs({ username, scmContext }).resolves(userMock);
+
+            pipeline = getPipelineMocks(testpipeline);
+            pipelineFactoryMock.get.withArgs(templatePipelineId).resolves(pipeline);
+
+            templateFactoryMock.get.resolves(testTemplateV1);
+            templateFactoryMock.get
+                .withArgs({ name: `${templateNameSpace}/${templateName}`, version: templateVersion1 })
+                .resolves(testTemplateV1);
+            templateTagFactoryMock.list.resolves([testTemplateTag]);
+        });
+
+        it('returns 404 when template version does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: `Template ${templateNameSpace}/${templateName} with version ${templateVersion1} does not exist`
+            };
+
+            templateFactoryMock.get.withArgs({ name: 'test-namespace/test-template', version: '1.0.0' }).resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+                assert.calledWith(templateFactoryMock.get, { name: 'test-namespace/test-template', version: '1.0.0' });
+            });
+        });
+
+        it('returns 404 when user does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'User myself does not exist'
+            };
+
+            userFactoryMock.get.withArgs({ username, scmContext }).resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 404 when pipeline does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: `Pipeline ${templatePipelineId} does not exist`
+            };
+
+            pipelineFactoryMock.get.withArgs(templatePipelineId).resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 403 when user does not have admin permissions', () => {
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'User myself does not have admin access for this template'
+            };
+
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('deletes template version and associated tags if user has pipeline admin credentials and template exists', () => {
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(testTemplateV1.remove);
+                assert.calledOnce(testTemplateTag.remove);
+                assert.equal(reply.statusCode, 204);
+            });
+        });
+
+        it('deletes template version and associated tags if user has Screwdriver admin credentials and template exists', () => {
+            options.auth.credentials.scope.push('admin');
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(testTemplateV1.remove);
+                assert.calledOnce(testTemplateTag.remove);
+                assert.equal(reply.statusCode, 204);
+            });
+        });
+
+        it('deletes template version and associated tags with valid credentials, and if deleted version was latest, update the previous version as the latest', () => {
+            const testTemplateV2 = decorateObj({
+                id: 1,
+                namespace: templateNameSpace,
+                name: templateName,
+                version: templateVersion2,
+                tag: 'stable',
+                pipelineId: templatePipelineId,
+                latest: false,
+                update: sinon.stub().resolves(null)
+            });
+
+            testTemplateV1.latest = true;
+
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
+            templateFactoryMock.list
+                .withArgs({
+                    params: { name: `${templateNameSpace}/${templateName}` },
+                    sort: 'descending',
+                    sortBy: 'createTime'
+                })
+                .resolves([testTemplateV2]);
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(testTemplateV1.remove);
+                assert.calledOnce(testTemplateTag.remove);
+                assert.calledOnce(testTemplateV2.update);
+                assert.isTrue(testTemplateV2.latest);
+                assert.equal(reply.statusCode, 204);
+            });
+        });
+
+        it('returns 403 when build credential pipelineId does not match target pipelineId', () => {
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'Not allowed to remove this template'
+            };
+
+            options.auth.credentials.scope = ['build'];
+            options.auth.credentials.pipelineId = anotherPipelineId;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 403 when build credential is from a PR', () => {
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'Not allowed to remove this template'
+            };
+
+            options.auth.credentials.scope = ['build'];
+            options.auth.credentials.pipelineId = templatePipelineId;
+            options.auth.credentials.isPR = true;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('deletes template version and associated tags if build credentials provided and pipelineIds match', () => {
+            options.auth.credentials.scope = ['build'];
+            options.auth.credentials.pipelineId = templatePipelineId;
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(testTemplateV1.remove);
+                assert.calledOnce(testTemplateTag.remove);
+                assert.equal(reply.statusCode, 204);
+            });
+        });
+    });
+
     describe('PUT /templates/trusted', () => {
         let options;
         let templateMock;


### PR DESCRIPTION
## Context

The existing API to remove a template, removes all the versions of the specified template and their associated tags.

There could be an use case where template owner publish a new version and later realized that there are some issues with it and prevent any jobs from using it.
To support this, we need an API to just delete a specific version of the template and its associated tags.


## Objective
Add a new API to delete the specified version of the template
`DELETE /templates/{name}/versions/{version}`

Example:
`DELETE /templates/nodejs%2Flib/versions/2.0.12` removes version `2.0.12` of template `lib` under the namespace `nodejs`.

**Note**
If the deleted version was the last published, the API would set the `latest` attribute of the previous version to `true`.


## References

https://github.com/screwdriver-cd/screwdriver/issues/2862

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
