### PR TITLE
feat: add get,getVersion,listTags,createTag fns

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -289,3 +289,36 @@ Example payload:
     }
 }
 ```
+
+#### Get a pipeline template by namespace and name
+
+`GET /pipeline/template/{namespace}/{name}`
+
+##### Get a specific pipeline template by id
+
+`GET /pipeline/template/{id}`
+
+##### Get version of a pipeline template by name, namespace, version or tag
+
+`GET /pipeline/template/{namespace}/{name}/{versionOrTag}`
+
+
+#### Template Tag
+Template tag allows fetching on template version by tag. For example, tag `mytemplate@1.1.0` as `stable`.
+
+##### Get all tags for a pipeline template by name, namespace
+
+`GET /pipeline/templates/{namespace}/{name}/tags`
+
+Can use additional options for sorting, pagination and count:
+`GET /pipeline/templates/{namespace}/{name}/tags?sort=ascending&sortBy=name&page=1&count=50`
+
+##### Create/Update a tag
+
+If the template tag already exists, it will update the tag with the new version. If the template tag doesn't exist yet, this endpoint will create the tag.
+
+*Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the template.*
+
+`PUT /templates/{templateName}/tags/{tagName}` with the following payload
+
+* `version` - Exact version of the template (ex: `1.1.0`)

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -29,10 +29,15 @@ const latestCommitEvent = require('./latestCommitEvent');
 const getAdmin = require('./admins/get');
 const deleteCache = require('./caches/delete');
 const openPrRoute = require('./openPr');
-const createTemplate = require('./templates/create');
-const validateTemplate = require('./templates/validate');
-const listTemplates = require('./templates/list');
-const listTemplateVersions = require('./templates/listVersions');
+const createTemplateRoute = require('./templates/create');
+const validateTemplateRoute = require('./templates/validate');
+const listTemplatesRoute = require('./templates/list');
+const listTemplateVersionsRoute = require('./templates/listVersions');
+const listTagsRoute = require('./templates/listTags');
+const getTemplateRoute = require('./templates/get');
+const getTemplateByIdRoute = require('./templates/getTemplateById');
+const createTagRoute = require('./templates/createTag');
+const getVersionRoute = require('./templates/getVersion');
 
 /**
  * Pipeline API Plugin
@@ -200,10 +205,15 @@ const pipelinesPlugin = {
             getAdmin(),
             deleteCache(),
             openPrRoute(),
-            createTemplate(),
-            validateTemplate(),
-            listTemplates(),
-            listTemplateVersions()
+            createTemplateRoute(),
+            validateTemplateRoute(),
+            listTemplatesRoute(),
+            listTemplateVersionsRoute(),
+            listTagsRoute(),
+            getVersionRoute(),
+            getTemplateByIdRoute(),
+            getTemplateRoute(),
+            createTagRoute()
         ]);
     }
 };

--- a/plugins/pipelines/templates/createTag.js
+++ b/plugins/pipelines/templates/createTag.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const baseSchema = schema.models.templateTag.base;
+const metaSchema = schema.models.templateMeta.base;
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/pipeline/template/{namespace}/{name}/tags/{tag}',
+    options: {
+        description: 'Add or update a pipeline template tag',
+        notes: 'Add or update a specific template',
+        tags: ['api', 'templates'],
+        auth: {
+            strategies: ['token'],
+            scope: ['build']
+        },
+        handler: async (request, h) => {
+            const { pipelineFactory, pipelineTemplateVersionFactory, pipelineTemplateTagFactory } = request.server.app;
+
+            const { isPR, pipelineId } = request.auth.credentials;
+
+            const { name, namespace, tag } = request.params;
+
+            const { version } = request.payload;
+
+            const [pipeline, template, templateTag] = await Promise.all([
+                pipelineFactory.get(pipelineId),
+                pipelineTemplateVersionFactory.get({ name, namespace, version }),
+                pipelineTemplateTagFactory.get({ name, namespace, tag })
+            ]);
+
+            // If template doesn't exist, throw error
+            if (!template) {
+                throw boom.notFound(`PipelineTemplate ${name}@${version} not found`);
+            }
+
+            // check if build has permission to publish
+            if (pipeline.id !== template.pipelineId || isPR) {
+                throw boom.forbidden('Not allowed to tag this pipeline template');
+            }
+
+            // If template tag exists, update the version
+            if (templateTag) {
+                templateTag.version = version;
+
+                const newTag = await templateTag.update();
+
+                return h.response(newTag.toJson()).code(200);
+            }
+
+            const newTag = await pipelineTemplateTagFactory.create({ namespace, name, tag, version });
+
+            const location = new URL(
+                `${request.path}/${newTag.id}`,
+                `${request.server.info.protocol}://${request.headers.host}`
+            ).toString();
+
+            return h.response(newTag.toJson()).header('Location', location).code(201);
+        },
+        validate: {
+            params: joi.object({
+                namespace: metaSchema.extract('namespace'),
+                name: metaSchema.extract('name'),
+                tag: baseSchema.extract('tag')
+            }),
+            payload: joi.object({
+                version: baseSchema.extract('version')
+            })
+        }
+    }
+});

