### PR TITLE
remove auth scopes from validator

### DIFF
--- a/plugins/pipelines/templates/validate.js
+++ b/plugins/pipelines/templates/validate.js
@@ -12,11 +12,6 @@ module.exports = () => ({
         description: 'Validate a given sd-template.yaml',
         notes: 'returns the parsed config, validation errors, or both',
         tags: ['api', 'validation', 'yaml'],
-        auth: {
-            strategies: ['token'],
-            scope: ['user', 'pipeline']
-        },
-
         handler: async (request, h) => {
             try {
                 const { yaml: templateString } = request.payload;


### PR DESCRIPTION
## Context

Remove auth scopes from validation API

## Objective

Remove auth scopes from `/pipeline/template/validate` API

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
