### PR TITLE
fix: return 403/404 error when stop events with mismatched scm host

### DIFF
--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -46,7 +46,17 @@ module.exports = () => ({
             }
 
             // Check permissions
-            const permissions = await user.getPermissions(pipeline.scmUri);
+            let permissions;
+
+            try {
+                permissions = await user.getPermissions(pipeline.scmUri);
+            } catch (err) {
+                if (err.statusCode === 403 && pipeline.scmRepo && pipeline.scmRepo.private) {
+                    throw boom.notFound();
+                }
+                throw boom.boomify(err, { statusCode: err.statusCode });
+            }
+
             const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
                 username,
                 scmContext,

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1116,6 +1116,80 @@ describe('event plugin test', () => {
             }
         );
 
+        it('returns 403 forbidden error when users scm host does not match', () => {
+            const e = new Error('Users scm host does not match');
+
+            e.statusCode = 403;
+
+            userMock.getPermissions.rejects(e);
+
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'Users scm host does not match'
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+                assert.notCalled(event.getBuilds);
+                assert.notCalled(builds[0].update);
+                assert.notCalled(builds[1].update);
+                assert.notCalled(builds[2].update);
+                assert.notCalled(builds[3].update);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 404 not found error when users scm host does not match and the pipeline is private', () => {
+            pipelineMock.scmRepo = { private: true };
+
+            const e = new Error('Users scm host does not match');
+
+            e.statusCode = 403;
+
+            userMock.getPermissions.rejects(e);
+
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'Not Found'
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+                assert.notCalled(event.getBuilds);
+                assert.notCalled(builds[0].update);
+                assert.notCalled(builds[1].update);
+                assert.notCalled(builds[2].update);
+                assert.notCalled(builds[3].update);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 500 error when get permission throws error', () => {
+            const e = new Error('Something happened');
+
+            e.statusCode = 500;
+
+            userMock.getPermissions.rejects(e);
+
+            const error = {
+                statusCode: 500,
+                error: 'Internal Server Error',
+                message: 'An internal server error occurred'
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 500);
+                assert.notCalled(event.getBuilds);
+                assert.notCalled(builds[0].update);
+                assert.notCalled(builds[1].update);
+                assert.notCalled(builds[2].update);
+                assert.notCalled(builds[3].update);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
         it('returns 200 when it successfully stops all event builds with pipeline token', () => {
             options.auth.credentials = {
                 scope: ['pipeline'],


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

SD API returns 500 error when user logged in mismatch SCM host stops events.

```js
{
    "statusCode": 500,
    "error": "Internal Server Error",
    "message": "Pipeline's scmHost xxx.com does not match with user's scmHost yyy.com"
}
```

But in this case, API should return 403 error (or 404 when private pipeline).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add error handling same as https://github.com/screwdriver-cd/screwdriver/pull/2655

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/pull/2655

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
