### PR TITLE
fix: Remote Join double build

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -971,7 +971,8 @@ const buildsPlugin = {
 
                             return existingBuild &&
                                 existingBuild.status !== 'CREATED' &&
-                                !existingBuild.parentBuildId.includes(current.build.id)
+                                !existingBuild.parentBuildId.includes(current.build.id) &&
+                                existingBuild.eventId !== current.event.parentEventId
                                 ? existingBuild
                                 : null;
                         })

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2948,7 +2948,7 @@ describe('build plugin test', () => {
                         configPipelineSha: 'abc123',
                         eventId: 8887,
                         jobId: 3,
-                        parentBuildId: 12345,
+                        parentBuildId: [12345],
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345 } },
                             2: { eventId: '8887', jobs: { a: 12345 } }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -3665,6 +3665,7 @@ describe('build plugin test', () => {
                             { src: '~sd@2:a', dest: 'a' }
                         ]
                     };
+                    eventMock.parentEventId = 8887;
                     buildMock.parentBuilds = {
                         2: { eventId: '8887', jobs: { a: 12345 } }
                     };
@@ -3775,6 +3776,7 @@ describe('build plugin test', () => {
                                     jobs: { a: 12344, c: 45678 }
                                 }
                             },
+                            eventId: 8888,
                             jobId: 3,
                             status: 'FAILED'
                         },


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
1. In the following Remote Join workflow, when the build of `a2` and the build of `a3` are finished almost simultaneously, the build of `a4` may be executed twice.

![image](https://github.com/screwdriver-cd/screwdriver/assets/59165943/350a4ce3-4df2-4b68-9aa6-95211e2bd81d)

2. If there are jobs waiting for the same job with Remote Join and Remote Or triggers, both of them (`b4` and `b5`) will be executed twice, as follows.

![image](https://github.com/screwdriver-cd/screwdriver/assets/59165943/306c08c1-8c55-4b36-a513-0dfc2ba2da45)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
1. In some cases, when jobs waiting for Remote Join finish almost simultaneously, the parentBuildId is not set correctly for the triggered build and [it becomes the target of Restart](https://github.com/screwdriver-cd/screwdriver/blob/cc915df162b3aa8117ad8f2294ced64c7f75513d/plugins/builds/index.js#L943-L953), resulting in double execution.
So, when a build is created by a remote trigger, modify parentBuildId to be set to all builds of the job that condition the Join.

2. Add to the Restart condition that the eventId of the already created build and the triggering event do not match.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[#2725](https://github.com/screwdriver-cd/screwdriver/issues/2725)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
