### PR TITLE
fix: Fix Remote join restart case

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -931,7 +931,11 @@ const buildsPlugin = {
                         .map(j => {
                             const existingBuild = externalGroupBuilds.find(b => b.jobId === nextJobs[j].id);
 
-                            return existingBuild && existingBuild.status !== 'CREATED' ? existingBuild : null;
+                            return existingBuild &&
+                                existingBuild.status !== 'CREATED' &&
+                                !existingBuild.parentBuildId.includes(current.build.id)
+                                ? existingBuild
+                                : null;
                         })
                         .filter(b => b !== null);
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -3585,7 +3585,7 @@ describe('build plugin test', () => {
                         groupEventId: '8889',
                         parentBuildId: 12345,
                         parentBuilds: {
-                            123: { eventId: '8888', jobs: { a: 12345, c: 45678 } }
+                            123: { eventId: '8888', jobs: { a: 12344, c: 45678 } }
                         },
                         parentEventId: '8888',
                         pipelineId: '2',
@@ -3652,10 +3652,11 @@ describe('build plugin test', () => {
                         },
                         {
                             id: 999,
+                            parentBuildId: [12344, 45678],
                             parentBuilds: {
                                 123: {
                                     eventId: '8888',
-                                    jobs: { a: 12345, c: 45678 }
+                                    jobs: { a: 12344, c: 45678 }
                                 }
                             },
                             jobId: 3,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In remote join case, an unintentional build was being executed twice.
When the two builds triggering Remote Join are completed almost simultaneously, `PUT /v4/builds/{id}` is processed at the same time.
The process in `PUT /v4/builds/{id}` determines whether the next build is triggered after the build status is updated, so if the process in `PUT /v4/builds/{id}` is performed at about the same time, the next build will be triggered at the time the previous build is processed. The next build will be triggered at the time of the earlier build, and the later build will be judged to be a Restart case because the next build has already been triggered. The later build is judged to be a Restart case, another Event is created and an unintentional build is executed.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In the case of Restart, the build being processed is not included in parentBuildId, so that is included in the determination of whether or not it is a Restart.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
