### PR TITLE
fix: enable coverage bookend

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -315,6 +315,7 @@ bookends:
       - screwdriver-cache-bookend
     teardown:
       - screwdriver-artifact-bookend
+      - screwdriver-coverage-bookend
       - screwdriver-cache-bookend
 
 notifications:


### PR DESCRIPTION
## Context

Coverage bookend is missing in OSSD builds

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
