### PR TITLE
fix: integrate auto populate sonar projectUrl in pipeline badge [3]

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "screwdriver-config-parser": "^8.0.1",
     "screwdriver-coverage-bookend": "^2.0.0",
     "screwdriver-coverage-sonar": "^4.1.1",
-    "screwdriver-data-schema": "^22.9.3",
+    "screwdriver-data-schema": "^22.9.8",
     "screwdriver-datastore-sequelize": "^8.0.0",
     "screwdriver-executor-base": "^9.0.1",
     "screwdriver-executor-docker": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "eslint . --quiet",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 10000 --retries 1 --exit --allow-uncaught true --color true",
-    "test-debug": "mocha --inspect ./test/**/*.js",
+    "test-debug": "mocha --inspect-brk ./test/**/*.js",
     "start": "./bin/server",
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const boom = require('@hapi/boom');
-const COVERAGE_SCOPE_ANNOTATION = 'screwdriver.cd/coverageScope';
-
+const logger = require('screwdriver-logger');
 const CoveragePlugin = require('screwdriver-coverage-bookend');
+
+const COVERAGE_SCOPE_ANNOTATION = 'screwdriver.cd/coverageScope';
 
 module.exports = config => ({
     method: 'GET',

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -92,7 +92,7 @@ module.exports = config => ({
                     let needPipelineUpdate = true;
 
                     if (pipeline.badges && pipeline.badges.sonar && pipeline.badges.sonar.defaultName === pipelineId && pipeline.badges.sonar.defaultUri === projectUrl) {
-                        let needPipelineUpdate = false;
+                        needPipelineUpdate = false;
                     }
 
                     if (needPipelineUpdate) {
@@ -104,7 +104,7 @@ module.exports = config => ({
                             }
                         }
 
-                        pipeline = await pipeline.update(); 
+                        await pipeline.update(); 
                     }
 
                 } catch (err) {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -62,7 +62,7 @@ module.exports = config => ({
                     throw boom.notFound(`Pipeline ${pipelineId} does not exist`);
                 }
 
-                tokenConfig.pipelineName = pipeline.name;             
+                tokenConfig.pipelineName = pipeline.name;
             }
 
             if (selfSonarHost && selfSonarAdminToken) {
@@ -83,10 +83,9 @@ module.exports = config => ({
 
                 try {
                     const projectUrl = selfSonar.coveragePlugin.getProjectData(tokenConfig);
-                    let pipelineSonarBadge = pipeline.badges['sonar'];
+                    const pipelineSonarBadge = pipeline.badges.sonar;
 
-                    if (pipelineSonarBadge.defaultName !== pipelineId ||
-                        pipelineSonarBadge.defaultUri !== projectUrl) {
+                    if (pipelineSonarBadge.defaultName !== pipelineId || pipelineSonarBadge.defaultUri !== projectUrl) {
                         pipelineSonarBadge.defaultName = pipelineId;
                         pipelineSonarBadge.defaultUri = projectUrl;
 
@@ -96,7 +95,7 @@ module.exports = config => ({
                     logger.error(`Failed to update pipeline:${pipeline.id}`, err);
 
                     throw err;
-                }   
+                }
 
                 return h.response(data);
             }

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -85,7 +85,7 @@ module.exports = config => ({
                 const data = await selfSonar.coveragePlugin.getAccessToken(tokenConfig);
                 const projectUrl = selfSonar.coveragePlugin.getProjectData(tokenConfig);
 
-                if (projectUrl) {          
+                if (projectUrl) {
                     try {
                         const pipelineSonarBadge = {
                             defaultName: pipelineId,
@@ -93,7 +93,12 @@ module.exports = config => ({
                         };
                         let shouldPipelineUpdate = true;
 
-                        if (pipeline.badges && pipeline.badges.sonar && pipeline.badges.sonar.defaultName === pipelineId && pipeline.badges.sonar.defaultUri === projectUrl) {
+                        if (
+                            pipeline.badges &&
+                            pipeline.badges.sonar &&
+                            pipeline.badges.sonar.defaultName === pipelineId &&
+                            pipeline.badges.sonar.defaultUri === projectUrl
+                        ) {
                             shouldPipelineUpdate = false;
                         }
 
@@ -103,13 +108,14 @@ module.exports = config => ({
                             } else {
                                 pipeline.badges = {
                                     sonar: pipelineSonarBadge
-                                }
+                                };
                             }
 
-                            await pipeline.update(); 
-                            logger.info(`update pipeline:${pipeline.id}'s sonar badge with defaultName:${pipelineId}, defaultUri: ${projectUrl}`);
+                            await pipeline.update();
+                            logger.info(
+                                `update pipeline:${pipeline.id}'s sonar badge with defaultName:${pipelineId}, defaultUri: ${projectUrl}`
+                            );
                         }
-
                     } catch (err) {
                         logger.error(`Failed to update pipeline:${pipeline.id}`, err);
 

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -54,7 +54,6 @@ module.exports = config => ({
                         ? job.permutations[0].annotations[COVERAGE_SCOPE_ANNOTATION]
                         : null;
             }
-
             let pipeline;
 
             // Get pipeline name
@@ -85,7 +84,7 @@ module.exports = config => ({
                 const data = await selfSonar.coveragePlugin.getAccessToken(tokenConfig);
                 const projectUrl = selfSonar.coveragePlugin.getProjectData(tokenConfig);
 
-                if (projectUrl) {
+                if (pipeline && projectUrl) {
                     try {
                         const pipelineSonarBadge = {
                             defaultName: pipelineId,
@@ -117,7 +116,7 @@ module.exports = config => ({
                             );
                         }
                     } catch (err) {
-                        logger.error(`Failed to update pipeline:${pipeline.id}`, err);
+                        logger.error(`Failed to update pipeline:${pipelineId}`, err);
 
                         throw err;
                     }

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -96,18 +96,14 @@ module.exports = config => ({
                         };
 
                         await pipeline.update();
-                    }
-
-                    if (!pipeline.badges.sonar) {
+                    } else if (!pipeline.badges.sonar) {
                         pipeline.badges.sonar = {
                             ...pipeline.badges.sonar,
                             ...pipelineSonarBadge
                         };
 
                         await pipeline.update();
-                    }
-
-                    if (
+                    } else if (
                         pipeline.badges.sonar.defaultName !== pipelineId ||
                         pipeline.badges.sonar.defaultUri !== projectUrl
                     ) {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -89,13 +89,13 @@ module.exports = config => ({
                         defaultName: pipelineId,
                         defaultUri: projectUrl
                     };
-                    let needPipelineUpdate = true;
+                    let shouldPipelineUpdate = true;
 
                     if (pipeline.badges && pipeline.badges.sonar && pipeline.badges.sonar.defaultName === pipelineId && pipeline.badges.sonar.defaultUri === projectUrl) {
-                        needPipelineUpdate = false;
+                        shouldPipelineUpdate = false;
                     }
 
-                    if (needPipelineUpdate) {
+                    if (shouldPipelineUpdate) {
                         if (pipeline.badges)
                             pipeline.badges.sonar = pipelineSonarBadge;
                         } else {
@@ -105,6 +105,7 @@ module.exports = config => ({
                         }
 
                         await pipeline.update(); 
+                        logger.info(`update pipeline:${pipeline.id}'s sonar badge with defaultName:${pipelineId}, defaultUri: ${projectUrl}`);
                     }
 
                 } catch (err) {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -89,33 +89,24 @@ module.exports = config => ({
                         defaultName: pipelineId,
                         defaultUri: projectUrl
                     };
+                    let needPipelineUpdate = true;
 
-                    if (!pipeline.badges) {
-                        pipeline.badges = {
-                            sonar: pipelineSonarBadge
-                        };
-
-                        await pipeline.update();
+                    if (pipeline.badges && pipeline.badges.sonar && pipeline.badges.sonar.defaultName === pipelineId && pipeline.badges.sonar.defaultUri === projectUrl) {
+                        let needPipelineUpdate = false;
                     }
 
-                    if (!pipeline.badges.sonar) {
-                        pipeline.badges.sonar = {
-                            ...pipeline.badges.sonar,
-                            ...pipelineSonarBadge
-                        };
+                    if (needPipelineUpdate) {
+                        if (pipeline.badges)
+                            pipeline.badges.sonar = pipelineSonarBadge;
+                        } else {
+                            pipeline.badges = {
+                                sonar: pipelineSonarBadge
+                            }
+                        }
 
-                        await pipeline.update();
-                    } 
-
-                    if (
-                        pipeline.badges.sonar.defaultName !== pipelineId ||
-                        pipeline.badges.sonar.defaultUri !== projectUrl
-                    ) {
-                        pipeline.badges.sonar.defaultName = pipelineId;
-                        pipeline.badges.sonar.defaultUri = projectUrl;
-
-                        await pipeline.update();
+                        pipeline = await pipeline.update(); 
                     }
+
                 } catch (err) {
                     logger.error(`Failed to update pipeline:${pipeline.id}`, err);
 

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -96,14 +96,18 @@ module.exports = config => ({
                         };
 
                         await pipeline.update();
-                    } else if (!pipeline.badges.sonar) {
+                    }
+
+                    if (!pipeline.badges.sonar) {
                         pipeline.badges.sonar = {
                             ...pipeline.badges.sonar,
                             ...pipelineSonarBadge
                         };
 
                         await pipeline.update();
-                    } else if (
+                    } 
+
+                    if (
                         pipeline.badges.sonar.defaultName !== pipelineId ||
                         pipeline.badges.sonar.defaultUri !== projectUrl
                     ) {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -82,36 +82,38 @@ module.exports = config => ({
 
                 const selfSonar = new CoveragePlugin(selfSonarConfig);
                 const data = await selfSonar.coveragePlugin.getAccessToken(tokenConfig);
+                const projectUrl = selfSonar.coveragePlugin.getProjectData(tokenConfig);
 
-                try {
-                    const projectUrl = selfSonar.coveragePlugin.getProjectData(tokenConfig);
-                    const pipelineSonarBadge = {
-                        defaultName: pipelineId,
-                        defaultUri: projectUrl
-                    };
-                    let shouldPipelineUpdate = true;
+                if (projectUrl) {          
+                    try {
+                        const pipelineSonarBadge = {
+                            defaultName: pipelineId,
+                            defaultUri: projectUrl
+                        };
+                        let shouldPipelineUpdate = true;
 
-                    if (pipeline.badges && pipeline.badges.sonar && pipeline.badges.sonar.defaultName === pipelineId && pipeline.badges.sonar.defaultUri === projectUrl) {
-                        shouldPipelineUpdate = false;
-                    }
-
-                    if (shouldPipelineUpdate) {
-                        if (pipeline.badges)
-                            pipeline.badges.sonar = pipelineSonarBadge;
-                        } else {
-                            pipeline.badges = {
-                                sonar: pipelineSonarBadge
-                            }
+                        if (pipeline.badges && pipeline.badges.sonar && pipeline.badges.sonar.defaultName === pipelineId && pipeline.badges.sonar.defaultUri === projectUrl) {
+                            shouldPipelineUpdate = false;
                         }
 
-                        await pipeline.update(); 
-                        logger.info(`update pipeline:${pipeline.id}'s sonar badge with defaultName:${pipelineId}, defaultUri: ${projectUrl}`);
+                        if (shouldPipelineUpdate) {
+                            if (pipeline.badges)
+                                pipeline.badges.sonar = pipelineSonarBadge;
+                            } else {
+                                pipeline.badges = {
+                                    sonar: pipelineSonarBadge
+                                }
+                            }
+
+                            await pipeline.update(); 
+                            logger.info(`update pipeline:${pipeline.id}'s sonar badge with defaultName:${pipelineId}, defaultUri: ${projectUrl}`);
+                        }
+
+                    } catch (err) {
+                        logger.error(`Failed to update pipeline:${pipeline.id}`, err);
+
+                        throw err;
                     }
-
-                } catch (err) {
-                    logger.error(`Failed to update pipeline:${pipeline.id}`, err);
-
-                    throw err;
                 }
 
                 return h.response(data);

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -97,7 +97,7 @@ module.exports = config => ({
                         }
 
                         if (shouldPipelineUpdate) {
-                            if (pipeline.badges)
+                            if (pipeline.badges) {
                                 pipeline.badges.sonar = pipelineSonarBadge;
                             } else {
                                 pipeline.badges = {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -85,7 +85,7 @@ module.exports = config => ({
 
                 try {
                     const projectUrl = selfSonar.coveragePlugin.getProjectData(tokenConfig);
-                    let pipelineSonarBadge = {
+                    const pipelineSonarBadge = {
                         defaultName: pipelineId,
                         defaultUri: projectUrl
                     };
@@ -99,17 +99,18 @@ module.exports = config => ({
                     }
 
                     if (!pipeline.badges.sonar) {
-                        pipeline.badges.sonar = { 
+                        pipeline.badges.sonar = {
                             ...pipeline.badges.sonar,
                             ...pipelineSonarBadge
-                        }
+                        };
 
                         await pipeline.update();
                     }
 
-                    if (pipeline.badges.sonar.defaultName !== pipelineId ||
-                        pipeline.badges.sonar.defaultUri !== projectUrl) {
-
+                    if (
+                        pipeline.badges.sonar.defaultName !== pipelineId ||
+                        pipeline.badges.sonar.defaultUri !== projectUrl
+                    ) {
                         pipeline.badges.sonar.defaultName = pipelineId;
                         pipeline.badges.sonar.defaultUri = projectUrl;
 

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -147,7 +147,12 @@ module.exports = () => ({
             }
 
             if (badges) {
-                oldPipeline.badges = { ...oldPipeline.badges, ...badges };
+                Object.keys(oldPipeline.badges).forEach(badgeKey => {
+                    oldPipeline.badges[key] = {
+                        ...oldPipeline.badges[key], 
+                        ...badges[key] 
+                    }
+                })
             }
 
             // update pipeline

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -147,12 +147,16 @@ module.exports = () => ({
             }
 
             if (badges) {
-                Object.keys(oldPipeline.badges).forEach(badgeKey => {
-                    oldPipeline.badges[badgeKey] = {
-                        ...oldPipeline.badges[badgeKey],
-                        ...badges[badgeKey]
-                    };
-                });
+                if (!oldPipeline.badges) {
+                    oldPipeline.badges = badges;
+                } else {
+                    Object.keys(oldPipeline.badges).forEach(badgeKey => {
+                        oldPipeline.badges[badgeKey] = {
+                            ...oldPipeline.badges[badgeKey],
+                            ...badges[badgeKey]
+                        };
+                    });
+                }
             }
 
             // update pipeline

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -148,11 +148,11 @@ module.exports = () => ({
 
             if (badges) {
                 Object.keys(oldPipeline.badges).forEach(badgeKey => {
-                    oldPipeline.badges[key] = {
-                        ...oldPipeline.badges[key], 
-                        ...badges[key] 
-                    }
-                })
+                    oldPipeline.badges[badgeKey] = {
+                        ...oldPipeline.badges[badgeKey],
+                        ...badges[badgeKey]
+                    };
+                });
             }
 
             // update pipeline

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -32,6 +32,7 @@ describe('coverage plugin test', () => {
                 sonarGitAppName: 'test'
             },
             getAccessToken: sinon.stub().resolves('faketoken'),
+            getProjectData: sinon.stub().resolves({ projectUrl: 'aabbcc', pipelineId: 1 }),
             getInfo: sinon.stub()
         };
         jobFactoryMock = {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

1. Sonar Coverage will populate the sonar `projectUrl` only when the scope is pipeline,
2. On the backend, we will only set the pipeline sonar badge if `pipeline` itself exists and `projectUrl` is available

## Objective
Only populate if `pipelineSonarBadge.defaultName` and `pipelineSonarBadge.defaultUri` were not generated, under assumption that `defaultName` and `defaultUri` does not change once populated. 

Users can override the `pipelineSonarBadge.name` and `pipelineSonarBadge.uri` however, just not the defaults

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/data-schema/pull/540
https://github.com/screwdriver-cd/coverage-sonar/pull/73
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
