### PR TITLE
fix(2767): fix stages tests per latest schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "screwdriver-config-parser": "^8.0.1",
     "screwdriver-coverage-bookend": "^2.0.0",
     "screwdriver-coverage-sonar": "^4.1.1",
-    "screwdriver-data-schema": "^22.9.14",
+    "screwdriver-data-schema": "^v22.9.15",
     "screwdriver-datastore-sequelize": "^8.0.0",
     "screwdriver-executor-base": "^9.0.1",
     "screwdriver-executor-docker": "^6.0.0",

--- a/test/plugins/data/stages.json
+++ b/test/plugins/data/stages.json
@@ -5,22 +5,26 @@
         "name": "setup",
         "jobIds": [1, 2, 3, 4],
         "description": "Stage for setting up",
-        "archived": false
+        "archived": false,
+        "setup": 11,
+        "teardown": 12
     },
     {
         "id": 2,
         "pipelineId": 123,
         "name": "deploy",
         "jobIds": [5, 6, 7],
-        "archived": true
+        "archived": true,
+        "setup": 13,
+        "teardown": 14
     },
     {
         "id": 3,
         "pipelineId": 123,
         "name": "test",
-        "jobIds": [],
+        "jobIds": [9],
         "archived": false,
-        "setup": 11,
-        "teardown": 12
+        "setup": 15,
+        "teardown": 16
     }
 ]


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/data-schema/pull/547

## Objective

Update mock data for stage tests to align to the latest schema

## References

https://github.com/screwdriver-cd/screwdriver/issues/2767

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
