### PR TITLE
fix(2980): remote trigger does not work when the job includes other normal join jobs [2]

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -845,7 +845,7 @@ const buildsPlugin = {
                  */
                 const isORTrigger = !joinListNames.includes(current.job.name);
 
-                if (joinListNames.length === 0 || isORTrigger) {
+                if (isORTrigger) {
                     const internalBuildConfig = {
                         jobFactory,
                         buildFactory,
@@ -1048,6 +1048,7 @@ const buildsPlugin = {
 
                         const joinList = nextJobs[nextJobName].join;
                         const joinListNames = joinList.map(j => j.name);
+                        const isORTrigger = !joinListNames.includes(triggerName);
 
                         if (nextBuild) {
                             // update current build info in parentBuilds
@@ -1083,22 +1084,30 @@ const buildsPlugin = {
                             });
                         }
 
-                        const { hasFailure, done } = await getParentBuildStatus({
-                            newBuild,
-                            joinListNames,
-                            pipelineId: externalPipelineId,
-                            buildFactory
-                        });
+                        if (isORTrigger) {
+                            if (['CREATED', null, undefined].includes(newBuild.status)) {
+                                newBuild.status = 'QUEUED';
+                                await newBuild.update();
+                                await newBuild.start();
+                            }
+                        } else {
+                            const { hasFailure, done } = await getParentBuildStatus({
+                                newBuild,
+                                joinListNames,
+                                pipelineId: externalPipelineId,
+                                buildFactory
+                            });
 
-                        // Check if external pipeline has Join
-                        // and join conditions are met
-                        await handleNewBuild({
-                            done,
-                            hasFailure,
-                            newBuild,
-                            jobName: nextJobName,
-                            pipelineId: externalPipelineId
-                        });
+                            // Check if external pipeline has Join
+                            // and join conditions are met
+                            await handleNewBuild({
+                                done,
+                                hasFailure,
+                                newBuild,
+                                jobName: nextJobName,
+                                pipelineId: externalPipelineId
+                            });
+                        }
                     }
 
                     return null;

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -3023,6 +3023,217 @@ describe('build plugin test', () => {
                     });
                 });
 
+                it('starts single external job with normal join when it circles back to original pipeline', () => {
+                    // For a pipeline like this:
+                    //  ~sd@2:a -> a -> ~sd@2:c (requires[ b, ~sd@123:a ])
+                    //  ~sd@2:b ------➚
+                    // If user is at `a`, it should trigger `sd@2:c`
+                    // ~sd@123:a is or trigger, so create
+                    eventMock.workflowGraph = {
+                        nodes: [
+                            { name: '~pr' },
+                            { name: '~commit' },
+                            { name: 'a', id: 1 },
+                            { name: '~sd@2:a', id: 4 },
+                            { name: 'sd@2:c', id: 6 }
+                        ],
+                        edges: [
+                            { src: '~pr', dest: 'a' },
+                            { src: '~commit', dest: 'a' },
+                            { src: '~sd@2:a', dest: 'a' },
+                            { src: 'a', dest: 'sd@2:c' }
+                        ]
+                    };
+                    buildMock.parentBuilds = {
+                        2: { eventId: '8887', jobs: { a: 12345 } }
+                    };
+                    const parentBuilds = {
+                        123: { eventId: '8888', jobs: { a: 12345 } },
+                        2: { eventId: '8887', jobs: { a: 12345 } }
+                    };
+                    const buildC = {
+                        jobId: 3,
+                        status: 'CREATED',
+                        parentBuilds,
+                        start: sinon.stub().resolves()
+                    };
+                    const updatedBuildC = Object.assign(buildC, {
+                        parentBuilds,
+                        start: sinon.stub().resolves()
+                    });
+                    const jobCConfig = {
+                        baseBranch: 'master',
+                        configPipelineSha: 'abc123',
+                        eventId: 8887,
+                        jobId: 3,
+                        parentBuildId: [12345],
+                        parentBuilds: {
+                            123: { eventId: '8888', jobs: { a: 12345 } },
+                            2: { eventId: '8887', jobs: { a: 12345, b: null } }
+                        },
+                        prRef: '',
+                        prSource: '',
+                        prInfo: '',
+                        scmContext: 'github:github.com',
+                        sha: '58393af682d61de87789fb4961645c42180cec5a',
+                        start: false,
+                        username: 12345
+                    };
+
+                    buildC.update = sinon.stub().resolves(updatedBuildC);
+                    const externalEventMock = {
+                        sha: '58393af682d61de87789fb4961645c42180cec5a',
+                        pr: {},
+                        id: 8887,
+                        configPipelineSha: 'abc123',
+                        pipelineId: 123,
+                        baseBranch: 'master',
+                        builds: [
+                            {
+                                id: 888,
+                                jobId: 4,
+                                status: 'SUCCESS'
+                            }
+                        ],
+                        getBuilds: sinon.stub().resolves([
+                            {
+                                id: 888,
+                                jobId: 4,
+                                status: 'SUCCESS'
+                            }
+                        ]),
+                        workflowGraph: {
+                            nodes: [
+                                { name: '~pr' },
+                                { name: '~commit' },
+                                { name: 'a', id: 4 },
+                                { name: 'b', id: 8 },
+                                { name: 'c', id: 6 },
+                                { name: '~sd@123:c', id: 3 }
+                            ],
+                            edges: [
+                                { src: '~pr', dest: 'a' },
+                                { src: '~commit', dest: 'a' },
+                                { src: 'a', dest: '~sd@123:c' },
+                                { src: '~sd@123:c', dest: 'c' },
+                                { src: 'b', dest: 'c', join: true }
+                            ]
+                        }
+                    };
+
+                    buildFactoryMock.getLatestBuilds.resolves([
+                        {
+                            jobId: 3,
+                            status: 'SUCCESS'
+                        }
+                    ]);
+                    eventFactoryMock.get.withArgs('8887').resolves(externalEventMock);
+                    eventFactoryMock.get.withArgs(8889).resolves({ ...externalEventMock, id: '8889' });
+                    eventFactoryMock.list.resolves([{ ...externalEventMock, id: '8889' }]);
+                    buildFactoryMock.create.onCall(0).resolves(buildC);
+                    buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
+
+                    return newServer.inject(options).then(() => {
+                        assert.notCalled(eventFactoryMock.create);
+                        assert.calledOnce(buildFactoryMock.getLatestBuilds);
+                        assert.calledOnce(buildFactoryMock.create);
+                        assert.calledWith(buildFactoryMock.create, jobCConfig);
+                        assert.calledOnce(buildC.update);
+                        assert.calledOnce(updatedBuildC.start);
+                    });
+                });
+
+                it('starts multiple builds with the existing downstream event', () => {
+                    eventMock.workflowGraph = {
+                        nodes: [
+                            { name: '~pr' },
+                            { name: '~commit' },
+                            { name: 'b', id: 2 },
+                            { name: 'sd@2:a', id: 4 },
+                            { name: 'sd@2:b', id: 5 },
+                            { name: 'a', id: 1 },
+                            { name: 'sd@2:c', id: 6 },
+                            { name: 'sd@2:d', id: 7 },
+                            { name: 'c', id: 3 }
+                        ],
+                        edges: [
+                            { src: '~commit', dest: 'b' },
+                            { src: 'b', dest: 'sd@2:a' },
+                            { src: 'b', dest: 'sd@2:b' },
+                            { src: 'sd@2:a', dest: 'a', join: true },
+                            { src: 'sd@2:b', dest: 'a', join: true },
+                            { src: 'a', dest: 'sd@2:c' },
+                            { src: 'a', dest: 'sd@2:d' },
+                            { src: 'sd@2:c', dest: 'c', join: true },
+                            { src: 'sd@2:d', dest: 'c', join: true }
+                        ]
+                    };
+                    buildMock.parentBuilds = {
+                        1: { eventId: '8888', jobs: { b: 12345 } },
+                        2: { eventId: '8889', jobs: { a: 12346, b: 12347 } }
+                    };
+                    buildFactoryMock.getLatestBuilds.resolves([
+                        {
+                            jobId: 4,
+                            status: 'SUCCESS'
+                        },
+                        {
+                            jobId: 5,
+                            status: 'SUCCESS'
+                        }
+                    ]);
+
+                    const externalEventMock = {
+                        id: 2,
+                        pipelineId: 2,
+                        builds: [],
+                        getBuilds: sinon.stub().resolves([]),
+                        workflowGraph: {
+                            nodes: [
+                                { name: '~pr' },
+                                { name: '~commit' },
+                                { name: 'a', id: 4 },
+                                { name: '~sd@1:a', id: 1 },
+                                { name: 'sd@1:b', id: 2 },
+                                { name: 'b', id: 5 },
+                                { name: 'c', id: 6 },
+                                { name: '~sd@1:b', id: 2 },
+                                { name: 'sd@1:c', id: 3 },
+                                { name: 'd', id: 7 },
+                                { name: 'sd@2:d', id: 7 },
+                                { name: 'sd@2:c', id: 6 }
+                            ],
+                            edges: [
+                                { src: '~sd@1:a', dest: 'c' },
+                                { src: 'a', dest: 'sd@1:a' },
+                                { src: '~sd@1:a', dest: 'd' },
+                                { src: 'b', dest: 'sd@1:a' },
+                                { src: '~sd@1:b', dest: 'a' },
+                                { src: 'c', dest: 'sd@1:c' },
+                                { src: '~sd@1:b', dest: 'b' },
+                                { src: 'd', dest: 'sd@1:c' },
+                                { src: '~sd@1:b', dest: 'sd@2:b' },
+                                { src: '~sd@1:b', dest: 'sd@2:a' },
+                                { src: '~sd@1:b', dest: 'sd@2:b' },
+                                { src: '~sd@1:b', dest: 'sd@2:a' }
+                            ]
+                        }
+                    };
+
+                    eventFactoryMock.get.withArgs('8887').resolves(externalEventMock);
+                    eventFactoryMock.list.resolves([{ ...externalEventMock, id: '8889' }]);
+                    buildFactoryMock.create.onCall(0).returns({ ...buildMock, status: 'CREATED' });
+                    buildFactoryMock.create.onCall(1).returns({ ...buildMock, status: 'CREATED' });
+                    jobFactoryMock.get.withArgs(6).resolves({ id: 6, state: 'ENABLED' });
+                    jobFactoryMock.get.withArgs(7).resolves({ id: 7, state: 'ENABLED' });
+
+                    return newServer.inject(options).then(() => {
+                        assert.notCalled(eventFactoryMock.create);
+                        assert.calledTwice(buildFactoryMock.create);
+                        assert.calledTwice(buildMock.start);
+                    });
+                });
+
                 it('creates a single event for downstream triggers in the same pipeline', () => {
                     // For a pipeline like this:
                     //      -> b

--- a/test/plugins/data/validator.output.json
+++ b/test/plugins/data/validator.output.json
@@ -90,7 +90,7 @@
         "edges": [
             { "src": "~pr", "dest": "main" },
             { "src": "~commit", "dest": "main" },
-            { "src": "main", "dest": "publish" }
+            { "src": "main", "dest": "publish", "join": true }
         ]
     }
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If a Remote Triggered downstream pipeline was Remote Triggered twice, only one job would be triggered.
Reference: https://github.com/screwdriver-cd/screwdriver/issues/2980.

Due to this issue, https://github.com/screwdriver-cd/screwdriver/pull/2964 was reverted.

I would like to change the https://github.com/screwdriver-cd/screwdriver/pull/2964 again with this issue resolved.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
As mentioned in https://github.com/screwdriver-cd/screwdriver/issues/2980#issuecomment-1895114395, the problem is that the loop would return, so we will fix it so that it triggers all necessary builds without returning.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
**The unit test fails until https://github.com/screwdriver-cd/workflow-parser/pull/49 is published.**

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
