### PR TITLE
feat: add badges to pipeline update PUT api

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -45,7 +45,7 @@ module.exports = () => ({
         },
 
         handler: async (request, h) => {
-            const { checkoutUrl, rootDir, settings } = request.payload;
+            const { checkoutUrl, rootDir, settings, badges } = request.payload;
             const { id } = request.params;
             const { pipelineFactory, userFactory, secretFactory } = request.server.app;
             const { scmContext, username } = request.auth.credentials;
@@ -144,6 +144,10 @@ module.exports = () => ({
                 logger.info(
                     `[Audit] user ${user.username}:${scmContext} updates the scmUri for pipelineID:${id} to ${oldPipeline.scmUri} from ${oldPipelineConfig.scmUri}.`
                 );
+            }
+
+            if (badges) {
+                oldPipeline.badges = { ...oldPipeline.badges, ...badges };
             }
 
             // update pipeline

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2431,6 +2431,22 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 when update the pipeline for sonar badges', () => {
+            options.payload.badges = {
+                sonar: {
+                    name: 'my-sonar-dashboard',
+                    uri: 'https://sonar.screwdriver.cd/pipeline112233'
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.update);
+                assert.include(reply.payload, 'my-sonar-dashboard');
+                assert.include(reply.payload, 'https://sonar.screwdriver.cd/pipeline112233');
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
         it('returns 404 when the pipeline id is not found', () => {
             pipelineFactoryMock.get.withArgs({ id }).resolves(null);
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2432,12 +2432,31 @@ describe('pipeline plugin test', () => {
         });
 
         it('returns 200 when update the pipeline for sonar badges', () => {
-            options.payload.badges = {
+            options.auth.credentials = {
+                username,
+                scmContext,
+                pipelineId: id,
+                scope: ['pipeline']
+            };
+
+            const badges = {
                 sonar: {
                     name: 'my-sonar-dashboard',
                     uri: 'https://sonar.screwdriver.cd/pipeline112233'
                 }
             };
+
+            options.payload.badges = badges;
+
+            const updatedPipelineMockLocal = {
+                ...updatedPipelineMock,
+                badges
+            };
+
+            updatedPipelineMockLocal.toJson = sinon.stub().returns(updatedPipelineMockLocal);
+            pipelineMock.sync.resolves(updatedPipelineMockLocal);
+
+            pipelineFactoryMock.get.withArgs({ id: `${id}` }).resolves(pipelineMock);
 
             return server.inject(options).then(reply => {
                 assert.calledOnce(pipelineMock.update);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Follow up of data-schema changes https://github.com/screwdriver-cd/data-schema/pull/531 

1) Add `badges: {}` to pipeline `GET` API
2) Add update `badges: {}` to pipeline `PUT` API 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR will make API to get and update badges information for given pipeline 
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
