### PR TITLE
fix: artifacts query to add allowUnknown

### DIFF
--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -92,7 +92,7 @@ module.exports = config => ({
             }),
             query: joi.object({
                 type: typeSchema
-            })
+            }).options({ allowUnknown: true })
         }
     }
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Per user request, the artifacts currently only allow
```
https://screwdriver.cd/pipelines/1053865/builds/51147439/artifacts/storybook-static/index.html 
```

and does not allow, 
```
https://api.screwdriver.ouroath.com/v4/builds/51147439/artifacts/storybook-static/iframe.html?type=preview&viewMode=story&id=* 
```

## Objective
```
  query: joi.object({
      type: typeSchema
  }).options({ allowUnknown: true })
```

will check and validate existing query, while allow unknow parameters 

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
Sample from https://joi.dev/tester/:  

![image](https://github.com/screwdriver-cd/screwdriver/assets/15989893/12883f55-53e1-4e68-a38a-252a558d93a6)


<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
