### PR TITLE
feat: getWithMetadata from pipelineTemplateVersion

### DIFF
--- a/plugins/pipelines/templates/createTag.js
+++ b/plugins/pipelines/templates/createTag.js
@@ -33,13 +33,13 @@ module.exports = () => ({
 
             const [pipeline, template, templateTag] = await Promise.all([
                 pipelineFactory.get(pipelineId),
-                pipelineTemplateVersionFactory.get({ name, namespace, version }, pipelineTemplateFactory),
+                pipelineTemplateVersionFactory.getWithMetadata({ name, namespace, version }, pipelineTemplateFactory),
                 pipelineTemplateTagFactory.get({ name, namespace, tag })
             ]);
 
             // If template doesn't exist, throw error
             if (!template) {
-                throw boom.notFound(`PipelineTemplate ${name}@${version} not found`);
+                throw boom.notFound(`PipelineTemplate ${namespace / name}@${version} not found`);
             }
 
             // check if build has permission to publish

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -833,7 +833,7 @@ describe('pipeline plugin test', () => {
             pipeline = getPipelineMocks(testPipeline);
             pipelineFactoryMock.get.resolves(pipeline);
             templateMock = getTemplateMocks(testTemplate);
-            pipelineTemplateVersionFactoryMock.get.resolves(templateMock);
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(templateMock);
         });
 
         it('creates template tag if template tag does not exist yet', () => {
@@ -848,7 +848,7 @@ describe('pipeline plugin test', () => {
                 assert.deepEqual(reply.result, hoek.merge({ id: 123 }, payload));
                 assert.strictEqual(reply.headers.location, expectedLocation);
                 assert.calledWith(
-                    pipelineTemplateVersionFactoryMock.get,
+                    pipelineTemplateVersionFactoryMock.getWithMetadata,
                     {
                         name: 'nodejs',
                         namespace: 'screwdriver',
@@ -884,7 +884,7 @@ describe('pipeline plugin test', () => {
             return server.inject(options).then(reply => {
                 assert.deepEqual(reply.result.version, template.version);
                 assert.calledWith(
-                    pipelineTemplateVersionFactoryMock.get,
+                    pipelineTemplateVersionFactoryMock.getWithMetadata,
                     {
                         name: 'nodejs',
                         namespace: 'screwdriver',
@@ -906,7 +906,7 @@ describe('pipeline plugin test', () => {
         it('returns 403 when pipelineId does not match', () => {
             templateMock = getTemplateMocks(testTemplate);
             templateMock.pipelineId = 321;
-            pipelineTemplateVersionFactoryMock.get.resolves(templateMock);
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(templateMock);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 403);
@@ -914,7 +914,7 @@ describe('pipeline plugin test', () => {
         });
 
         it('returns 404 when template does not exist', () => {
-            pipelineTemplateVersionFactoryMock.get.resolves(null);
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(null);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);


### PR DESCRIPTION
## Context

Use `getWithMetadata` from `pipelineTemplateVersionFactory` as we need `pipelineId`

## Objective

Call function `getWithMetadata` to get all fields related to pipelineTemplateVersion

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