--- a/plugins/pipelines/templates/get.js
+++ b/plugins/pipelines/templates/get.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const getSchema = schema.models.templateMeta.get;
+const metaSchema = schema.models.templateMeta.base;
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipeline/template/{namespace}/{name}',
+    options: {
+        description: 'Get a specific template by namespace and name',
+        notes: 'Returns template meta for the specified namespace and name',
+        tags: ['api', 'pipeline', 'template'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        handler: async (request, h) => {
+            console.log('request.params', request.params);
+
+            const { namespace, name } = request.params;
+            const { pipelineTemplateFactory } = request.server.app;
+
+            const pipelineTemplate = await pipelineTemplateFactory.get({
+                name,
+                namespace
+            });
+
+            if (!pipelineTemplate) {
+                throw boom.notFound('Pipeline Template does not exist');
+            }
+
+            return h.response(pipelineTemplate).code(200);
+        },
+        response: {
+            schema: getSchema
+        },
+        validate: {
+            params: joi.object({
+                namespace: metaSchema.extract('namespace'),
+                name: metaSchema.extract('name')
+            })
+        }
+    }
+});

--- a/plugins/pipelines/templates/getTemplateById.js
+++ b/plugins/pipelines/templates/getTemplateById.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const getSchema = schema.models.templateMeta.get;
+const idSchema = schema.models.templateMeta.base.extract('id');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipeline/template/{id}',
+    options: {
+        description: 'Get a single template',
+        notes: 'Returns a template record',
+        tags: ['api', 'templates'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        handler: async (request, h) => {
+            const { pipelineTemplateFactory } = request.server.app;
+
+            const pipelineTemplate = await pipelineTemplateFactory.get({ id: request.params.id });
+
+            if (!pipelineTemplate) {
+                throw boom.notFound('Pipeline Template does not exist');
+            }
+
+            return h.response(pipelineTemplate).code(200);
+        },
+        response: {
+            schema: getSchema
+        },
+        validate: {
+            params: joi.object({
+                id: idSchema
+            })
+        }
+    }
+});

--- a/plugins/pipelines/templates/getVersion.js
+++ b/plugins/pipelines/templates/getVersion.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const metaSchema = schema.models.templateMeta.base;
+const versionSchema = schema.models.pipelineTemplateVersions.base.extract('version');
+const tagSchema = schema.models.templateTag.base.extract('tag');
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipeline/template/{namespace}/{name}/{versionOrTag}',
+    options: {
+        description: 'Get a specific template version details by version number or tag',
+        notes: 'Returns template meta and version for namespace, name and version/tag',
+        tags: ['api', 'pipeline', 'template'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+        handler: async (request, h) => {
+            const { namespace, name, versionOrTag } = request.params;
+            const { pipelineTemplateVersionFactory } = request.server.app;
+
+            const pipelineTemplate = await pipelineTemplateVersionFactory.getWithMetadata({
+                name,
+                namespace,
+                versionOrTag
+            });
+
+            if (!pipelineTemplate) {
+                throw boom.notFound('Pipeline Template does not exist');
+            }
+
+            return h.response(pipelineTemplate).code(200);
+        },
+        validate: {
+            params: joi.object({
+                namespace: metaSchema.extract('namespace'),
+                name: metaSchema.extract('name'),
+                versionOrTag: joi.alternatives().try(versionSchema, tagSchema)
+            })
+        }
+    }
+});

