### PR TITLE
feat: Create Workflow when Issues opened or labeled

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,21 @@
+name: Issue Workflow
+
+on:
+  issues:
+    types:
+      - labeled
+      - opened
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run similarity analysis
+        if: (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'triage')) || (github.event.action == 'opened')
+        uses: actions-cool/issues-similarity-analysis@main
+        with:
+          filter-threshold: 0.3
+          title-excludes: 'bug, not, 1234'
+          comment-title: '### Similar issues'
+          comment-body: '${index}. ${similarity} #${number}'


### PR DESCRIPTION
## Context

Run similarity analysis when issues are opened or labeled with `triage`. 

## Objective

Perform cleanup of issues that have similarity and group issues accordingly based on the frequency of asks in order to learn the user pain points. 

## References

The action used in the step was found in the [Github marketplace](https://github.com/marketplace/actions/issues-similarity-analysis). Some trial runs have been performed on the personal repo to ensure that the action is safe to run and produce the expected outcome. 

- [Sample workflow](https://github.com/VonnyJap/models/blob/master/.github/workflows/issues.yaml)
- [Sample events that have been run](https://github.com/VonnyJap/models/actions/workflows/issues.yaml)
- Sample issues that have been analyzed:
  - https://github.com/VonnyJap/models/issues/10
  - https://github.com/VonnyJap/models/issues/11

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
