### PR TITLE
feat: remove org admin permissions check

### DIFF
--- a/test/plugins/buildClusters.test.js
+++ b/test/plugins/buildClusters.test.js
@@ -229,15 +229,8 @@ describe('buildCluster plugin test', () => {
         let options;
         let userMock;
         let buildClusterMock;
-        let scmConfig;
 
         beforeEach(() => {
-            scmConfig = {
-                token: 'iamtoken',
-                scmContext,
-                organization: 'screwdriver-cd',
-                username
-            };
             options = {
                 method: 'POST',
                 url: '/buildclusters',
@@ -290,7 +283,6 @@ describe('buildCluster plugin test', () => {
                     id: buildClusterId,
                     other: 'dataToBeIncluded'
                 });
-                assert.calledWith(buildClusterFactoryMock.scm.getOrgPermissions, scmConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(buildClusterFactoryMock.create, params);
             });
@@ -314,7 +306,6 @@ describe('buildCluster plugin test', () => {
                     id: buildClusterId,
                     other: 'dataToBeIncluded'
                 });
-                assert.notCalled(buildClusterFactoryMock.scm.getOrgPermissions);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(buildClusterFactoryMock.create, params);
             });
@@ -325,20 +316,6 @@ describe('buildCluster plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 422);
-                assert.notCalled(buildClusterFactoryMock.scm.getOrgPermissions);
-                assert.notCalled(buildClusterFactoryMock.create);
-            });
-        });
-
-        it('returns 403 when the user is not an org admin for an external cluster', () => {
-            buildClusterFactoryMock.scm.getOrgPermissions.resolves({
-                admin: false,
-                member: true
-            });
-
-            return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 403);
-                assert.calledWith(buildClusterFactoryMock.scm.getOrgPermissions, scmConfig);
                 assert.notCalled(buildClusterFactoryMock.create);
             });
         });
@@ -350,7 +327,6 @@ describe('buildCluster plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 403);
-                assert.notCalled(buildClusterFactoryMock.scm.getOrgPermissions);
                 assert.notCalled(buildClusterFactoryMock.create);
             });
         });
@@ -382,7 +358,6 @@ describe('buildCluster plugin test', () => {
         let options;
         let updatedBuildClusterMock;
         let buildClustersMock;
-        let userMock;
 
         beforeEach(() => {
             buildClustersMock = getMockBuildClusters(testBuildClusters);
@@ -398,10 +373,6 @@ describe('buildCluster plugin test', () => {
                     strategy: ['token']
                 }
             };
-            userMock = {
-                username,
-                unsealToken: sinon.stub()
-            };
 
             updatedBuildClusterMock = getMockBuildClusters(updatedBuildCluster);
             buildClusterFactoryMock.list.resolves(buildClustersMock);
@@ -411,7 +382,6 @@ describe('buildCluster plugin test', () => {
                 admin: true,
                 member: true
             });
-            userFactoryMock.get.resolves(userMock);
             bannerFactoryMock.scm.getDisplayName.withArgs({ scmContext }).returns(scmDisplayName);
         });
 
@@ -458,23 +428,7 @@ describe('buildCluster plugin test', () => {
             });
         });
 
-        it('returns 403 when the user is not an org admin for an external cluster', () => {
-            buildClusterFactoryMock.scm.getOrgPermissions.resolves({
-                admin: false,
-                member: true
-            });
-
-            return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 403);
-                assert.notCalled(buildClusterFactoryMock.create);
-            });
-        });
-
         it('returns 422 when build cluster returns non-array for external cluster', () => {
-            buildClusterFactoryMock.scm.getOrgPermissions.resolves({
-                admin: false,
-                member: true
-            });
             buildClusterFactoryMock.list.resolves({});
 
             return server.inject(options).then(reply => {


### PR DESCRIPTION
## Context


BuildCluster scm org can only be added if sd admin is admin on that org which is restrictive if we want to allowlist multiple orgs

## Objective

This PR removes the check for admin permissions in scm org to add build cluster

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
