### PR TITLE
feat: fix getVersion for pipelineTemplates

### DIFF
--- a/plugins/pipelines/templates/getVersion.js
+++ b/plugins/pipelines/templates/getVersion.js
@@ -20,13 +20,22 @@ module.exports = () => ({
         },
         handler: async (request, h) => {
             const { namespace, name, versionOrTag } = request.params;
-            const { pipelineTemplateFactory, pipelineTemplateVersionFactory } = request.server.app;
+            const { pipelineTemplateFactory, pipelineTemplateVersionFactory, pipelineTemplateTagFactory } =
+                request.server.app;
+
+            const templateTag = await pipelineTemplateTagFactory.get({
+                name,
+                namespace,
+                tag: versionOrTag
+            });
+
+            const version = templateTag ? templateTag.version : versionOrTag;
 
             const pipelineTemplate = await pipelineTemplateVersionFactory.getWithMetadata(
                 {
                     name,
                     namespace,
-                    versionOrTag
+                    version
                 },
                 pipelineTemplateFactory
             );

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -760,6 +760,10 @@ describe('pipeline plugin test', () => {
 
     describe('GET /pipeline/template/{namespace}/{name}/{versionOrTag}', () => {
         let options;
+        const payload = {
+            version: '1.2.3'
+        };
+        const testTemplateTag = decorateObj(hoek.merge({ id: 123 }, payload));
 
         beforeEach(() => {
             options = {
@@ -775,14 +779,25 @@ describe('pipeline plugin test', () => {
                 }
             };
 
+            pipelineTemplateTagFactoryMock.get.resolves(null);
             pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(testTemplateVersionsGet);
         });
 
-        it('returns 200 for getting a template', () =>
+        it('returns 200 for getting a template with version', () =>
             server.inject(options).then(reply => {
                 assert.deepEqual(reply.result, testTemplateVersionsGet);
                 assert.equal(reply.statusCode, 200);
             }));
+
+        it('returns 200 for getting a template with tag', () => {
+            pipelineTemplateTagFactoryMock.get.resolves(testTemplateTag);
+            options.url = '/pipeline/template/screwdriver/nodejs/stable';
+
+            server.inject(options).then(reply => {
+                assert.deepEqual(reply.result, testTemplateVersionsGet);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
 
         it('returns 404 when template does not exist', () => {
             pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(null);


### PR DESCRIPTION
## Context

Fix GET pipeline template version with version or tag

## Objective

Fix GET pipeline template version with version or tag

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
