### PR TITLE
fix: Refixed PR delete fails and PR remains unless manually closed

### DIFF
--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -457,22 +457,6 @@ Then(
 
 After(
     {
-        tags: '@workflow-chainPR or @workflow-PR'
-    },
-    function hook() {
-        github
-            .closePullRequest(this.repoOrg, this.repoName, this.pullRequestNumber)
-            .then(() => {
-                github.removeBranch(this.repoOrg, this.repoName, this.branch);
-            })
-            .catch(() => {
-                Assert.fail('Failed to close Pull Request or remove branch.');
-            });
-    }
-);
-
-After(
-    {
         tags: '@workflow',
         timeout: TIMEOUT
     },


### PR DESCRIPTION
## Context
In the PR of #2899, In restrict-pr, the after function was removed, but workflow forgot to remove it.

## Objective
Delete after functions that I forgot to delete.

## References
https://github.com/screwdriver-cd/screwdriver/pull/2899

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
