### PR TITLE
[3] fix(2892): API tokens are correctly authenticated with new sd admins format

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -205,23 +205,26 @@ const authPlugin = {
                             return { isValid: false, credentials: {} };
                         }
 
-                        let scmUser;
+                        let scmUser = {};
 
                         try {
                             scmUser = await scm.decorateAuthor({
                                 username: user.username,
                                 scmContext: user.scmContext,
-                                token: await user.unsealToken(),
+                                token: await user.unsealToken()
                             });
                         } catch (e) {
-                            request.log(['auth', 'error'], `Fails to find the user "${user.username}" in ${user.scmContext}.`);
+                            request.log(
+                                ['auth', 'error'],
+                                `Fails to find the user "${user.username}" in ${user.scmContext}.`
+                            );
                         }
 
                         await createDefaultCollection(user, collectionFactory);
 
                         profile = {
                             username: user.username,
-                            scmUserId: scmUser?.id,
+                            scmUserId: scmUser.id,
                             scmContext: user.scmContext,
                             scope: ['user']
                         };

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -213,11 +213,13 @@ const authPlugin = {
                                 scmContext: user.scmContext,
                                 token: await user.unsealToken()
                             });
-                        } catch (e) {
+                        } catch (err) {
                             request.log(
                                 ['auth', 'error'],
                                 `Fails to find the user "${user.username}" in ${user.scmContext}.`
                             );
+
+                            return { isValid: false, credentials: {} };
                         }
 
                         await createDefaultCollection(user, collectionFactory);

