### PR TITLE
feat: add previous branch name into audit log

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -88,6 +88,7 @@ module.exports = () => ({
 
             let token;
             let formattedCheckoutUrl;
+            const oldPipelineConfig = { ...oldPipeline };
 
             if (checkoutUrl || rootDir) {
                 formattedCheckoutUrl = formatCheckoutUrl(request.payload.checkoutUrl);
@@ -141,7 +142,7 @@ module.exports = () => ({
 
             if (checkoutUrl || rootDir) {
                 logger.info(
-                    `[Audit] user ${user.username}:${scmContext} updates the scmUri for pipelineID:${id} to ${oldPipeline.scmUri}.`
+                    `[Audit] user ${user.username}:${scmContext} updates the scmUri for pipelineID:${id} to ${oldPipeline.scmUri} from ${oldPipelineConfig.scmUri}.`
                 );
             }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Audit logs was added in #2700 .
But logs that users update checkout URL does not include previous settings.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will add previous SCM URI into audit log.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue
https://github.com/screwdriver-cd/screwdriver/issues/2700

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
