### PR TITLE
feat: move name, namespace to config for pipelineTemplates

### DIFF
--- a/plugins/pipelines/templates/listVersions.js
+++ b/plugins/pipelines/templates/listVersions.js
@@ -24,7 +24,8 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { pipelineTemplateFactory, pipelineTemplateVersionFactory } = request.server.app;
             const config = {
-                params: request.params,
+                namespace: request.params.namespace,
+                name: request.params.name,
                 sort: request.query.sort
             };
 

--- a/plugins/pipelines/templates/remove.js
+++ b/plugins/pipelines/templates/remove.js
@@ -32,7 +32,7 @@ module.exports = () => ({
 
             const [tags, templateVersions] = await Promise.all([
                 pipelineTemplateTagFactory.list({ params: { namespace, name } }),
-                pipelineTemplateVersionFactory.list({ params: { namespace, name } }, pipelineTemplateFactory)
+                pipelineTemplateVersionFactory.list({ namespace, name }, pipelineTemplateFactory)
             ]);
 
             const canRemoveFlag = await canRemove(credentials, pipelineTemplate, 'admin', request.server.app);

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -568,10 +568,8 @@ describe('pipeline plugin test', () => {
                 assert.calledWith(
                     pipelineTemplateVersionFactoryMock.list,
                     {
-                        params: {
-                            name: 'nodejs',
-                            namespace: 'screwdriver'
-                        },
+                        name: 'nodejs',
+                        namespace: 'screwdriver',
                         paginate: {
                             page: undefined,
                             count: 30
@@ -1011,10 +1009,8 @@ describe('pipeline plugin test', () => {
                 assert.calledWith(
                     pipelineTemplateVersionFactoryMock.list,
                     {
-                        params: {
-                            name: 'nodejs',
-                            namespace: 'screwdriver'
-                        }
+                        name: 'nodejs',
+                        namespace: 'screwdriver'
                     },
                     pipelineTemplateFactoryMock
                 );


### PR DESCRIPTION
## Context

Move name, and namespace to config object for `pipelineTemplates`

## Objective

Move name, and namespace to config for `pipelineTemplates`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
