### PR TITLE
fix(3072): Unable to delete a specific version of a pipeline template

### DIFF
--- a/plugins/pipelines/templates/removeVersion.js
+++ b/plugins/pipelines/templates/removeVersion.js
@@ -26,7 +26,7 @@ module.exports = () => ({
                 request.server.app;
 
             const [templateVersion, tags] = await Promise.all([
-                pipelineTemplateVersionFactory.getWithMetadata({ namespace, name, version }, pipelineTemplateFactory),
+                pipelineTemplateVersionFactory.get({ namespace, name, version }, pipelineTemplateFactory),
                 pipelineTemplateTagFactory.list({ params: { namespace, name, version } })
             ]);
 

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -1241,7 +1241,7 @@ describe('pipeline plugin test', () => {
             templateTagsMock = getTagsMock(testTemplateTags);
             pipelineTemplateTagFactoryMock.list.resolves(templateTagsMock);
             templateVersionMock = getTagsMock(testTemplateVersionsGet);
-            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(templateVersionMock);
+            pipelineTemplateVersionFactoryMock.get.resolves(templateVersionMock);
 
             templateMock = getTemplateMocks(testTemplate);
             pipelineTemplateFactoryMock.get.resolves(templateMock);
@@ -1270,13 +1270,13 @@ describe('pipeline plugin test', () => {
                 message: `PipelineTemplate ${templateNameSpace}/${templateName} with version ${templateVersion1} does not exist`
             };
 
-            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(null);
+            pipelineTemplateVersionFactoryMock.get.resolves(null);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, error.statusCode);
                 assert.deepEqual(reply.result, error);
                 assert.calledWith(
-                    pipelineTemplateVersionFactoryMock.getWithMetadata,
+                    pipelineTemplateVersionFactoryMock.get,
                     {
                         namespace: templateNameSpace,
                         name: templateName,
@@ -1367,7 +1367,7 @@ describe('pipeline plugin test', () => {
 
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
             templateVersionMock.latestVersion = templateVersion1;
-            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(templateVersionMock);
+            pipelineTemplateVersionFactoryMock.get.resolves(templateVersionMock);
             pipelineTemplateVersionFactoryMock.list
                 .withArgs(
                     {


### PR DESCRIPTION
## Context
API `/pipeline/templates/{templateNamespace}/{templateName}/versions/{version}` invokes `getWithMetadata` method of `PipelineTemplateVersionFactory`. But, the method `getWithMetadata` returns a plain javascript object instead of an object that extends [BaseModel](https://github.com/screwdriver-cd/models/blob/master/lib/base.js).

This results in below error
```
{
    "statusCode": 500,
    "error": "Internal Server Error",
    "message": "templateVersion.remove is not a function"
}
```


## Objective

API should call `get` instead of `getWithMetadata`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3072

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
