### PR TITLE
fix: Support for cases when parentBuildId is not Array

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -454,7 +454,8 @@ async function updateParentBuilds({ joinParentBuilds, nextBuild, build }) {
     );
 
     nextBuild.parentBuilds = newParentBuilds;
-    nextBuild.parentBuildId = Array.from(new Set([build.id, ...(nextBuild.parentBuildId || [])]));
+    // nextBuild.parentBuildId may be int or Array, so it needs to be flattened
+    nextBuild.parentBuildId = Array.from(new Set([build.id, nextBuild.parentBuildId || []].flat()));
 
     // FIXME: Is this needed ? Why not update once in handleNewBuild()
     return nextBuild.update();


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This is PR to follow up on https://github.com/screwdriver-cd/screwdriver/pull/2937.

`nextBuild.parentBuildId` could be int instead of Array, which would result in a `not iterable error`.

```
Error in triggerJobsInExternalPipeline:xxxxx from pipeline:xxxxx  (nextBuild.parentBuildId || []) is not iterable","stack":"TypeError: (nextBuild.parentBuildId || []) is not iterable\n    at updateParentBuilds (/usr/src/app/node_modules/screwdriver-api/plugins/builds/index.js:457:89)\n
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix `nextBuild.parentBuildId` to be flattened after concatenating in Array so that it can handle both int and Array.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
