### PR TITLE
[skip ci] fix: docker npm install log level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 # Install Screwdriver API
-RUN npm install screwdriver-api@$VERSION
+RUN npm install -d screwdriver-api@$VERSION
 WORKDIR /usr/src/app/node_modules/screwdriver-api
 
 # Setup configuration folder


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
https://github.com/screwdriver-cd/screwdriver/pull/2996

Change logging level in `dockerfile` for npm install
## Objective
`-d == --loglevel info`
So, we get more information about in case npm install failed  
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
```
   Aliases
       The log levels listed above have various corresponding aliases, including:

       •   -d: --loglevel info

       •   --dd: --loglevel verbose

       •   --verbose: --loglevel verbose

       •   --ddd: --loglevel silly

       •   -q: --loglevel warn

       •   --quiet: --loglevel warn

       •   -s: --loglevel silent

       •   --silent: --loglevel silent
```
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