--- a/plugins/pipelines/templates/listTags.js
+++ b/plugins/pipelines/templates/listTags.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const listSchema = joi.array().items(schema.models.templateTag.base).label('List of templates');
+const metaSchema = schema.models.templateMeta.base;
+
+module.exports = () => ({
+    method: 'GET',
+    path: '/pipeline/templates/{namespace}/{name}/tags',
+    options: {
+        description: 'Get all pipeline template tags for a given template name and namespace',
+        notes: 'Returns all pipeline template tags for a given template name and namespace',
+        tags: ['api', 'templates', 'tags'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', 'build']
+        },
+
+        handler: async (request, h) => {
+            const { pipelineTemplateTagFactory } = request.server.app;
+            const config = {
+                params: request.params,
+                sort: request.query.sort
+            };
+
+            if (request.query.page || request.query.count) {
+                config.paginate = {
+                    page: request.query.page,
+                    count: request.query.count
+                };
+            }
+
+            const tags = await pipelineTemplateTagFactory.list(config);
+
+            return h.response(tags);
+        },
+        response: {
+            schema: listSchema
+        },
+        validate: {
+            params: joi.object({
+                namespace: metaSchema.extract('namespace'),
+                name: metaSchema.extract('name')
+            }),
+            query: schema.api.pagination.concat(
+                joi.object({
+                    search: joi.forbidden()
+                })
+            )
+        }
+    }
+});

--- a/test/plugins/data/pipelineTemplateTags.json
+++ b/test/plugins/data/pipelineTemplateTags.json
@@ -1,0 +1,14 @@
+[{
+    "id": 7969,
+    "name": "screwdriver/pipeline",
+    "tag": "stable",
+    "version": "0.0.4",
+    "templateType": "PIPELINE"
+},
+{
+    "id": 7970,
+    "name": "screwdriver/pipeline",
+    "tag": "latest",
+    "version": "1.0.5",
+    "templateType": "PIPELINE"
+}]

--- a/test/plugins/data/pipelineTemplateVersion.json
+++ b/test/plugins/data/pipelineTemplateVersion.json
@@ -1,0 +1,31 @@
+{
+    "id": 1,
+    "templateId": 1234,
+    "description": "An example template",
+    "version": "1.0.0",
+    "config": {
+        "jobs": {
+            "main": {
+                "image": "node:18",
+                "steps": [
+                    {
+                        "printLine": "echo 'Testing template creation V1'"
+                    }
+                ],
+                "requires": [
+                    "~pr",
+                    "~commit"
+                ]
+            }
+        }
+    },
+    "pipelineId": 123,
+    "namespace": "my-namespace",
+    "name": "example-template",
+    "maintainer": "example@gmail.com",
+    "templateType": "PIPELINE",
+    "trustedSinceVersion": "1.3.2",
+    "latestVersion": "1.3.2",
+    "createTime": "2023-06-12T21:52:22.706Z",
+    "updateTime": "2023-06-29T11:23:45.706Z"
+}

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -5,9 +5,13 @@ const badgeMaker = require('badge-maker');
 const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
 const hoek = require('@hapi/hoek');
+const testPipeline = require('./data/pipeline.json');
 const testTemplate = require('./data/pipeline-template.json');
 const testTemplates = require('./data/pipelineTemplates.json');
+const testTemplateGet = testTemplates[0];
 const testTemplateVersions = require('./data/pipelineTemplateVersions.json');
+const testTemplateVersionsGet = require('./data/pipelineTemplateVersion.json');
+const testTemplateTags = require('./data/pipelineTemplateTags.json');
 const TEMPLATE_INVALID = require('./data/pipeline-template-validator.missing-version.json');
 const TEMPLATE_VALID = require('./data/pipeline-template-validator.input.json');
 const TEMPLATE_VALID_NEW_VERSION = require('./data/pipeline-template-create.input.json');
@@ -30,6 +34,14 @@ const getTemplateMocks = templates => {
     return decorateObj(templates);
 };
 
