### PR TITLE
fix(3062): fix Dockerfile not to use npm start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,11 @@ RUN ln -s /usr/src/app/node_modules/screwdriver-api/config /config
 # Expose the web service port
 EXPOSE 8080
 
+# Add Tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 # Run the service
-CMD [ "npm", "start" ]
+CMD [ "node", "./bin/server" ]


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
API server cannot receive `SIGTERM`

See this issue for details:
https://github.com/screwdriver-cd/screwdriver/issues/3062

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Fix Dockerfile as belows:
  - Add tini process
  - Run the service by `node ./bin/server` directly, not via `npm start`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Issue: https://github.com/screwdriver-cd/screwdriver/issues/3062
Docker and Node.js Best Practices: 
https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