--- a/plugins/banners/create.js
+++ b/plugins/banners/create.js
@@ -23,7 +23,11 @@ module.exports = () => ({
             const scmDisplayName = scm.getDisplayName({ scmContext });
 
             // lookup whether user is admin
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
 
             // verify user is authorized to create banners
             // return unauthorized if not system admin

--- a/plugins/banners/create.js
+++ b/plugins/banners/create.js
@@ -18,13 +18,12 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { bannerFactory } = request.server.app;
-            const { username } = request.auth.credentials;
-            const { scmContext } = request.auth.credentials;
+            const { username, scmContext, scmUserId } = request.auth.credentials;
             const { scm } = bannerFactory;
             const scmDisplayName = scm.getDisplayName({ scmContext });
 
             // lookup whether user is admin
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
 
             // verify user is authorized to create banners
             // return unauthorized if not system admin

--- a/plugins/banners/index.js
+++ b/plugins/banners/index.js
@@ -23,21 +23,20 @@ const bannerPlugin = {
          * @param  {String}        scmDisplayName Scm display name of the person
          * @return {Object}                   Details including the display name and admin status of user
          */
-        server.expose('screwdriverAdminDetails', (username, scmDisplayName) => {
+        server.expose('screwdriverAdminDetails', (username, scmDisplayName, scmUserId) => {
             // construct object with defaults to store details
             const adminDetails = {
                 isAdmin: false
             };
 
             if (scmDisplayName) {
-                const adminsList = options.admins;
+                const userDisplayName = options.authCheckById
+                    ? `${scmDisplayName}:${username}:${scmUserId}`
+                    : `${scmDisplayName}:${username}`;
+                const admins = options.authCheckById ? options.sdAdmins : options.admins;
 
-                // construct displayable username string
-                adminDetails.userDisplayName = `${scmDisplayName}:${username}`;
-
-                // Check system configuration for list of system admins
-                // set admin status true if current user is identified to be a system admin
-                if (adminsList.length > 0 && adminsList.includes(adminDetails.userDisplayName)) {
+                // Check admin
+                if (admins.length > 0 && admins.includes(userDisplayName)) {
                     adminDetails.isAdmin = true;
                 }
             }

--- a/plugins/banners/remove.js
+++ b/plugins/banners/remove.js
@@ -20,14 +20,12 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { bannerFactory } = request.server.app;
             const { id } = request.params; // id of banner to delete
-
-            const { username } = request.auth.credentials;
-            const { scmContext } = request.auth.credentials;
+            const { username, scmContext, scmUserId } = request.auth.credentials;
             const { scm } = bannerFactory;
             const scmDisplayName = scm.getDisplayName({ scmContext });
 
             // lookup whether user is admin
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
 
             // verify user is authorized to remove banners
             // return unauthorized if not system admin

--- a/plugins/banners/remove.js
+++ b/plugins/banners/remove.js
@@ -25,7 +25,11 @@ module.exports = () => ({
             const scmDisplayName = scm.getDisplayName({ scmContext });
 
             // lookup whether user is admin
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
 
             // verify user is authorized to remove banners
             // return unauthorized if not system admin

--- a/plugins/banners/update.js
+++ b/plugins/banners/update.js
@@ -25,7 +25,11 @@ module.exports = () => ({
             const scmDisplayName = scm.getDisplayName({ scmContext });
 
             // lookup whether user is admin
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
 
             // verify user is authorized to update banners
             // return unauthorized if not system admin

--- a/plugins/banners/update.js
+++ b/plugins/banners/update.js
@@ -20,13 +20,12 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { bannerFactory } = request.server.app;
             const { id } = request.params; // id of banner to update
-            const { username } = request.auth.credentials;
-            const { scmContext } = request.auth.credentials;
+            const { username, scmContext, scmUserId } = request.auth.credentials;
             const { scm } = bannerFactory;
             const scmDisplayName = scm.getDisplayName({ scmContext });
 
             // lookup whether user is admin
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
 
             // verify user is authorized to update banners
             // return unauthorized if not system admin

--- a/plugins/buildClusters/create.js
+++ b/plugins/buildClusters/create.js
@@ -18,7 +18,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { buildClusterFactory, bannerFactory } = request.server.app;
-            const { username, scmContext: userContext } = request.auth.credentials;
+            const { username, scmContext: userContext, scmUserId } = request.auth.credentials;
             const { payload } = request;
             const { managedByScrewdriver, name, scmOrganizations } = payload;
 
@@ -27,7 +27,7 @@ module.exports = () => ({
             // Check permissions
             // Must be Screwdriver admin to add Screwdriver build cluster
             const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext: payload.scmContext });
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
 
             if (!adminDetails.isAdmin) {
                 return boom.forbidden(

--- a/plugins/buildClusters/create.js
+++ b/plugins/buildClusters/create.js
@@ -27,7 +27,11 @@ module.exports = () => ({
             // Check permissions
             // Must be Screwdriver admin to add Screwdriver build cluster
             const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext: payload.scmContext });
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
 
             if (!adminDetails.isAdmin) {
                 return boom.forbidden(

--- a/plugins/buildClusters/remove.js
+++ b/plugins/buildClusters/remove.js
@@ -20,7 +20,7 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { buildClusterFactory, userFactory, bannerFactory } = request.server.app;
             const { name } = request.params;
-            const { username, scmContext } = request.auth.credentials;
+            const { username, scmContext, scmUserId } = request.auth.credentials;
             const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
 
             // Fetch the buildCluster and user models
@@ -46,7 +46,8 @@ module.exports = () => ({
 
                     const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
                         username,
-                        scmDisplayName
+                        scmDisplayName,
+                        scmUserId
                     );
 
                     if (!adminDetails.isAdmin) {

--- a/plugins/buildClusters/update.js
+++ b/plugins/buildClusters/update.js
@@ -20,7 +20,7 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { buildClusterFactory, bannerFactory } = request.server.app;
             const { name } = request.params; // name of build cluster to update
-            const { username, scmContext: userContext } = request.auth.credentials;
+            const { username, scmContext: userContext, scmUserId } = request.auth.credentials;
             const { payload } = request;
             const { managedByScrewdriver, scmOrganizations } = payload;
 
@@ -29,7 +29,7 @@ module.exports = () => ({
             // Check permissions
             // Must be Screwdriver admin to update Screwdriver build cluster
             const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext: userContext });
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
 
             if (!adminDetails.isAdmin) {
                 return boom.forbidden(

--- a/plugins/buildClusters/update.js
+++ b/plugins/buildClusters/update.js
@@ -29,7 +29,11 @@ module.exports = () => ({
             // Check permissions
             // Must be Screwdriver admin to update Screwdriver build cluster
             const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext: userContext });
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
 
             if (!adminDetails.isAdmin) {
                 return boom.forbidden(

--- a/plugins/builds/artifacts/unzip.js
+++ b/plugins/builds/artifacts/unzip.js
@@ -26,11 +26,11 @@ module.exports = config => ({
                 return h.response(data).code(200);
             }
             const buildId = req.params.id;
-            const { username, scope, scmContext } = req.auth.credentials;
+            const { username, scope, scmContext, scmUserId } = req.auth.credentials;
             const isBuild = scope.includes('build');
             const { buildFactory } = req.server.app;
             const scmDisplayName = buildFactory.scm.getDisplayName({ scmContext })
-            const adminDetails = req.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+            const adminDetails = req.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
 
             if (scope.includes('user') && !adminDetails.isAdmin) {
                 return boom.forbidden(`User ${adminDetails.userDisplayName} does not have Screwdriver administrative privileges.`)

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -93,13 +93,13 @@ async function getBuildToUpdate(id, buildFactory) {
  */
 async function validateUserPermission(build, request) {
     const { jobFactory, userFactory, bannerFactory, pipelineFactory } = request.server.app;
-    const { username, scmContext } = request.auth.credentials;
+    const { username, scmContext, scmUserId } = request.auth.credentials;
 
     const { status: desiredStatus } = request.payload;
 
     const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
     // Check if Screwdriver admin
-    const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+    const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
 
     // Check desired status
     if (adminDetails.isAdmin) {

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -47,7 +47,11 @@ module.exports = () => ({
 
             // Check permissions
             const permissions = await user.getPermissions(pipeline.scmUri);
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmContext, scmUserId);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmContext,
+                scmUserId
+            );
             const isPrOwner = hoek.reach(event, 'commit.author.username') === username;
 
             // PR author should be able to stop their own PR event

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -22,7 +22,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { eventFactory, pipelineFactory, userFactory } = request.server.app;
-            const { username, scmContext } = request.auth.credentials;
+            const { username, scmContext, scmUserId } = request.auth.credentials;
             const { isValidToken } = request.server.plugins.pipelines;
             const eventId = request.params.id;
             const { updateAdmins } = request.server.plugins.events;
@@ -47,7 +47,7 @@ module.exports = () => ({
 
             // Check permissions
             const permissions = await user.getPermissions(pipeline.scmUri);
-            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmContext);
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmContext, scmUserId);
             const isPrOwner = hoek.reach(event, 'commit.author.username') === username;
 
             // PR author should be able to stop their own PR event

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -104,7 +104,7 @@ const pipelinesPlugin = {
          * @return {Object} pipeline
          */
         server.expose('canAccessPipeline', (credentials, pipelineId, permission, app) => {
-            const { username, scmContext, scope } = credentials;
+            const { username, scmContext, scope, scmUserId } = credentials;
             const { userFactory, pipelineFactory } = app;
 
             return pipelineFactory.get(pipelineId).then(pipeline => {
@@ -141,7 +141,8 @@ const pipelinesPlugin = {
                                 const scmDisplayName = pipelineFactory.scm.getDisplayName({ scmContext });
                                 const adminDetails = server.plugins.banners.screwdriverAdminDetails(
                                     username,
-                                    scmDisplayName
+                                    scmDisplayName,
+                                    scmUserId
                                 );
 
                                 if (adminDetails.isAdmin) {

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -87,7 +87,11 @@ module.exports = () => ({
                     if (scmContext) {
                         const scmDisplayName = pipelineFactory.scm.getDisplayName({ scmContext });
 
-                        adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
+                        adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                            username,
+                            scmDisplayName,
+                            scmUserId
+                        );
                     }
 
                     if (scope.includes('user') && adminDetails && adminDetails.isAdmin) {

--- a/plugins/pipelines/list.js
+++ b/plugins/pipelines/list.js
@@ -81,13 +81,13 @@ module.exports = () => ({
             return Promise.all(pipelineArray)
                 .then(pipelineArrays => [].concat(...pipelineArrays))
                 .then(allPipelines => {
-                    const { username, scope, scmContext } = request.auth.credentials;
+                    const { username, scope, scmContext, scmUserId } = request.auth.credentials;
                     let adminDetails;
 
                     if (scmContext) {
                         const scmDisplayName = pipelineFactory.scm.getDisplayName({ scmContext });
 
-                        adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName);
+                        adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
                     }
 
                     if (scope.includes('user') && adminDetails && adminDetails.isAdmin) {

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -21,8 +21,7 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { pipelineFactory, bannerFactory } = request.server.app;
             const { userFactory } = request.server.app;
-            const { username } = request.auth.credentials;
-            const { scmContext } = request.auth.credentials;
+            const { username, scmContext, scmUserId } = request.auth.credentials;
 
             // Fetch the pipeline and user models
             return Promise.all([pipelineFactory.get(request.params.id), userFactory.get({ username, scmContext })])
@@ -57,7 +56,8 @@ module.exports = () => ({
                                 // Lookup whether user is admin
                                 const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
                                     username,
-                                    scmDisplayName
+                                    scmDisplayName,
+                                    scmUserId
                                 );
 
                                 // Allow cluster admins to remove pipeline

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -25,10 +25,12 @@ function getUserMock(user) {
     const result = {
         update: sinon.stub(),
         sealToken: sinon.stub(),
+        unsealToken: sinon.stub().returns('token'),
         getDisplayName: sinon.stub(),
         id: user.id,
         username: user.username,
-        token: user.token
+        token: user.token,
+        scmContext: user.scmContext
     };
 
     return result;
@@ -93,7 +95,8 @@ describe('auth plugin test', () => {
                     scope: ['admin:repo_hook', 'read:org', 'repo:status']
                 }
             },
-            autoDeployKeyGenerationEnabled: sinon.stub().returns(true)
+            autoDeployKeyGenerationEnabled: sinon.stub().returns(true),
+            decorateAuthor: sinon.stub()
         };
         userFactoryMock = {
             get: sinon.stub(),
@@ -335,6 +338,7 @@ describe('auth plugin test', () => {
                 });
 
                 expect(profile.username).to.contain('batman');
+                expect(profile.scmUserId).to.equal(1312);
                 expect(profile.scmContext).to.contain('github:github.com');
                 expect(profile.scope).to.contain('user');
                 expect(profile.scope).to.contain('admin');
@@ -344,12 +348,14 @@ describe('auth plugin test', () => {
             it('does not add admin scope for non-admins', () => {
                 const profile = server.plugins.auth.generateProfile({
                     username: 'robin',
+                    scmUserId: 1357,
                     scmContext: 'github:mygithub.com',
                     scope: ['user'],
                     metadata: {}
                 });
 
                 expect(profile.username).to.contain('robin');
+                expect(profile.scmUserId).to.equal(1357);
                 expect(profile.scmContext).to.contain('github:mygithub.com');
                 expect(profile.scope).to.contain('user');
                 expect(profile.scope).to.not.contain('admin');
@@ -359,12 +365,14 @@ describe('auth plugin test', () => {
             it('does not add admin scope for admins without SCM user id', () => {
                 const profile = server.plugins.auth.generateProfile({
                     username: 'batman',
+                    scmUserId: 1359,
                     scmContext: 'github:mygithub.com',
                     scope: ['user'],
                     metadata: {}
                 });
 
                 expect(profile.username).to.contain('batman');
+                expect(profile.scmUserId).to.equal(1359);
                 expect(profile.scmContext).to.contain('github:mygithub.com');
                 expect(profile.scope).to.contain('user');
                 expect(profile.scope).to.not.contain('admin');
@@ -405,6 +413,7 @@ describe('auth plugin test', () => {
                 });
 
                 expect(profile.username).to.contain('batman');
+                expect(profile.scmUserId).to.equal(1312);
                 expect(profile.scmContext).to.contain('github:github.com');
                 expect(profile.scope).to.contain('user');
                 expect(profile.scope).to.contain('admin');
@@ -414,12 +423,14 @@ describe('auth plugin test', () => {
             it('does not add admin scope for non-admins', () => {
                 const profile = server.plugins.auth.generateProfile({
                     username: 'robin',
+                    scmUserId: 1357,
                     scmContext: 'github:mygithub.com',
                     scope: ['user'],
                     metadata: {}
                 });
 
                 expect(profile.username).to.contain('robin');
+                expect(profile.scmUserId).to.equal(1357);
                 expect(profile.scmContext).to.contain('github:mygithub.com');
                 expect(profile.scope).to.contain('user');
                 expect(profile.scope).to.not.contain('admin');
@@ -429,12 +440,14 @@ describe('auth plugin test', () => {
             it('adds admin scope for admins without SCM user id', () => {
                 const profile = server.plugins.auth.generateProfile({
                     username: 'batman',
+                    scmUserId: 1359,
                     scmContext: 'github:mygithub.com',
                     scope: ['user'],
                     metadata: {}
                 });
 
                 expect(profile.username).to.contain('batman');
+                expect(profile.scmUserId).to.equal(1359);
                 expect(profile.scmContext).to.contain('github:mygithub.com');
                 expect(profile.scope).to.contain('user');
                 expect(profile.scope).to.contain('admin');
@@ -1029,7 +1042,8 @@ describe('auth plugin test', () => {
                                 {
                                     username: 'robin',
                                     scope: ['user'],
-                                    environment: 'beta'
+                                    environment: 'beta',
+                                    scmUserId: 1579
                                 },
                                 jwtPrivateKey,
                                 {
@@ -1046,6 +1060,7 @@ describe('auth plugin test', () => {
                     assert.equal(reply.statusCode, 200, 'Login route should be available');
                     assert.ok(reply.result.token, 'Token not returned');
                     expect(reply.result.token).to.be.a.jwt.and.deep.include({
+                        scmUserId: 1579,
                         username: 'robin',
                         scope: ['user'],
                         environment: 'beta'
@@ -1054,75 +1069,33 @@ describe('auth plugin test', () => {
 
         it('returns user signed token given an API access token', () => {
             tokenMock.userId = id;
-            server
-                .inject({
-                    url: `/auth/token?api_token=${apiKey}`,
-                    auth: {
-                        credentials: {
-                            username: 'robin',
-                            scope: ['user'],
-                            token: jwt.sign(
-                                {
-                                    username: 'robin',
-                                    scope: ['user']
-                                },
-                                jwtPrivateKey,
-                                {
-                                    algorithm: 'RS256',
-                                    expiresIn: '2h',
-                                    jwtid: 'abc'
-                                }
-                            )
-                        },
-                        strategy: ['token']
-                    }
-                })
-                .then(reply => {
-                    assert.equal(reply.statusCode, 200, 'Login route should be available');
-                    assert.ok(reply.result.token, 'Token not returned');
-                    expect(reply.result.token).to.be.a.jwt.and.deep.include({
-                        username: 'robin',
-                        scope: ['user']
-                    });
+            scm.decorateAuthor.resolves({ id: 1315 });
+            collectionFactoryMock.list.resolves([[1], [2]]);
+
+            return server.inject({ url: `/auth/token?api_token=${apiKey}` }).then(reply => {
+                assert.equal(reply.statusCode, 200, 'Login route should be available');
+                assert.ok(reply.result.token, 'Token not returned');
+                expect(reply.result.token).to.be.a.jwt.and.deep.include({
+                    scmUserId: 1315,
+                    username: 'batman',
+                    scope: ['user'],
+                    scmContext: 'github:github.com'
                 });
+            });
         });
 
         it('returns pipeline signed token given an API access token', () => {
             tokenMock.pipelineId = pipelineId;
 
-            server
-                .inject({
-                    url: `/auth/token?api_token=${apiKey}`,
-                    auth: {
-                        credentials: {
-                            username: 'robin',
-                            scope: ['pipeline'],
-                            token: jwt.sign(
-                                {
-                                    username: 'robin',
-                                    pipelineId: 1,
-                                    scope: ['pipeline']
-                                },
-                                jwtPrivateKey,
-                                {
-                                    algorithm: 'RS256',
-                                    expiresIn: '2h',
-                                    jwtid: 'abc'
-                                }
-                            )
-                        },
-                        strategy: ['token']
-                    }
-                })
-                .then(reply => {
-                    assert.equal(reply.statusCode, 200, 'Login route should be available');
-                    assert.ok(reply.result.token, 'Token not returned');
-                    expect(reply.result.token).to.be.a.jwt.and.deep.include({
-                        username: 'robin',
-                        scope: ['pipeline'],
-                        pipelineId: 1
-                    });
+            return server.inject({ url: `/auth/token?api_token=${apiKey}` }).then(reply => {
+                assert.equal(reply.statusCode, 200, 'Login route should be available');
+                assert.ok(reply.result.token, 'Token not returned');
+                expect(reply.result.token).to.be.a.jwt.and.deep.include({
+                    username: 'batman',
+                    scope: ['pipeline'],
+                    pipelineId: 12345
                 });
+            });
         });
 
         it('fails to issue a jwt given an invalid application auth token', () => {

--- a/test/plugins/buildClusters.test.js
+++ b/test/plugins/buildClusters.test.js
@@ -31,12 +31,14 @@ const getMockBuildClusters = buildClusters => {
 
 describe('buildCluster plugin test', () => {
     const username = 'myself';
+    const scmUserId = 123;
     const scmContext = 'github:github.com';
     const scmDisplayName = 'github';
     const buildClusterId = 12345;
     const name = 'iOS';
     const credentials = {
         scope: ['user'],
+        scmUserId,
         username,
         scmContext
     };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The new sd admins format was introduced by this PR.
https://github.com/screwdriver-cd/screwdriver/pull/2854

But it cannot authenticate API token has admin permission.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix to authenticate correctly even when using API tokens.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Please review the following PRs first.

- https://github.com/screwdriver-cd/data-schema/pull/518
- https://github.com/screwdriver-cd/scm-github/pull/216

Issue

- https://github.com/screwdriver-cd/screwdriver/issues/2892

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
