### PR TITLE
fix: use node:20 for docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:21
 
 # Screwdriver Version
 ARG VERSION=latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21
+FROM node:20
 
 # Screwdriver Version
 ARG VERSION=latest

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:21
 
 # Create our application directory
 RUN mkdir -p /usr/src/app

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:21
+FROM node:20
 
 # Create our application directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
## Context

Current node image used for the docker build is node:18, while the latest node docker image is node:21

## Objective

Update the node image with the latest version

## References

Build has been failing recently with the connectivity issue to npm registry, hoping the upgrade of node image might help resolving. 
https://cd.screwdriver.cd/pipelines/1/builds/919086/steps/build-push

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
