### PR TITLE
fix: Fix join build not triggering on restart during build execution

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -908,7 +908,7 @@ const buildsPlugin = {
                 if (!nextBuild) {
                     // If the build to join fails and it succeeds on restart, depending on the timing, the latest build will be that of a child event.
                     // In that case, `nextBuild` will be null and will not be triggered even though there is a build that should be triggered.
-                    // Now we need to check for the existence of a build that should be triggered in its own event
+                    // Now we need to check for the existence of a build that should be triggered in its own event.
                     nextBuild = await buildFactory.get({
                         eventId: current.event.id,
                         jobId: nextJobId

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -898,12 +898,27 @@ const buildsPlugin = {
                     finishedInternalBuilds = finishedInternalBuilds.concat(parallelBuilds);
                 }
 
-                fillParentBuilds(parentBuilds, current, finishedInternalBuilds);
-                // If next build is internal, look at the finished builds for this event
                 const nextJobId = joinObj[nextJobName].id;
-                const nextBuild = finishedInternalBuilds.find(
-                    b => b.jobId === nextJobId && b.eventId === current.event.id
-                );
+
+                let nextBuild;
+
+                // If next build is internal, look at the finished builds for this event
+                nextBuild = finishedInternalBuilds.find(b => b.jobId === nextJobId && b.eventId === current.event.id);
+
+                if (!nextBuild) {
+                    // If the build to join fails and it succeeds on restart, depending on the timing, the latest build will be that of a child event.
+                    // In that case, `nextBuild` will be null and will not be triggered even though there is a build that should be triggered.
+                    // Now we need to check for the existence of a build that should be triggered in its own event
+                    nextBuild = await buildFactory.get({
+                        eventId: current.event.id,
+                        jobId: nextJobId
+                    });
+
+                    finishedInternalBuilds = finishedInternalBuilds.concat(nextBuild);
+                }
+
+                fillParentBuilds(parentBuilds, current, finishedInternalBuilds);
+
                 let newBuild;
 
                 // Create next build


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The build of `target` is not triggered in the following cases.

1. `a` fails.
2. `b` succeeds.
3. restarted `a` succeeds.
4. `c` succeeds.

![image](https://github.com/screwdriver-cd/screwdriver/assets/59165943/ca8dc75d-70bf-4aa0-9af4-18977a43a759)

![image](https://github.com/screwdriver-cd/screwdriver/assets/59165943/f357cdf9-ece7-4ff9-8fde-4c7f4f7b2dde)

The build created by restart in No. 3 is the latest build and the `target` build is not triggered in No. 4.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
If `nextBuild` is not present, check for events that should be triggered within the same event.

![image](https://github.com/screwdriver-cd/screwdriver/assets/59165943/15911b36-976e-4d44-8b61-b66045385ba4)

Visually, the `target` build should be executed on the child event created by restart.
However, as the issue https://github.com/screwdriver-cd/screwdriver/issues/2957 is created, it is not easy to modify them that way.

As a matter of urgency, fix the builds that should be triggered so that they are triggered.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
