### PR TITLE
Revert "Revert "fix: Fix job triggers not working properly depending on conditions""

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -528,27 +528,29 @@ async function getParentBuildStatus({ newBuild, joinListNames, pipelineId, build
  * @return {Promise}                The newly updated/created build
  */
 async function handleNewBuild({ done, hasFailure, newBuild, jobName, pipelineId }) {
-    if (done) {
-        // Delete new build since previous build failed
-        if (hasFailure) {
-            logger.info(
-                `Failure occurred in upstream job, removing new build - build:${newBuild.id} pipeline:${pipelineId}-${jobName} event:${newBuild.eventId} `
-            );
-            await newBuild.remove();
-
-            return null;
-        }
-
-        // If all join builds finished successfully and it's clear that a new build has not been started before, start new build
-        if (['CREATED', null, undefined].includes(newBuild.status)) {
-            newBuild.status = 'QUEUED';
-            const queuedBuild = await newBuild.update();
-
-            return queuedBuild.start();
-        }
+    if (!done) {
+        return null;
+    }
+    if (!['CREATED', null, undefined].includes(newBuild.status)) {
+        return null;
     }
 
-    return null;
+    // Delete new build since previous build failed
+    if (hasFailure) {
+        logger.info(
+            `Failure occurred in upstream job, removing new build - build:${newBuild.id} pipeline:${pipelineId}-${jobName} event:${newBuild.eventId} `
+        );
+        await newBuild.remove();
+
+        return null;
+    }
+
+    // All join builds finished successfully and it's clear that a new build has not been started before.
+    // Start new build.
+    newBuild.status = 'QUEUED';
+    await newBuild.update();
+
+    return newBuild.start();
 }
 
 /**
@@ -830,18 +832,29 @@ const buildsPlugin = {
                         parentBuilds,
                         parentBuildId: current.build.id
                     };
-                    let newBuild;
 
-                    try {
-                        newBuild = await createInternalBuild(internalBuildConfig);
-                    } catch (err) {
-                        logger.error(
-                            `Error in triggerNextJobs - pipeline:${current.pipeline.id}-${nextJobName} event:${event.id} `,
-                            err
-                        );
+                    const nextJob = await jobFactory.get({
+                        name: nextJobName,
+                        pipelineId: current.pipeline.id
+                    });
+
+                    const existNextBuild = await buildFactory.get({
+                        eventId: current.event.id,
+                        jobId: nextJob.id
+                    });
+
+                    if (existNextBuild === null) {
+                        return createInternalBuild(internalBuildConfig);
                     }
 
-                    return newBuild;
+                    if (!['CREATED', null, undefined].includes(existNextBuild.status)) {
+                        return existNextBuild;
+                    }
+
+                    existNextBuild.status = 'QUEUED';
+                    await existNextBuild.update();
+
+                    return existNextBuild.start();
                 }
 
                 logger.info(`Fetching finished builds for event ${event.id}`);

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1467,6 +1467,7 @@ describe('build plugin test', () => {
                     };
                     buildMock.eventId = '8888';
                     eventMock.sha = testBuild.sha;
+                    buildFactoryMock.get.withArgs({ eventId: eventMock.id, jobId: publishJobId }).returns(null);
                 });
 
                 it('triggers next job in the chainPR workflow', () => {
@@ -1798,6 +1799,13 @@ describe('build plugin test', () => {
                         parentBuilds: { 123: { eventId: '8888', jobs: { a: 12345, d: 123456 } } },
                         jobId: 3
                     };
+
+                    buildFactoryMock.get
+                        .withArgs({ eventId: jobBconfig.eventId, jobId: jobBconfig.jobId })
+                        .returns(null);
+                    buildFactoryMock.get
+                        .withArgs({ eventId: jobCconfig.eventId, jobId: jobCconfig.jobId })
+                        .returns(null);
                 });
 
                 it('triggers if not a join', () => {
@@ -2002,6 +2010,51 @@ describe('build plugin test', () => {
                     return server.inject(options).then(() => {
                         assert.notCalled(buildFactoryMock.create);
                         assert.calledOnce(buildC.remove);
+                    });
+                });
+
+                it('not delete build if it was queued before, and join has some failures', () => {
+                    eventMock.workflowGraph.edges = [
+                        { src: '~pr', dest: 'a' },
+                        { src: '~commit', dest: 'a' },
+                        { src: 'a', dest: 'c', join: true },
+                        { src: 'd', dest: 'c', join: true }
+                    ];
+
+                    const buildC = {
+                        jobId: 3, // job c was previously created
+                        remove: sinon.stub().resolves(null),
+                        eventId: '8888',
+                        id: 123455,
+                        parentBuilds: {},
+                        status: 'QUEUED'
+                    };
+
+                    buildC.update = sinon.stub().resolves(buildC);
+
+                    buildMocks = [
+                        {
+                            jobId: 1,
+                            status: 'SUCCESS',
+                            id: 12345,
+                            eventId: '8888'
+                        },
+                        {
+                            jobId: 4,
+                            status: 'FAILURE',
+                            id: 123456,
+                            eventId: '8888'
+                        },
+                        buildC
+                    ];
+
+                    buildFactoryMock.getLatestBuilds.resolves(buildMocks);
+                    buildFactoryMock.get.withArgs(123456).resolves(buildMocks[1]);
+                    buildFactoryMock.get.withArgs(123455).resolves(buildC);
+
+                    return server.inject(options).then(() => {
+                        assert.notCalled(buildFactoryMock.create);
+                        assert.notCalled(buildC.remove);
                     });
                 });
 
@@ -2241,6 +2294,13 @@ describe('build plugin test', () => {
                         port: 12345,
                         host: 'localhost'
                     });
+
+                    buildFactoryMock.get
+                        .withArgs({ eventId: jobBconfig.eventId, jobId: jobBconfig.jobId })
+                        .returns(null);
+                    buildFactoryMock.get
+                        .withArgs({ eventId: jobCconfig.eventId, jobId: jobCconfig.jobId })
+                        .returns(null);
 
                     newServer.app = {
                         buildFactory: buildFactoryMock,
@@ -2521,6 +2581,62 @@ describe('build plugin test', () => {
                             }
                         };
                         assert.calledWith(buildFactoryMock.create, jobBconfig);
+                    });
+                });
+
+                it('or triggers if next build is already exists', () => {
+                    eventMock.workflowGraph.edges = [
+                        { src: '~pr', dest: 'a' },
+                        { src: '~commit', dest: 'a' },
+                        { src: 'a', dest: 'b' },
+                        { src: 'c', dest: 'b', join: true },
+                        { src: 'd', dest: 'b', join: true }
+                    ];
+
+                    const buildB = {
+                        jobId: jobB.id,
+                        id: 3,
+                        status: 'CREATED',
+                        start: sinon.stub().resolves(),
+                        update: sinon.stub().resolves()
+                    };
+
+                    jobFactoryMock.get.withArgs({ name: 'b', pipelineId }).returns(jobB);
+                    buildFactoryMock.get.withArgs({ eventId: '8888', jobId: buildB.jobId }).returns(buildB);
+
+                    return newServer.inject(options).then(() => {
+                        assert.notCalled(buildFactoryMock.create);
+                        assert.calledOnce(buildB.start);
+                        assert.calledOnce(buildB.update);
+                        assert.equal(buildB.status, 'QUEUED');
+                    });
+                });
+
+                it('or triggers if next build is already queued', () => {
+                    eventMock.workflowGraph.edges = [
+                        { src: '~pr', dest: 'a' },
+                        { src: '~commit', dest: 'a' },
+                        { src: 'a', dest: 'b' },
+                        { src: 'c', dest: 'b', join: true },
+                        { src: 'd', dest: 'b', join: true }
+                    ];
+
+                    const buildB = {
+                        jobId: jobB.id,
+                        id: 3,
+                        status: 'QUEUED',
+                        start: sinon.stub().resolves(),
+                        update: sinon.stub().resolves()
+                    };
+
+                    jobFactoryMock.get.withArgs({ name: 'b', pipelineId }).returns(jobB);
+                    buildFactoryMock.get.withArgs({ eventId: '8888', jobId: buildB.jobId }).returns(buildB);
+
+                    return newServer.inject(options).then(() => {
+                        assert.notCalled(buildFactoryMock.create);
+                        assert.notCalled(buildB.start);
+                        assert.notCalled(buildB.update);
+                        assert.equal(buildB.status, 'QUEUED');
                     });
                 });
 


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#2914

So the  revert was not needed, since the original change never made it to prod. and the duplicate collapsed builds is not caused by that. 