### PR TITLE
fix: Add sha filter for pipeline events

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -109,7 +109,7 @@ Query Params:
 * `sort` - *Optional* Sort rangekey by `ascending` or `descending` (default `descending`)
 * `type` - *Optional* Get pipeline or pr events (default `pipeline`)
 * `prNum` - *Optional* Return only PR events of specified PR number
-* `sha` - *Optional* Fuzzy search `sha` and `configPipelineSha` for events
+* `sha` - *Optional* Search `sha` and `configPipelineSha` for events
 
 `GET /pipelines/{id}/events?page={pageNumber}&count={countNumber}&sort={sort}&type={type}&prNum={prNumber}&sha={sha}`
 

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -101,10 +101,17 @@ Example payload:
 `POST /pipelines/{id}/sync/pullrequests`
 
 #### Get all pipeline events
-`page`, `count`, `sort`, and `prNum` are optional
-Only PR events of specified PR number will be searched when `prNum` is set
 
-`GET /pipelines/{id}/events?page={pageNumber}&count={countNumber}&sort={sort}&prNum={prNumber}`
+Query Params:
+
+* `page` - *Optional* Specific page of the set to return
+* `count` - *Optional* Number of items per page
+* `sort` - *Optional* Sort rangekey by `ascending` or `descending` (default `descending`)
+* `type` - *Optional* Get pipeline or pr events (default `pipeline`)
+* `prNum` - *Optional* Return only PR events of specified PR number
+* `sha` - *Optional* Fuzzy search `sha` and `configPipelineSha` for events
+
+`GET /pipelines/{id}/events?page={pageNumber}&count={countNumber}&sort={sort}&type={type}&prNum={prNumber}&sha={sha}`
 
 #### Get all pipeline builds
 `page`, `count`, `sort`, `latest`, `sortBy`, `fetchSteps`, `readOnly`, and `groupEventId` are optional

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -50,9 +50,9 @@ module.exports = () => ({
                     if (sha) {
                         config.search = {
                             field: ['sha', 'configPipelineSha'],
-                            // Do a fuzzy search for sha
+                            // Do a search for sha
                             // See https://www.w3schools.com/sql/sql_like.asp for syntax
-                            keyword: `%${sha}%`
+                            keyword: `${sha}%`
                         };
                     }
 

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -5,6 +5,8 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const eventListSchema = joi.array().items(schema.models.event.get).label('List of events');
 const prNumSchema = schema.models.event.base.extract('prNum');
+const shaSchema = schema.models.event.base.extract('sha');
+const typeSchema = schema.models.event.base.extract('type');
 const pipelineIdSchema = schema.models.pipeline.base.extract('id');
 
 module.exports = () => ({
@@ -21,6 +23,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const factory = request.server.app.pipelineFactory;
+            const { page, count, sha, prNum } = request.query;
 
             return factory
                 .get(request.params.id)
@@ -32,16 +35,25 @@ module.exports = () => ({
                     const eventType = request.query.type || 'pipeline';
                     const config = { params: { type: eventType } };
 
-                    if (request.query.page || request.query.count) {
+                    if (page || count) {
                         config.paginate = {
-                            page: request.query.page,
-                            count: request.query.count
+                            page,
+                            count
                         };
                     }
 
-                    if (request.query.prNum) {
+                    if (prNum) {
                         config.params.type = 'pr';
-                        config.params.prNum = request.query.prNum;
+                        config.params.prNum = prNum;
+                    }
+
+                    if (sha) {
+                        config.search = {
+                            field: ['sha', 'configPipelineSha'],
+                            // Do a fuzzy search for sha
+                            // See https://www.w3schools.com/sql/sql_like.asp for syntax
+                            keyword: `%${sha}%`
+                        };
                     }
 
                     return pipeline.getEvents(config);
@@ -60,8 +72,9 @@ module.exports = () => ({
             }),
             query: schema.api.pagination.concat(
                 joi.object({
-                    type: joi.string(),
+                    type: typeSchema,
                     prNum: prNumSchema,
+                    sha: shaSchema,
                     search: joi.forbidden(), // we don't support search for Pipeline list events
                     getCount: joi.forbidden() // we don't support getCount for Pipeline list events
                 })

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1455,11 +1455,26 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 200 for getting events with pr Number', () => {
+        it('returns 200 for getting events with pr number', () => {
             options.url = `/pipelines/${id}/events?prNum=4`;
             server.inject(options).then(reply => {
                 assert.calledOnce(pipelineMock.getEvents);
                 assert.calledWith(pipelineMock.getEvents, { params: { prNum: 4, type: 'pr' } });
+                assert.deepEqual(reply.result, testEvents);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 200 for getting events with sha', () => {
+            options.url = `/pipelines/${id}/events?sha=ccc49349d3cffbd12ea9e3d41521480b4aa5de5f`;
+            server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.getEvents);
+                assert.calledWith(pipelineMock.getEvents, {
+                    search: {
+                        field: ['sha', 'configPipelineSha'],
+                        keyword: '%ccc49349d3cffbd12ea9e3d41521480b4aa5de5f%'
+                    }
+                });
                 assert.deepEqual(reply.result, testEvents);
                 assert.equal(reply.statusCode, 200);
             });

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1502,7 +1502,7 @@ describe('pipeline plugin test', () => {
                 assert.calledWith(pipelineMock.getEvents, {
                     search: {
                         field: ['sha', 'configPipelineSha'],
-                        keyword: '%ccc49349d3cffbd12ea9e3d41521480b4aa5de5f%'
+                        keyword: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f%'
                     }
                 });
                 assert.deepEqual(reply.result, testEvents);


### PR DESCRIPTION
## Context

It would be nice for users to be able to filter events by commit SHA.

## Objective

This PR adds query param to filter by sha for pipeline events.

## References
N/A

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
