### PR TITLE
fix: Fixed PR delete fails and PR remains unless manually closed

### DIFF
--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -20,11 +20,6 @@ Before(
         this.jobName = 'main';
         this.pullRequestNumber = null;
         this.pipelines = {};
-
-        return Promise.all([
-            github.removeBranch(this.repoOrg, this.repoName, 'test-branch-PR'),
-            github.removeBranch('screwdriver-cd', this.repoName, 'test-branch-PR')
-        ]).catch(err => Assert.strictEqual(404, err.status));
     }
 );
 
@@ -58,7 +53,10 @@ When(
 
         this.sourceOrg = sourceOrg;
         this.sourceBranch = sourceBranch;
-
+        
+        await github.removeBranch(this.sourceOrg, this.repoName, this.sourceBranch)
+            .catch(err => Assert.strictEqual(404, err.status));
+        
         await github
             .createBranch(this.sourceBranch, this.sourceOrg, this.repoName)
             .catch(() => Assert.fail('Failed to create branch.'));

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -20,7 +20,7 @@ Before(
         this.jobName = 'main';
         this.pullRequestNumber = null;
         this.pipelines = {};
-        
+
         return Promise.all([
             github.removeBranch(this.repoOrg, this.repoName, 'test-branch-PR'),
             github.removeBranch('screwdriver-cd', this.repoName, 'test-branch-PR')

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -20,6 +20,7 @@ Before(
         this.jobName = 'main';
         this.pullRequestNumber = null;
         this.pipelines = {};
+        
         return Promise.all([
             github.removeBranch(this.repoOrg, this.repoName, 'test-branch-PR'),
             github.removeBranch('screwdriver-cd', this.repoName, 'test-branch-PR')

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Assert = require('chai').assert;
-const { Before, Given, When, Then, After } = require('@cucumber/cucumber');
+const { Before, Given, When, Then } = require('@cucumber/cucumber');
 const github = require('../support/github');
 const sdapi = require('../support/sdapi');
 
@@ -20,6 +20,10 @@ Before(
         this.jobName = 'main';
         this.pullRequestNumber = null;
         this.pipelines = {};
+        return Promise.all([
+            github.removeBranch(this.repoOrg, this.repoName, 'test-branch-PR'),
+            github.removeBranch('screwdriver-cd', this.repoName, 'test-branch-PR')
+        ]).catch(err => Assert.strictEqual(404, err.status));
     }
 );
 
@@ -49,8 +53,7 @@ When(
         timeout: TIMEOUT
     },
     async function step(sourceOrg) {
-        const postfix = new Date().getTime().toString();
-        const sourceBranch = `test-branch-${postfix}`;
+        const sourceBranch = 'test-branch-PR';
 
         this.sourceOrg = sourceOrg;
         this.sourceBranch = sourceBranch;
@@ -134,21 +137,5 @@ Then(
         });
 
         Assert.equal(build.body.length, 0, 'Unexpected job was triggered.');
-    }
-);
-
-After(
-    {
-        tags: '@restrict-pr'
-    },
-    function hook() {
-        github
-            .closePullRequest(this.repoOrg, this.repoName, this.pullRequestNumber)
-            .then(() => {
-                github.removeBranch(this.sourceOrg, this.repoName, this.sourceBranch);
-            })
-            .catch(() => {
-                Assert.fail('Failed to close Pull Request or remove branch.');
-            });
     }
 );

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -53,10 +53,11 @@ When(
 
         this.sourceOrg = sourceOrg;
         this.sourceBranch = sourceBranch;
-        
-        await github.removeBranch(this.sourceOrg, this.repoName, this.sourceBranch)
+
+        await github
+            .removeBranch(this.sourceOrg, this.repoName, this.sourceBranch)
             .catch(err => Assert.strictEqual(404, err.status));
-        
+
         await github
             .createBranch(this.sourceBranch, this.sourceOrg, this.repoName)
             .catch(() => Assert.fail('Failed to create branch.'));

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -108,7 +108,8 @@ When(
         const sourceBranch = `${branch}-PR`;
         const targetBranch = 'master';
 
-        await github.removeBranch(this.repoOrg, this.repoName, sourceBranch)
+        await github
+            .removeBranch(this.repoOrg, this.repoName, sourceBranch)
             .catch(err => Assert.strictEqual(404, err.status));
 
         return github
@@ -134,7 +135,8 @@ When(
     async function step(branch) {
         const sourceBranch = `${branch}-PR`;
 
-        await github.removeBranch(this.repoOrg, this.repoName, sourceBranch)
+        await github
+            .removeBranch(this.repoOrg, this.repoName, sourceBranch)
             .catch(err => Assert.strictEqual(404, err.status));
 
         return github

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -11,7 +11,7 @@ const WAIT_TIME = 3;
 
 Before(
     {
-        tags: '@workflow and (not @workflow-PR) and (not @workflow-chainPR)'        
+        tags: '@workflow and (not @workflow-PR) and (not @workflow-chainPR)'
     },
     function hook() {
         this.repoOrg = this.testOrg;


### PR DESCRIPTION
## Context
The PR used for the test will be closed after the test is completed.
However, if it fails at that time, the PR will remain unless it is manually closed.

## Objective

Fix PR test to avoid them remaining.

## References

https://github.com/screwdriver-cd-test/functional-restrict-pr/pulls

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
