### PR TITLE
feat(3036): update hapi-swagger package

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "hapi-auth-bearer-token": "^8.0.0",
     "hapi-auth-jwt2": "^10.4.0",
     "hapi-rate-limit": "^7.1.0",
-    "hapi-swagger": "^15.0.0",
+    "hapi-swagger": "^17.2.1",
     "ioredis": "^5.2.3",
     "joi": "^17.7.0",
     "js-yaml": "^3.14.1",

--- a/plugins/swagger.js
+++ b/plugins/swagger.js
@@ -19,6 +19,7 @@ const swaggerPlugin = {
                         in: 'header'
                     }
                 },
+                OAS: 'v3.0',
                 // see https://github.com/glennjones/hapi-swagger/blob/master/optionsreference.md#json-json-endpoint-needed-to-create-ui
                 documentationRoutePlugins: {
                     'hapi-rate-limit': {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Cullently Swagger plugin version is v2, but this version does not support some feature.
https://github.com/screwdriver-cd/screwdriver/issues/3036

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Bump up `hapi/swagger` module.
After this PR, we will use OpenAPI v3 but its setting file is automatically generated by `hapi/swagger`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3036

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
