### PR TITLE
fix: run pipeline after workflow-parser

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -16,6 +16,7 @@ jobs:
             - ~commit
             - ~sd@73:publish #artifact-bookend https://cd.screwdriver.cd/pipelines/73
             - ~sd@9:publish  #models https://cd.screwdriver.cd/pipelines/9
+            - ~sd@529:publish  #workflow-parse https://cd.screwdriver.cd/pipelines/529
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - install: npm install


### PR DESCRIPTION
## Context

Currently we have to manually start API release after workflow parser

## Objective

Don't have to manually start API pipeline for picking up new workflow parser

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
