### PR TITLE
[2]feat(3012): add functional tests related to triggers

### DIFF
--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -181,6 +181,36 @@ Then(
 );
 
 Then(
+    /^the "(.*)" job is triggered once$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step(jobName) {
+        return sdapi
+            .searchForBuilds({
+                instance: this.instance,
+                pipelineId: this.pipelineId,
+                desiredSha: this.sha,
+                desiredStatus: ['QUEUED', 'RUNNING', 'SUCCESS', 'FAILURE'],
+                jobName,
+                jwt: this.jwt
+            })
+            .then(builds => {
+                if (builds.length > 1) {
+                    Assert.fail(`${jobName} has been triggered more than twice.`);
+                }
+                const build = builds[0];
+                this.eventId = build.eventId;
+                const job = this.jobs.find(j => j.name === jobName);
+
+                Assert.equal(build.jobId, job.id);
+
+                this.buildId = build.id;
+            });
+    }
+);
+
+Then(
     /^the "(.*)" PR job is triggered$/,
     {
         timeout: TIMEOUT

--- a/features/trigger.feature
+++ b/features/trigger.feature
@@ -5,9 +5,9 @@ Feature: Remote Trigger
     express dependencies between otherwise unrelated projects.
 
     Eg: The following combined pipeline workflows:
-        (~commit) -> (success_A) -> (success_B)
+        (~commit) -> (success_A_*) -> (success_B_*)
 
-        (fail_A) -> (fail_B)
+        (fail_A) -> (fail_B_*)
 
                         (parallel_B1)
         (parallel_A) ->
@@ -26,24 +26,91 @@ Feature: Remote Trigger
         - If multiple jobs in a pipeline requires the same external pipeline's Job as trigger, then
           builds for these jobs should be part of same pipeline event
 
+    @prod
     Scenario: External builds are not triggered if required build is not successful.
         Given an existing pipeline on branch "pipelineA" with job "fail_A"
         And an existing pipeline on branch "pipelineB" with the workflow jobs:
-            | job       | requires      |
-            | fail_B    | ~sd@?:fail_A  |
+            | job         | requires      |
+            | fail_B_prod | ~sd@?:fail_A  |
         When the "fail_A" job on branch "pipelineA" is started
         And the "fail_A" build failed
-        Then the "fail_B" job on branch "pipelineB" is not triggered
+        Then the "fail_B_prod" job on branch "pipelineB" is not triggered
 
+    @beta
+    Scenario: External builds are not triggered if required build is not successful.
+        Given an existing pipeline on branch "pipelineA" with job "fail_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job         | requires      |
+            | fail_B_beta | ~sd@?:fail_A  |
+        When the "fail_A" job on branch "pipelineA" is started
+        And the "fail_A" build failed
+        Then the "fail_B_beta" job on branch "pipelineB" is not triggered
+
+    @prod
+    Scenario: External join build is triggered after another build is successful.
+        Given an existing pipeline on branch "pipelineA" with job "success_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job            | requires                         |
+            | or_join_B_prod | ~sd@?:success_A, ~sd@?:fail_A |
+        When the "success_A" job on branch "pipelineA" is started
+        And the "success_A" build succeeded
+        Then the "or_join_B_prod" job on branch "pipelineB" is started
+        And the "or_join_B_prod" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
+
+    @beta
+    Scenario: External join build is triggered after another build is successful.
+        Given an existing pipeline on branch "pipelineA" with job "success_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job            | requires                         |
+            | or_join_B_beta | ~sd@?:success_A, ~sd@?:fail_A |
+        When the "success_A" job on branch "pipelineA" is started
+        And the "success_A" build succeeded
+        Then the "or_join_B_beta" job on branch "pipelineB" is started
+        And the "or_join_B_beta" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
+
+    @prod
     Scenario: External build is triggered after another build is successful.
         Given an existing pipeline on branch "pipelineA" with job "success_A"
         And an existing pipeline on branch "pipelineB" with the workflow jobs:
-            | job       | requires          |
-            | success_B | ~sd@?:success_A   |
+            | job               | requires        |
+            | success_B_or_prod | ~sd@?:success_A |
         When the "success_A" job on branch "pipelineA" is started
         And the "success_A" build succeeded
-        Then the "success_B" job on branch "pipelineB" is started
-        And the "success_B" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
+        Then the "success_B_or_prod" job on branch "pipelineB" is started
+        And the "success_B_or_prod" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
+
+    @beta
+    Scenario: External build is triggered after another build is successful.
+        Given an existing pipeline on branch "pipelineA" with job "success_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job                | requires        |
+            | success_B_and_beta | ~sd@?:success_A |
+        When the "success_A" job on branch "pipelineA" is started
+        And the "success_A" build succeeded
+        Then the "success_B_or_beta" job on branch "pipelineB" is started
+        And the "success_B_or_beta" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
+
+    @prod
+    Scenario: External build which requires single AND trigger is triggered after another build is successful.
+        Given an existing pipeline on branch "pipelineA" with job "success_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job                | requires       |
+            | success_B_and_prod | sd@?:success_A |
+        When the "success_A" job on branch "pipelineA" is started
+        And the "success_A" build failed
+        Then the "success_B_and_prod" job on branch "pipelineB" is not triggered
+        And the "success_B_and_prod" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
+
+    @beta
+    Scenario: External build which requires single AND trigger is triggered after another build is successful.
+        Given an existing pipeline on branch "pipelineA" with job "success_A"
+        And an existing pipeline on branch "pipelineB" with the workflow jobs:
+            | job                | requires       |
+            | success_B_and_beta | sd@?:success_A |
+        When the "success_A" job on branch "pipelineA" is started
+        And the "success_A" build failed
+        Then the "success_B_and_beta" job on branch "pipelineB" is not triggered
+        And the "success_B_and_beta" build's parentBuildId on branch "pipelineB" is that "success_A" build's buildId
 
     Scenario: Fan-out. Multiple external builds are triggered in parallel as a result of a build's success.
         Given an existing pipeline on branch "pipelineA" with job "parallel_A"
@@ -141,15 +208,43 @@ Feature: Remote Trigger
       Then a new build from "job1" should be created to test that change
 
     @require-or
-    Scenario: require-or
+    Scenario: SINGLE OR FAIL
         Given an existing pipeline on branch "master" with the workflow jobs:
-            | job       | requires     |
-            | job1      |  ~commit     |
-            | job2      |  ~commit     |
-            | OR        | ~job1, ~job2 |
-        When start "job1" job
-        And the "job1" build succeeded
-        Then the "OR" job is triggered
-        When start "job2" job
-        And the "job2" build succeeded
-        Then the "OR" job is triggered
+            | job       | requires |
+            | FAIL      |          |
+            | AFTERFAIL | ~FAIL    |
+        When start "FAIL" job
+        And the "FAIL" build failed
+        Then the "AFTERFAIL" job is not triggered
+
+    @require-or
+    Scenario: JOIN OR
+        Given an existing pipeline on branch "master" with the workflow jobs:
+            | job       | requires               |
+            | PARALLEL1 |                        |
+            | PARALLEL2 |                        |
+            | JOIN      | ~PARALLEL1, ~PARALLEL2 |
+        When start "PARALLEL1" job
+        And the "PARALLEL1" build succeeded
+        And the "JOIN" job is triggered
+        Then that "JOIN" build uses the same SHA as the "PARALLEL1" build
+        When start "PARALLEL2" job
+        And the "PARALLEL2" build succeeded
+        And the "JOIN" job is triggered
+        Then that "JOIN" build uses the same SHA as the "PARALLEL2" build
+
+    @require-or
+    Scenario: JOIN OR ONCE
+        Given an existing pipeline on branch "master" with the workflow jobs:
+            | job            | requires               |
+            | SIMPLE         | ~commit                |
+            | PARALLEL1      | ~SIMPLE                |
+            | PARALLEL2      | ~SIMPLE                |
+            | JOIN           | ~PARALLEL1, ~PARALLEL2 |
+        When start "SIMPLE" job
+        And the "SIMPLE" build succeeded
+        And the "PARALLEL1" job is triggered from "SIMPLE"
+        And the "PARALLEL1" build succeeded
+        And the "PARALLEL2" job is triggered from "SIMPLE"
+        And the "PARALLEL2" build succeeded
+        Then the "JOIN" job is triggered once

--- a/features/workflow.feature
+++ b/features/workflow.feature
@@ -68,6 +68,19 @@ Feature: Workflow
         Then the "JOIN" job is triggered from "PARALLEL1" and "PARALLEL2"
         And that "JOIN" build uses the same SHA as the "SIMPLE" build
 
+    Scenario: Join Failure
+        Given an existing pipeline on "failure" branch with the workflow jobs:
+            | job             | requires     |
+            | SIMPLE          | ~commit      |
+            | FAIL            | ~commit      |
+            | AFTER-FAIL-JOIN | SIMPLE, FAIL |
+        When a new commit is pushed to "failure" branch
+        Then the "SIMPLE" job is triggered
+        Then the "SIMPLE" build succeeded
+        Then the "FAIL" job is triggered
+        Then the "FAIL" build failed
+        Then the "AFTER-FAIL-JOIN" job is not triggered
+
     Scenario: Branch filtering (the master branch is committed)
         Given an existing pipeline on "master" branch with the workflow jobs:
             | job           | requires              |


### PR DESCRIPTION
## Context
We want to add the necessary tests before the refactoring of triggers.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
I added following function tests related to triggers.

- Cases where `a` fails with require `[∼a]`
- Cases where `a` succeeds with require `[∼a, ~b]`
- Cases where both `a` and `b` succeed with require `[∼a, ~b]`
- Cases where `a` succeeds but `b` fails with require `[a, b]`
- Cases where `sd@_:a` succeeds with require `[sd@_:a]`
- Cases where `sd@_:a` succeeds with require `[~sd@_:a, ~sd@_:b]`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/3012
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
