### PR TITLE
feat(2135): Set templateType filter while getting template tag from DB

### DIFF
--- a/plugins/templates/createTag.js
+++ b/plugins/templates/createTag.js
@@ -30,7 +30,7 @@ module.exports = () => ({
             return Promise.all([
                 pipelineFactory.get(pipelineId),
                 templateFactory.get({ name, version }),
-                templateTagFactory.get({ name, tag })
+                templateTagFactory.get({ name, tag, templateType: 'JOB' })
             ])
                 .then(([pipeline, template, templateTag]) => {
                     // If template doesn't exist, throw error

--- a/test/plugins/templates.test.js
+++ b/test/plugins/templates.test.js
@@ -1140,7 +1140,8 @@ describe('template plugin test', () => {
                 });
                 assert.calledWith(templateTagFactoryMock.get, {
                     name: 'testtemplate',
-                    tag: 'stable'
+                    tag: 'stable',
+                    templateType: 'JOB'
                 });
                 assert.calledWith(templateTagFactoryMock.create, {
                     name: 'testtemplate',
@@ -1168,7 +1169,8 @@ describe('template plugin test', () => {
                 });
                 assert.calledWith(templateTagFactoryMock.get, {
                     name: 'testtemplate',
-                    tag: 'stable'
+                    tag: 'stable',
+                    templateType: 'JOB'
                 });
                 assert.calledOnce(template.update);
                 assert.notCalled(templateTagFactoryMock.create);


### PR DESCRIPTION
## Context
Schema changes made in PRs https://github.com/screwdriver-cd/data-schema/pull/521 and https://github.com/screwdriver-cd/data-schema/pull/528 added a new column `templateType` to `templateTags` table.
This new column is now included in the unique constraint along with `name`, `namespace` and `tag`.

This change has broken the API (`/templates/{templateName}/tags/{tagName}`) to add/update tags to a Job template.
[Factory implementation](https://github.com/screwdriver-cd/models/blob/master/lib/baseFactory.js#L76) includes all the fields that part of unique constraint as filter (`WHERE` clause) which resulted in below error

```
230823/151514.910, (1692803702779:C02ZM198LVDV:9912:llnvkqft:10188) [request,server,error] data: Error: WHERE parameter "templateType" has invalid "undefined" value
    at MySQLQueryGenerator.whereItemQuery (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/dialects/abstract/query-generator.js:1743:13)
    at /Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/dialects/abstract/query-generator.js:1734:25
    at Array.forEach (<anonymous>)
    at MySQLQueryGenerator.whereItemsQuery (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/dialects/abstract/query-generator.js:1732:35)
    at MySQLQueryGenerator.getWhereConditions (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/dialects/abstract/query-generator.js:2075:19)
    at MySQLQueryGenerator.selectQuery (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/dialects/abstract/query-generator.js:988:28)
    at MySQLQueryInterface.select (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/dialects/abstract/query-interface.js:407:59)
    at templateTags.findAll (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/model.js:1140:47)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async templateTags.findOne (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/sequelize/lib/model.js:1240:12)
    at async Promise.all (index 2)
    at async exports.Manager.execute (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at async internals.handler (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at async exports.execute (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at async Request._lifecycle (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/@hapi/hapi/lib/request.js:370:32)
    at async Request._execute (/Users/dsagar/Workspace/screwdriver-cd/screwdriver/node_modules/@hapi/hapi/lib/request.js:280:9)
230823/151502.779, (1692803702779:C02ZM198LVDV:9912:llnvkqft:10188) [response,api,templates] http://192.168.87.159:9001/: put /v4/templates/sagar1312%2Fsd-job-template-apple/tags/latest {} 500 (12134ms)
```

## Objective
Set `templateType='JOB'` in the config to get `Template Tag` from DB via Factory.

**Note**
Need to revisit after PR https://github.com/screwdriver-cd/models/pull/585 is merged

## References

https://github.com/screwdriver-cd/screwdriver/issues/2135
https://beta.cd.screwdriver.cd/pipelines/14593/builds/151440/steps/publish

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
