### PR TITLE
feat(2135): Fix templateTags tests to align to the new data schema

### DIFF
--- a/test/plugins/data/templateTags.json
+++ b/test/plugins/data/templateTags.json
@@ -2,11 +2,13 @@
     "id": 7969,
     "name": "screwdriver/build",
     "tag": "stable",
-    "version": "0.0.1"
+    "version": "0.0.1",
+    "templateType": "JOB"
 },
 {
     "id": 7970,
     "name": "screwdriver/build",
     "tag": "latest",
-    "version": "1.0.2"
+    "version": "1.0.2",
+    "templateType": "JOB"
 }]


### PR DESCRIPTION
## Context

PR https://github.com/screwdriver-cd/screwdriver/issues/2135 added a field `templateType` to `templateTag` schema.
This new field is non-nullable with default was as 'JOB'.

## Objective

Update mock data for tests to include the new field

## References

https://github.com/screwdriver-cd/screwdriver/issues/2135

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
