### PR TITLE
fix: webhook returns 4xx error code when parseUrl failed

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -2,6 +2,8 @@
 
 const joi = require('joi');
 const logger = require('screwdriver-logger');
+const boom = require('@hapi/boom');
+const { ValidationError } = require('joi');
 const { startHookEvent } = require('./helper');
 
 const DEFAULT_MAX_BYTES = 1048576;
@@ -97,7 +99,11 @@ const webhooksPlugin = {
                     } catch (err) {
                         logger.error(`[${hookId}]: ${err}`);
 
-                        throw err;
+                        if (err instanceof ValidationError) {
+                            throw boom.badData(err);
+                        }
+
+                        throw boom.boomify(err, { statusCode: err.statusCode });
                     }
                 }
             }

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
 const rewire = require('rewire');
 const { assert } = chai;
+const { ValidationError } = require('joi');
 
 chai.use(require('chai-as-promised'));
 
@@ -220,6 +221,25 @@ describe('webhooks plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 500);
+            });
+        });
+
+        it('returns 404 when repository does not found', () => {
+            const testError = new Error('Cannot find repository');
+
+            testError.statusCode = 404;
+            pipelineFactoryMock.scm.parseHook.rejects(testError);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 422 when webhook has wrong value', () => {
+            pipelineFactoryMock.scm.parseHook.rejects(new ValidationError('Invalid value'));
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 422);
             });
         });
     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The error status of parseUrl when `POST /webhook` is only 500.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The parseUrl even throws error when the webhook is correct.

ex1: If PR created from branch with long name (more than 128), parseUrl throws `ValidationError` and return 500 response.

ex2: If PR created from private repository, parseUrl throws 404 error. But 500 response returned.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
