### PR TITLE
[skip ci] fix: save npm logs

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -49,6 +49,8 @@ jobs:
             screwdriver.cd/dockerRam: HIGH
         requires: publish
         template: sd/dind@2.0.20
+        steps:
+            - teardown-cp-logs: cp -r /root/.npm/_logs $SD_ARTIFACTS_DIR
     # Deploy to our beta environment and run tests
     beta:
         image: node:18


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`docker-publish` keeps failing at https://cd.screwdriver.cd/pipelines/1/builds/919086, and we need to save npm logs to view
i.e.
```
00:10:12 #15 561.7 npm ERR! network If you are behind a proxy, please make sure that the
00:10:12 #15 561.7 npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
00:10:12 #15 561.8 
00:10:12 #15 561.8 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2024-01-23T18_12_14_377Z-debug-0.log
00:10:12 #15 ERROR: process "/bin/sh -c npm install screwdriver-api@$VERSION" did not complete successfully: exit code: 1
00:10:12 ------
00:10:12  > [linux/arm64 4/6] RUN npm install screwdriver-api@latest:
00:10:12 #15 561.5 npm ERR! code ECONNRESET
00:10:12 #15 561.5 npm ERR! errno ECONNRESET
00:10:12  ERR! network request to https://registry.npmjs.org/css-color-converter failed, reason: socket hang up
00:10:12 #15 561.7 npm ERR! network This is a problem related to network connectivity.
00:10:12 #15 561.7 npm ERR! network In most cases you are behind a proxy or have bad network settings.
00:10:12 #15 561.7 npm ERR! network 
00:10:12 #15 561.7 npm ERR! network If you are behind a proxy, please make sure that the
00:10:12 #15 561.7 npm ERR! network 'proxy' config is set properly.  See: 'npm help config'
00:10:12 #15 561.8 
00:10:12 #15 561.8 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2024-01-23T18_12_14_377Z-debug-0.log
00:10:12 ------
00:10:12 Dockerfile:11
00:10:12 --------------------
00:10:12    9 |     
00:10:12   10 |     # Install Screwdriver API
00:10:12   11 | >>> RUN npm install screwdriver-api@$VERSION
00:10:12   12 |     WORKDIR /usr/src/app/node_modules/screwdriver-api
00:10:12   13 |     
00:10:12 --------------------
00:10:12 ERROR: failed to solve: process "/bin/sh -c npm install screwdriver-api@$VERSION" did not complete successfully: exit code: 1
```
## Objective
This PR saves the generated npm logs to artifacts for downloading later
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
