### PR TITLE
feat(2862): Template metrics - Support date/time filter while fetching build count

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "screwdriver-executor-queue": "^4.0.0",
     "screwdriver-executor-router": "^3.0.0",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-models": "^29.0.0",
+    "screwdriver-models": "^29.3.0",
     "screwdriver-notifications-email": "^3.0.0",
     "screwdriver-notifications-slack": "^4.0.0",
     "screwdriver-request": "^2.0.1",

--- a/plugins/templates/listVersionsWithMetric.js
+++ b/plugins/templates/listVersionsWithMetric.js
@@ -25,12 +25,20 @@ module.exports = () => ({
                 },
                 sort: request.query.sort
             };
+            const { startTime, endTime, page, count } = request.query;
 
-            if (request.query.page || request.query.count) {
+            if (page || count) {
                 config.paginate = {
-                    page: request.query.page,
-                    count: request.query.count
+                    page,
+                    count
                 };
+            }
+
+            if (startTime) {
+                config.startTime = startTime;
+            }
+            if (endTime) {
+                config.endTime = endTime;
             }
 
             return factory
@@ -56,7 +64,9 @@ module.exports = () => ({
             }),
             query: schema.api.pagination.concat(
                 joi.object({
-                    search: joi.forbidden() // we don't support search for Template list versions with metrics
+                    search: joi.forbidden(), // we don't support search for Template list versions with metrics,
+                    startTime: joi.string().isoDate(),
+                    endTime: joi.string().isoDate()
                 })
             )
         }

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -473,6 +473,59 @@ describe('template plugin test', () => {
             });
         });
 
+        it('returns 200 and all versions and metrics for a template name with build count within the specified time interval', () => {
+            const startTime = '2023-01-01T01:47:27.863Z';
+            const endTime = '2023-01-30T01:47:27.863Z';
+
+            options.url = `/templates/screwdriver%2Fbuild/metrics?startTime=${startTime}&endTime=${endTime}`;
+            templateFactoryMock.listWithMetrics.resolves(testTemplateVersionsMetrics);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testTemplateVersionsMetrics);
+                assert.calledWith(templateFactoryMock.listWithMetrics, {
+                    params: { name: 'screwdriver/build' },
+                    startTime,
+                    endTime,
+                    sort: 'descending'
+                });
+            });
+        });
+
+        it('returns 200 and all versions and metrics for a template name with build count on or after the specified start time', () => {
+            const startTime = '2023-01-01T01:47:27.863Z';
+
+            options.url = `/templates/screwdriver%2Fbuild/metrics?startTime=${startTime}`;
+            templateFactoryMock.listWithMetrics.resolves(testTemplateVersionsMetrics);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testTemplateVersionsMetrics);
+                assert.calledWith(templateFactoryMock.listWithMetrics, {
+                    params: { name: 'screwdriver/build' },
+                    startTime,
+                    sort: 'descending'
+                });
+            });
+        });
+
+        it('returns 200 and all versions and metrics for a template name with build count on or before the specified end time', () => {
+            const endTime = '2023-01-30T01:47:27.863Z';
+
+            options.url = `/templates/screwdriver%2Fbuild/metrics?endTime=${endTime}`;
+            templateFactoryMock.listWithMetrics.resolves(testTemplateVersionsMetrics);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testTemplateVersionsMetrics);
+                assert.calledWith(templateFactoryMock.listWithMetrics, {
+                    params: { name: 'screwdriver/build' },
+                    endTime,
+                    sort: 'descending'
+                });
+            });
+        });
+
         it('returns 404 when template does not exist', () => {
             templateFactoryMock.listWithMetrics.resolves([]);
 


### PR DESCRIPTION
## Context
The API to fetch all the versions of a template along with their usage metrics, returns all time usage by builds for each version.
We need ability to compute build usage metric for each version within a specified date/time interval

## Objective

Enhance the API to support an optional date/time filter while computing usage by builds for each version.
Related PR: https://github.com/screwdriver-cd/models/pull/575

**TODO:**
Need to update `screwdriver-models` version in `package.json` after PR https://github.com/screwdriver-cd/models/pull/575 is merged/published.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2862

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
