### PR TITLE
fix: scm-router fn needs scmContext

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "screwdriver-scm-bitbucket": "^5.0.1",
     "screwdriver-scm-github": "^12.6.0",
     "screwdriver-scm-gitlab": "^3.1.0",
-    "screwdriver-scm-router": "^7.0.0",
+    "screwdriver-scm-router": "^7.1.0",
     "screwdriver-template-validator": "^7.0.0",
     "screwdriver-workflow-parser": "^4.1.1",
     "sqlite3": "^5.1.4",

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -111,7 +111,8 @@ function addOAuthRoutes(config) {
                 if (scmConfig && scmConfig.gheCloud) {
                     const isEnterpriseUser = await userFactory.scm.isEnterpriseUser({
                         token: accessToken,
-                        login: username
+                        login: username,
+                        scmContext
                     });
 
                     if (!isEnterpriseUser) {

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -843,7 +843,8 @@ describe('auth plugin test', () => {
                             });
                             assert.calledWith(scm.isEnterpriseUser, {
                                 token,
-                                login: username
+                                login: username,
+                                scmContext
                             });
                         });
                     });
@@ -857,7 +858,8 @@ describe('auth plugin test', () => {
                             assert.notCalled(userFactoryMock.get);
                             assert.calledWith(scm.isEnterpriseUser, {
                                 token,
-                                login: username
+                                login: username,
+                                scmContext
                             });
                         });
                     });


### PR DESCRIPTION
## Context

`scm-router` fn `isEnterpriseUser` needs `scmContext` param

## Objective

This PR passes `scmContext` as param to fn

## References

https://github.com/screwdriver-cd/scm-router/pull/35

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
