### PR TITLE
fix: upgrade hapi-rate-limit for node20

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "dayjs": "^1.11.7",
     "hapi-auth-bearer-token": "^8.0.0",
     "hapi-auth-jwt2": "^10.4.0",
-    "hapi-rate-limit": "^6.0.0",
+    "hapi-rate-limit": "^7.1.0",
     "hapi-swagger": "^15.0.0",
     "ioredis": "^5.2.3",
     "joi": "^17.7.0",


### PR DESCRIPTION
## Context

with engine upgrade comes engine compat hiccup

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