+const getPipelineMocks = pipelines => {
+    if (Array.isArray(pipelines)) {
+        return pipelines.map(decorateObj);
+    }
+
+    return decorateObj(pipelines);
+};
+
 describe('pipeline plugin test', () => {
     let pipelineFactoryMock;
     let userFactoryMock;
@@ -46,6 +58,7 @@ describe('pipeline plugin test', () => {
     let scmMock;
     let pipelineTemplateFactoryMock;
     let pipelineTemplateVersionFactoryMock;
+    let pipelineTemplateTagFactoryMock;
     let plugin;
     let server;
     const password = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
@@ -116,12 +129,20 @@ describe('pipeline plugin test', () => {
         screwdriverAdminDetailsMock = sinon.stub();
         pipelineTemplateFactoryMock = {
             get: sinon.stub(),
-            list: sinon.stub()
+            list: sinon.stub(),
+            create: sinon.stub()
         };
         pipelineTemplateVersionFactoryMock = {
             create: sinon.stub(),
             list: sinon.stub(),
-            get: sinon.stub()
+            get: sinon.stub(),
+            getWithMetadata: sinon.stub()
+        };
+
+        pipelineTemplateTagFactoryMock = {
+            list: sinon.stub(),
+            get: sinon.stub(),
+            create: sinon.stub()
         };
 
         /* eslint-disable global-require */
@@ -143,6 +164,7 @@ describe('pipeline plugin test', () => {
             secretFactory: secretFactoryMock,
             pipelineTemplateFactory: pipelineTemplateFactoryMock,
             pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock,
+            pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,
             ecosystem: {
                 badges: '{{subject}}/{{status}}/{{color}}'
             }
@@ -541,6 +563,326 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /pipeline/templates/{namespace}/{name}/tags', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: '/pipeline/templates/screwdriver/nodejs/tags',
+                auth: {
+                    credentials: {
+                        username: 'foo',
+                        scmContext: 'github:github.com',
+                        scope: ['user']
+                    },
+                    strategy: ['token']
+                }
+            };
+
+            pipelineTemplateTagFactoryMock.list.resolves(testTemplateTags);
+        });
+
+        it('returns 200 for getting all template tags for name and namespace', () =>
+            server.inject(options).then(reply => {
+                assert.deepEqual(reply.result, testTemplateTags);
+                assert.equal(reply.statusCode, 200);
+            }));
+
+        it('returns 200 and all tags for a pipeline template name and namespace with pagination', () => {
+            options.url = '/pipeline/templates/screwdriver/nodejs/tags?count=30';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testTemplateTags);
+                assert.calledWith(pipelineTemplateTagFactoryMock.list, {
+                    params: {
+                        name: 'nodejs',
+                        namespace: 'screwdriver'
+                    },
+                    paginate: {
+                        page: undefined,
+                        count: 30
+                    },
+                    sort: 'descending'
+                });
+            });
+        });
+
+        it('returns 200 and an empty array when there are no template tags', () => {
+            pipelineTemplateTagFactoryMock.list.resolves([]);
+
+            return server.inject(options).then(reply => {
+                assert.deepEqual(reply.result, []);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 500 when the pipeline template model fails to get', () => {
+            const testError = new Error('templateModelGetError');
+
+            pipelineTemplateTagFactoryMock.list.rejects(testError);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /pipeline/template/{namespace}/{name}', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: '/pipeline/template/screwdriver/nodejs',
+                auth: {
+                    credentials: {
+                        username: 'foo',
+                        scmContext: 'github:github.com',
+                        scope: ['user']
+                    },
+                    strategy: ['token']
+                }
+            };
+
+            pipelineTemplateFactoryMock.get.resolves(testTemplateGet);
+        });
+
+        it('returns 200 for getting a pipeline template', () =>
+            server.inject(options).then(reply => {
+                assert.deepEqual(reply.result, testTemplateGet);
+                assert.equal(reply.statusCode, 200);
+            }));
+
+        it('returns 404 when pipeline template does not exist', () => {
+            pipelineTemplateFactoryMock.get.resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 500 when the pipeline template model fails to get', () => {
+            const testError = new Error('templateModelGetError');
+
+            pipelineTemplateFactoryMock.get.rejects(testError);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /pipeline/template/{id}', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: '/pipeline/template/123',
+                auth: {
+                    credentials: {
+                        username: 'foo',
+                        scmContext: 'github:github.com',
+                        scope: ['user']
+                    },
+                    strategy: ['token']
+                }
+            };
+
+            pipelineTemplateFactoryMock.get.resolves(testTemplateGet);
+        });
+
+        it('returns 200 for getting a template', () =>
+            server.inject(options).then(reply => {
+                assert.deepEqual(reply.result, testTemplateGet);
+                assert.equal(reply.statusCode, 200);
+            }));
+
+        it('returns 404 when template does not exist', () => {
+            pipelineTemplateFactoryMock.get.resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 500 when the template model fails to get', () => {
+            const testError = new Error('templateModelGetError');
+
+            pipelineTemplateFactoryMock.get.rejects(testError);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('GET /pipeline/template/{namespace}/{name}/{versionOrTag}', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'GET',
+                url: '/pipeline/template/screwdriver/nodejs/1.2.3',
+                auth: {
+                    credentials: {
+                        username: 'foo',
+                        scmContext: 'github:github.com',
+                        scope: ['user']
+                    },
+                    strategy: ['token']
+                }
+            };
+
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(testTemplateVersionsGet);
+        });
+
+        it('returns 200 for getting a template', () =>
+            server.inject(options).then(reply => {
+                assert.deepEqual(reply.result, testTemplateVersionsGet);
+                assert.equal(reply.statusCode, 200);
+            }));
+
+        it('returns 404 when template does not exist', () => {
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 500 when the template model fails to get', () => {
+            const testError = new Error('templateModelGetError');
+
+            pipelineTemplateVersionFactoryMock.getWithMetadata.rejects(testError);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 500);
+            });
+        });
+    });
+
+    describe('PUT /pipeline/template/{namespace}/{name}/tags/{tag}', () => {
+        let options;
+        let templateMock;
+        const testId = 123;
+        let pipeline;
+        const payload = {
+            version: '1.2.3'
+        };
+        const testTemplateTag = decorateObj(hoek.merge({ id: 123 }, payload));
+
+        beforeEach(() => {
+            options = {
+                method: 'PUT',
+                url: '/pipeline/template/screwdriver/nodejs/tags/stable',
+                payload: {
+                    version: '1.2.3'
+                },
+                auth: {
+                    credentials: {
+                        username: 'foo',
+                        scmContext: 'github:github.com',
+                        scope: ['build']
+                    },
+                    strategy: ['token']
+                }
+            };
+
+            pipeline = getPipelineMocks(testPipeline);
+            pipelineFactoryMock.get.resolves(pipeline);
+            templateMock = getTemplateMocks(testTemplate);
+            pipelineTemplateVersionFactoryMock.get.resolves(templateMock);
+        });
+
+        it('creates template tag if template tag does not exist yet', () => {
+            pipelineTemplateTagFactoryMock.create.resolves(testTemplateTag);
+
+            return server.inject(options).then(reply => {
+                const expectedLocation = new URL(
+                    `${options.url}/${testId}`,
+                    `${reply.request.server.info.protocol}://${reply.request.headers.host}`
+                ).toString();
+
+                assert.deepEqual(reply.result, hoek.merge({ id: 123 }, payload));
+                assert.strictEqual(reply.headers.location, expectedLocation);
+                assert.calledWith(pipelineTemplateVersionFactoryMock.get, {
+                    name: 'nodejs',
+                    namespace: 'screwdriver',
+                    version: '1.2.3'
+                });
+                assert.calledWith(pipelineTemplateTagFactoryMock.get, {
+                    name: 'nodejs',
+                    namespace: 'screwdriver',
+                    tag: 'stable'
+                });
+                assert.calledWith(pipelineTemplateTagFactoryMock.create, {
+                    namespace: 'screwdriver',
+                    name: 'nodejs',
+                    tag: 'stable',
+                    version: '1.2.3'
+                });
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('updates template version if the tag already exists', () => {
+            const template = hoek.merge(
+                {
+                    update: sinon.stub().resolves(testTemplateTag)
+                },
+                testTemplateTag
+            );
+
+            pipelineTemplateTagFactoryMock.get.resolves(template);
+
+            return server.inject(options).then(reply => {
+                assert.deepEqual(reply.result.version, template.version);
+                assert.calledWith(pipelineTemplateVersionFactoryMock.get, {
+                    name: 'nodejs',
+                    namespace: 'screwdriver',
+                    version: '1.2.3'
+                });
+                assert.calledWith(pipelineTemplateTagFactoryMock.get, {
+                    name: 'nodejs',
+                    namespace: 'screwdriver',
+                    tag: 'stable'
+                });
+                assert.calledOnce(template.update);
+                assert.notCalled(pipelineTemplateVersionFactoryMock.create);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 403 when pipelineId does not match', () => {
+            templateMock = getTemplateMocks(testTemplate);
+            templateMock.pipelineId = 321;
+            pipelineTemplateVersionFactoryMock.get.resolves(templateMock);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+            });
+        });
+
+        it('returns 404 when template does not exist', () => {
+            pipelineTemplateVersionFactoryMock.get.resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 403 if it is a PR build', () => {
+            options.auth.credentials.isPR = true;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
             });
         });
     });


### PR DESCRIPTION
## Context

Add operations get, list for `pipelineTemplate` meta , `pipelineTemplateVersions` and `templateTags`

## Objective

Below changes have been made
- added get,getVersion.getTemplateById API in `/pipeline/templates`
- added listTags,createTags API in `/pipeline/templates`


## References

https://github.com/screwdriver-cd/models/pull/599

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
