### PR TITLE
fix(3062): use dumb-init instead of tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,10 @@ RUN ln -s /usr/src/app/node_modules/screwdriver-api/config /config
 # Expose the web service port
 EXPOSE 8080
 
-# Add Tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+# Add dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
+RUN chmod +x /usr/local/bin/dumb-init
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
 # Run the service
 CMD [ "node", "./bin/server" ]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -14,5 +14,10 @@ COPY . /usr/src/app
 # Expose the web service port
 EXPOSE 8080
 
+# Add dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
+RUN chmod +x /usr/local/bin/dumb-init
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 # Run the service
-CMD [ "npm", "start" ]
+CMD [ "node", "./bin/server" ]


### PR DESCRIPTION
## Context
In [the previous PR](https://github.com/screwdriver-cd/screwdriver/pull/3063), we have fixed the Dockerfile to use `tini`  to handle sigterm appropriately for graceful shutdown. However it seems there are some issues for signal TRAP with `tini` as [this comment](https://github.com/screwdriver-cd/screwdriver/pull/3063#issuecomment-2025390989) mentioned.

## Objective
It switches `tini` to `dumb-init` for the init process in the container as same as `launcher` does.

## References
[issue](https://github.com/screwdriver-cd/screwdriver/issues/3062)
[original comment](https://github.com/screwdriver-cd/screwdriver/pull/3063#issuecomment-2025390989)
[dumb-init official](https://github.com/Yelp/dumb-init)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
