### PR TITLE
feat(3056): add endpoint to mark pipeline template as trusted

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "screwdriver-coverage-bookend": "^2.0.0",
     "screwdriver-coverage-sonar": "^4.1.1",
     "screwdriver-data-schema": "^v23.0.0",
-    "screwdriver-datastore-sequelize": "^8.0.0",
+    "screwdriver-datastore-sequelize": "^8.1.1",
     "screwdriver-executor-base": "^9.0.1",
     "screwdriver-executor-docker": "^6.0.0",
     "screwdriver-executor-k8s": "^15.0.1",

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -361,3 +361,23 @@ Delete the template tag. This does not delete the template itself.
 * `namespace` - Namespace of the template
 * `name` - Name of the template
 * `tag` - Tag name of the template
+
+##### Update a pipeline template's trusted property
+
+Update a pipeline template's trusted property
+
+`PUT /pipeline/templates/{namespace}/{name}/trusted`
+
+###### Arguments
+
+'namespace', 'name'
+
+* `namespace` - Namespace of the template
+* `name` - Name of the template
+
+Example payload:
+```json
+{
+    "trusted": true
+}
+```

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -41,6 +41,7 @@ const getVersionRoute = require('./templates/getVersion');
 const removeTemplateRoute = require('./templates/remove');
 const removeTemplateTagRoute = require('./templates/removeTag');
 const removeTemplateVersionRoute = require('./templates/removeVersion');
+const updateTrustedRoute = require('./templates/updateTrusted');
 
 /**
  * Pipeline API Plugin
@@ -272,7 +273,8 @@ const pipelinesPlugin = {
             createTagRoute(),
             removeTemplateRoute(),
             removeTemplateTagRoute(),
-            removeTemplateVersionRoute()
+            removeTemplateVersionRoute(),
+            updateTrustedRoute()
         ]);
     }
 };

--- a/plugins/pipelines/templates/updateTrusted.js
+++ b/plugins/pipelines/templates/updateTrusted.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const metaSchema = schema.models.templateMeta.base;
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/pipeline/templates/{namespace}/{name}/trusted',
+    options: {
+        description: "Update a pipeline template's trusted property",
+        notes: 'Returns null if successful',
+        tags: ['api', 'pipeline', 'templates', 'trusted'],
+        auth: {
+            strategies: ['token'],
+            scope: ['admin', '!guest']
+        },
+
+        handler: async (request, h) => {
+            const { namespace, name } = request.params;
+            const { pipelineTemplateFactory } = request.server.app;
+            const { trusted } = request.payload;
+
+            const pipelineTemplateMeta = await pipelineTemplateFactory.get({
+                name,
+                namespace
+            });
+
+            if (!pipelineTemplateMeta) {
+                throw boom.notFound(`Pipeline template ${namespace}/${name} does not exist`);
+            }
+
+            if (!trusted) {
+                pipelineTemplateMeta.trustedSinceVersion = null;
+            } else if (trusted && !pipelineTemplateMeta.trustedSinceVersion) {
+                pipelineTemplateMeta.trustedSinceVersion = pipelineTemplateMeta.latestVersion;
+            }
+
+            return pipelineTemplateMeta.update().then(
+                () => h.response().code(204),
+                err => h.response(boom.boomify(err))
+            );
+        },
+        validate: {
+            params: joi.object({
+                namespace: metaSchema.extract('namespace'),
+                name: metaSchema.extract('name')
+            }),
+            payload: joi.object({
+                trusted: joi.boolean().description('Whether pipeline template is trusted')
+            })
+        }
+    }
+});

--- a/test/plugins/data/pipeline-template-untrusted.json
+++ b/test/plugins/data/pipeline-template-untrusted.json
@@ -1,0 +1,13 @@
+{
+    "id": 123,
+    "pipelineId": 123,
+    "namespace": "my-namespace",
+    "name": "example-template",
+    "description": "An example template",
+    "maintainer": "example@gmail.com",
+    "trustedSinceVersion": null,
+    "latestVersion": "1.3.2",
+    "createTime": "2023-06-12T21:52:22.706Z",
+    "updateTime": "2023-06-29T11:23:45.706Z"
+}
+  


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
add endpoint to mark pipeline template as trusted
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add endpoint to mark pipeline template as trusted
## References
https://github.com/screwdriver-cd/screwdriver/issues/3056
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
