### PR TITLE
fix: Fix job triggers not working properly depending on conditions

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -851,6 +851,8 @@ const buildsPlugin = {
 
                             return (await existNextBuild.update()).start();
                         }
+
+                        return existNextBuild;
                     }
 
                     return createInternalBuild(internalBuildConfig);

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -845,8 +845,12 @@ const buildsPlugin = {
                         jobId: nextJob.id
                     });
 
-                    if (['CREATED', null, undefined].includes(existNextBuild.status)) {
-                        existNextBuild.start();
+                    if (existNextBuild) {
+                        if (['CREATED', null, undefined].includes(existNextBuild.status)) {
+                            existNextBuild.status = 'QUEUED';
+
+                            return (await existNextBuild.update()).start();
+                        }
                     }
 
                     return createInternalBuild(internalBuildConfig);

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -834,18 +834,22 @@ const buildsPlugin = {
                         parentBuilds,
                         parentBuildId: current.build.id
                     };
-                    let newBuild;
 
-                    try {
-                        newBuild = await createInternalBuild(internalBuildConfig);
-                    } catch (err) {
-                        logger.error(
-                            `Error in triggerNextJobs - pipeline:${current.pipeline.id}-${nextJobName} event:${event.id} `,
-                            err
-                        );
+                    const nextJob = await jobFactory.get({
+                        name: nextJobName,
+                        pipelineId: current.pipeline.id
+                    });
+
+                    const existNextBuild = await buildFactory.get({
+                        eventId: current.event.id,
+                        jobId: nextJob.id
+                    });
+
+                    if (['CREATED', null, undefined].includes(existNextBuild.status)) {
+                        existNextBuild.start();
                     }
 
-                    return newBuild;
+                    return createInternalBuild(internalBuildConfig);
                 }
 
                 logger.info(`Fetching finished builds for event ${event.id}`);

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -548,9 +548,9 @@ async function handleNewBuild({ done, hasFailure, newBuild, jobName, pipelineId 
     // All join builds finished successfully and it's clear that a new build has not been started before.
     // Start new build.
     newBuild.status = 'QUEUED';
-    const queuedBuild = await newBuild.update();
+    await newBuild.update();
 
-    return queuedBuild.start();
+    return newBuild.start();
 }
 
 /**
@@ -852,9 +852,9 @@ const buildsPlugin = {
                     }
 
                     existNextBuild.status = 'QUEUED';
-                    const queuedBuild = await existNextBuild.update();
+                    await existNextBuild.update();
 
-                    return queuedBuild.start();
+                    return existNextBuild.start();
                 }
 
                 logger.info(`Fetching finished builds for event ${event.id}`);


### PR DESCRIPTION
## Context
Currently, it has been observed that the trigger is not functioning correctly under certain conditions. The conditions are as follows: The numbers indicate the order of execution. S = Succeeded, F = Failed

1. requires [S1, ~S2, F3]
It seems that the next build starts due to the success of S2 without waiting for the result of F3. However, since the build has already been created at S1, S2 fails to create the next build and cannot start the job.
![スクリーンショット 2023-08-04 16 23 17](https://github.com/screwdriver-cd/screwdriver/assets/138551445/95a3428e-a46b-4ecf-842b-06b0052a8fda)

2. requires [~S1, F2, S3] 
After the success of S1, the build is created and started. However, the failure of F2 and S3 trigger results in the removal of the build created by S1. Therefore, causing the next build will be deleted.
![スクリーンショット 2023-08-04 16 23 06](https://github.com/screwdriver-cd/screwdriver/assets/138551445/083c9cdd-1068-4804-a132-17f3c9bea865)

3. requires [~S1, ~S2]
In this case, the operation works, but an error occurs when trying to create a build with a duplicate key in the database upon the success of S2.

## Objective
Fixes the above problems.
The specific fixes are as follows.
1. Prevent multiple calls to the create build function by checking in advance whether the next build exists before the trigger's build creation process.
2. If the trigger meets the execution conditions when the next build already exists, the existing build is executed as is.
3. When deleting a build, add a condition that it is before execution.
4. Fix the test according to the above modifications.

## References


## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
