### PR TITLE
fix(2368): Fix description in swagger [2]

### DIFF
--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -4,6 +4,7 @@ const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
 const joi = require('joi');
 const buildIdSchema = schema.models.build.base.extract('id');
+const usernameSchema = schema.models.user.base.extract('username');
 
 /**
  * Generate a new JSON Web Token
@@ -60,7 +61,7 @@ module.exports = () => ({
         },
         validate: {
             params: joi.object({
-                buildId: buildIdSchema
+                buildId: joi.alternatives().try(buildIdSchema, usernameSchema)
             })
         }
     }

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -2,6 +2,8 @@
 
 const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
+const joi = require('joi');
+const buildIdSchema = schema.models.build.base.extract('id');
 
 /**
  * Generate a new JSON Web Token
@@ -55,6 +57,11 @@ module.exports = () => ({
         },
         response: {
             schema: schema.api.auth.token
+        },
+        validate: {
+            params: joi.object({
+                buildId: buildIdSchema
+            })
         }
     }
 });

--- a/plugins/builds/steps/list.js
+++ b/plugins/builds/steps/list.js
@@ -64,7 +64,7 @@ module.exports = () => ({
             schema: listSchema
         },
         validate: {
-            params:joi.object({
+            params: joi.object({
                 id: idSchema
             })
         }

--- a/plugins/builds/steps/list.js
+++ b/plugins/builds/steps/list.js
@@ -3,7 +3,6 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
-const {isSchema} = require('joi');
 const listSchema = joi.array().items(schema.models.build.getStep).label('List of steps');
 const idSchema = schema.models.build.base.extract('id');
 

--- a/plugins/builds/steps/list.js
+++ b/plugins/builds/steps/list.js
@@ -66,7 +66,7 @@ module.exports = () => ({
         },
         validate: {
             params:joi.object({
-                id: isSchema
+                id: idSchema
             })
         }
     }

--- a/plugins/builds/steps/list.js
+++ b/plugins/builds/steps/list.js
@@ -3,7 +3,9 @@
 const boom = require('@hapi/boom');
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
+const {isSchema} = require('joi');
 const listSchema = joi.array().items(schema.models.build.getStep).label('List of steps');
+const idSchema = schema.models.build.base.extract('id');
 
 module.exports = () => ({
     method: 'GET',
@@ -61,6 +63,11 @@ module.exports = () => ({
         },
         response: {
             schema: listSchema
+        },
+        validate: {
+            params:joi.object({
+                id: isSchema
+            })
         }
     }
 });

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -43,6 +43,8 @@ module.exports = () => ({
                         config.params.type = 'pr';
                         config.params.prNum = request.query.prNum;
                     }
+                    config.sort = request.query.sort;
+                    config.sortBy = request.query.sortBy;
 
                     return pipeline.getEvents(config);
                 })
@@ -62,7 +64,8 @@ module.exports = () => ({
                 joi.object({
                     type: joi.string(),
                     prNum: prNumSchema,
-                    search: joi.forbidden() // we don't support search for Pipeline list events
+                    search: joi.forbidden(), // we don't support search for Pipeline list events
+                    getCount: joi.forbidden() // we don't support search for Pipeline list events
                 })
             )
         }

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -43,8 +43,6 @@ module.exports = () => ({
                         config.params.type = 'pr';
                         config.params.prNum = request.query.prNum;
                     }
-                    config.sort = request.query.sort;
-                    config.sortBy = request.query.sortBy;
 
                     return pipeline.getEvents(config);
                 })

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -63,7 +63,7 @@ module.exports = () => ({
                     type: joi.string(),
                     prNum: prNumSchema,
                     search: joi.forbidden(), // we don't support search for Pipeline list events
-                    getCount: joi.forbidden() // we don't support search for Pipeline list events
+                    getCount: joi.forbidden() // we don't support getCount for Pipeline list events
                 })
             )
         }

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -23,7 +23,8 @@ module.exports = () => ({
                 params: {
                     name: request.params.name
                 },
-                sort: request.query.sort
+                sort: request.query.sort,
+                sortBy: request.query.sortBy
             };
 
             if (request.query.page || request.query.count) {
@@ -49,7 +50,8 @@ module.exports = () => ({
             }),
             query: schema.api.pagination.concat(
                 joi.object({
-                    search: joi.forbidden() // we don't support search for Template list tags
+                    search: joi.forbidden(), // we don't support search for Template list tags
+                    getCount: joi.forbidden()
                 })
             )
         }

--- a/plugins/templates/listTags.js
+++ b/plugins/templates/listTags.js
@@ -23,8 +23,7 @@ module.exports = () => ({
                 params: {
                     name: request.params.name
                 },
-                sort: request.query.sort,
-                sortBy: request.query.sortBy
+                sort: request.query.sort
             };
 
             if (request.query.page || request.query.count) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Issues are where parameters cannot be specified or queries that cannot be used can be specified on the Swagger UI.
Details are on https://github.com/screwdriver-cd/screwdriver/issues/2368

PR [1] is https://github.com/screwdriver-cd/data-schema/pull/550

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix the above problem. Details are as follows.
- getCount is only used in templates/ and commands/ endpoints, so it is disabled.
- Parameters can be specified.

However, due to the #3036 problem, /auth/token only accepts BuildId(integer) on the UI and not UserName(string).
Also, JWT cannot be obtained using api_token queries if buildId in auth/token is set to required, so it is set to optional.

The modified endpoints are as follows.
- [GET /v4/auth/token](https://api.screwdriver.cd/v4/documentation#/v4/getV4AuthTokenBuildid)
- [GET /v4/builds/{id}/steps](https://api.screwdriver.cd/v4/documentation#/v4/getV4BuildsIdSteps)
- [GET /v4/pipelines/{id}/events](https://api.screwdriver.cd/v4/documentation#/v4/getV4PipelinesIdEvents)
- [GET /v4/templates/{name}/tags](https://api.screwdriver.cd/v4/documentation#/v4/getV4TemplatesNameTags)

Example of After
![New](https://github.com/screwdriver-cd/screwdriver/assets/138551445/15b35a04-bc62-4f77-8921-41a88ddec034)
![New](https://github.com/screwdriver-cd/screwdriver/assets/138551445/5dc8bbe0-0e6f-4655-8907-7eb2fd4f1121)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2368
#3036 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
