### PR TITLE
feat: return namespace, name in create pipelineTemplate

### DIFF
--- a/plugins/pipelines/templates/create.js
+++ b/plugins/pipelines/templates/create.js
@@ -12,10 +12,10 @@ module.exports = () => ({
         description: 'Create a new pipeline template',
         notes: 'Create a specific pipeline template',
         tags: ['api', 'pipelineTemplate'],
-        // auth: {
-        //     strategies: ['token'],
-        //     scope: ['build', 'user', 'pipeline']
-        // },
+        auth: {
+            strategies: ['token'],
+            scope: ['build']
+        },
         handler: async (request, h) => {
             const { pipelineTemplateVersionFactory, pipelineTemplateFactory } = request.server.app;
 

--- a/plugins/pipelines/templates/create.js
+++ b/plugins/pipelines/templates/create.js
@@ -12,11 +12,10 @@ module.exports = () => ({
         description: 'Create a new pipeline template',
         notes: 'Create a specific pipeline template',
         tags: ['api', 'pipelineTemplate'],
-        auth: {
-            strategies: ['token'],
-            scope: ['build']
-        },
-
+        // auth: {
+        //     strategies: ['token'],
+        //     scope: ['build', 'user', 'pipeline']
+        // },
         handler: async (request, h) => {
             const { pipelineTemplateVersionFactory, pipelineTemplateFactory } = request.server.app;
 
@@ -39,7 +38,7 @@ module.exports = () => ({
                 throw boom.forbidden('Not allowed to publish this template');
             }
 
-            const template = await pipelineTemplateVersionFactory.create(
+            const templateVersion = await pipelineTemplateVersionFactory.create(
                 {
                     ...config.template,
                     pipelineId
@@ -48,11 +47,18 @@ module.exports = () => ({
             );
 
             const location = new URL(
-                `${request.path}/${template.id}`,
+                `${request.path}/${templateVersion.id}`,
                 `${request.server.info.protocol}://${request.headers.host}`
             ).toString();
 
-            return h.response(template.toJson()).header('Location', location).code(201);
+            return h
+                .response({
+                    namespace: config.template.namespace,
+                    name: config.template.name,
+                    ...templateVersion.toJson()
+                })
+                .header('Location', location)
+                .code(201);
         },
         validate: {
             payload: templateSchema.input

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -323,7 +323,9 @@ describe('pipeline plugin test', () => {
                     `${reply.request.server.info.protocol}://${reply.request.headers.host}`
                 ).toString();
 
-                assert.deepEqual(reply.result, testTemplate);
+                assert.deepEqual(reply.result, {
+                    ...testTemplate
+                });
                 assert.strictEqual(reply.headers.location, expectedLocation);
                 assert.calledWith(pipelineTemplateFactoryMock.get, {
                     name: 'template_name',


### PR DESCRIPTION
## Context

Create pipeline template endpoint should return namespace and name

## Objective

Added a change to return the `templateMeta` information

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
