### PR TITLE
Revert "fix: Fix job triggers not working properly depending on conditions"

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1467,7 +1467,6 @@ describe('build plugin test', () => {
                     };
                     buildMock.eventId = '8888';
                     eventMock.sha = testBuild.sha;
-                    buildFactoryMock.get.withArgs({ eventId: eventMock.id, jobId: publishJobId }).returns(null);
                 });
 
                 it('triggers next job in the chainPR workflow', () => {
@@ -1799,13 +1798,6 @@ describe('build plugin test', () => {
                         parentBuilds: { 123: { eventId: '8888', jobs: { a: 12345, d: 123456 } } },
                         jobId: 3
                     };
-
-                    buildFactoryMock.get
-                        .withArgs({ eventId: jobBconfig.eventId, jobId: jobBconfig.jobId })
-                        .returns(null);
-                    buildFactoryMock.get
-                        .withArgs({ eventId: jobCconfig.eventId, jobId: jobCconfig.jobId })
-                        .returns(null);
                 });
 
                 it('triggers if not a join', () => {
@@ -2010,51 +2002,6 @@ describe('build plugin test', () => {
                     return server.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);
                         assert.calledOnce(buildC.remove);
-                    });
-                });
-
-                it('not delete build if it was queued before, and join has some failures', () => {
-                    eventMock.workflowGraph.edges = [
-                        { src: '~pr', dest: 'a' },
-                        { src: '~commit', dest: 'a' },
-                        { src: 'a', dest: 'c', join: true },
-                        { src: 'd', dest: 'c', join: true }
-                    ];
-
-                    const buildC = {
-                        jobId: 3, // job c was previously created
-                        remove: sinon.stub().resolves(null),
-                        eventId: '8888',
-                        id: 123455,
-                        parentBuilds: {},
-                        status: 'QUEUED'
-                    };
-
-                    buildC.update = sinon.stub().resolves(buildC);
-
-                    buildMocks = [
-                        {
-                            jobId: 1,
-                            status: 'SUCCESS',
-                            id: 12345,
-                            eventId: '8888'
-                        },
-                        {
-                            jobId: 4,
-                            status: 'FAILURE',
-                            id: 123456,
-                            eventId: '8888'
-                        },
-                        buildC
-                    ];
-
-                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
-                    buildFactoryMock.get.withArgs(123456).resolves(buildMocks[1]);
-                    buildFactoryMock.get.withArgs(123455).resolves(buildC);
-
-                    return server.inject(options).then(() => {
-                        assert.notCalled(buildFactoryMock.create);
-                        assert.notCalled(buildC.remove);
                     });
                 });
 
@@ -2294,13 +2241,6 @@ describe('build plugin test', () => {
                         port: 12345,
                         host: 'localhost'
                     });
-
-                    buildFactoryMock.get
-                        .withArgs({ eventId: jobBconfig.eventId, jobId: jobBconfig.jobId })
-                        .returns(null);
-                    buildFactoryMock.get
-                        .withArgs({ eventId: jobCconfig.eventId, jobId: jobCconfig.jobId })
-                        .returns(null);
 
                     newServer.app = {
                         buildFactory: buildFactoryMock,
@@ -2581,62 +2521,6 @@ describe('build plugin test', () => {
                             }
                         };
                         assert.calledWith(buildFactoryMock.create, jobBconfig);
-                    });
-                });
-
-                it('or triggers if next build is already exists', () => {
-                    eventMock.workflowGraph.edges = [
-                        { src: '~pr', dest: 'a' },
-                        { src: '~commit', dest: 'a' },
-                        { src: 'a', dest: 'b' },
-                        { src: 'c', dest: 'b', join: true },
-                        { src: 'd', dest: 'b', join: true }
-                    ];
-
-                    const buildB = {
-                        jobId: jobB.id,
-                        id: 3,
-                        status: 'CREATED',
-                        start: sinon.stub().resolves(),
-                        update: sinon.stub().resolves()
-                    };
-
-                    jobFactoryMock.get.withArgs({ name: 'b', pipelineId }).returns(jobB);
-                    buildFactoryMock.get.withArgs({ eventId: '8888', jobId: buildB.jobId }).returns(buildB);
-
-                    return newServer.inject(options).then(() => {
-                        assert.notCalled(buildFactoryMock.create);
-                        assert.calledOnce(buildB.start);
-                        assert.calledOnce(buildB.update);
-                        assert.equal(buildB.status, 'QUEUED');
-                    });
-                });
-
-                it('or triggers if next build is already queued', () => {
-                    eventMock.workflowGraph.edges = [
-                        { src: '~pr', dest: 'a' },
-                        { src: '~commit', dest: 'a' },
-                        { src: 'a', dest: 'b' },
-                        { src: 'c', dest: 'b', join: true },
-                        { src: 'd', dest: 'b', join: true }
-                    ];
-
-                    const buildB = {
-                        jobId: jobB.id,
-                        id: 3,
-                        status: 'QUEUED',
-                        start: sinon.stub().resolves(),
-                        update: sinon.stub().resolves()
-                    };
-
-                    jobFactoryMock.get.withArgs({ name: 'b', pipelineId }).returns(jobB);
-                    buildFactoryMock.get.withArgs({ eventId: '8888', jobId: buildB.jobId }).returns(buildB);
-
-                    return newServer.inject(options).then(() => {
-                        assert.notCalled(buildFactoryMock.create);
-                        assert.notCalled(buildB.start);
-                        assert.notCalled(buildB.update);
-                        assert.equal(buildB.status, 'QUEUED');
                     });
                 });
 


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#2908

@yakanechi @itleigns We are noticing something weird, multiple builds are now being created in a join scenario with OR condition and they extra builds end up changing to Collapsed builds.

This event https://cd.screwdriver.cd/pipelines/10293/events/765417 has a COLLAPSED status. Because the join job `join` in the OR condition is getting created multiple times in same event. 

