### PR TITLE
Revert "fix(3072): Unable to delete a specific version of a pipeline template"

### DIFF
--- a/plugins/pipelines/templates/removeVersion.js
+++ b/plugins/pipelines/templates/removeVersion.js
@@ -26,7 +26,7 @@ module.exports = () => ({
                 request.server.app;
 
             const [templateVersion, tags] = await Promise.all([
-                pipelineTemplateVersionFactory.get({ namespace, name, version }, pipelineTemplateFactory),
+                pipelineTemplateVersionFactory.getWithMetadata({ namespace, name, version }, pipelineTemplateFactory),
                 pipelineTemplateTagFactory.list({ params: { namespace, name, version } })
             ]);
 

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -1241,7 +1241,7 @@ describe('pipeline plugin test', () => {
             templateTagsMock = getTagsMock(testTemplateTags);
             pipelineTemplateTagFactoryMock.list.resolves(templateTagsMock);
             templateVersionMock = getTagsMock(testTemplateVersionsGet);
-            pipelineTemplateVersionFactoryMock.get.resolves(templateVersionMock);
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(templateVersionMock);
 
             templateMock = getTemplateMocks(testTemplate);
             pipelineTemplateFactoryMock.get.resolves(templateMock);
@@ -1270,13 +1270,13 @@ describe('pipeline plugin test', () => {
                 message: `PipelineTemplate ${templateNameSpace}/${templateName} with version ${templateVersion1} does not exist`
             };
 
-            pipelineTemplateVersionFactoryMock.get.resolves(null);
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(null);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, error.statusCode);
                 assert.deepEqual(reply.result, error);
                 assert.calledWith(
-                    pipelineTemplateVersionFactoryMock.get,
+                    pipelineTemplateVersionFactoryMock.getWithMetadata,
                     {
                         namespace: templateNameSpace,
                         name: templateName,
@@ -1367,7 +1367,7 @@ describe('pipeline plugin test', () => {
 
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
             templateVersionMock.latestVersion = templateVersion1;
-            pipelineTemplateVersionFactoryMock.get.resolves(templateVersionMock);
+            pipelineTemplateVersionFactoryMock.getWithMetadata.resolves(templateVersionMock);
             pipelineTemplateVersionFactoryMock.list
                 .withArgs(
                     {


### PR DESCRIPTION
Reverts screwdriver-cd/screwdriver#3073

The core issue is fixed in the models that affects multiple APIs
https://github.com/screwdriver-cd/models/pull/620

Issue https://github.com/screwdriver-cd/screwdriver/issues/3072