### PR TITLE
fix: Relax query param for pipeline event sha filter

### DIFF
--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -5,7 +5,12 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const eventListSchema = joi.array().items(schema.models.event.get).label('List of events');
 const prNumSchema = schema.models.event.base.extract('prNum');
-const shaSchema = schema.models.event.base.extract('sha');
+const shaSchema = joi
+    .string()
+    .hex()
+    .max(40)
+    .description('SHA or partial SHA')
+    .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f');
 const typeSchema = schema.models.event.base.extract('type');
 const pipelineIdSchema = schema.models.pipeline.base.extract('id');
 


### PR DESCRIPTION
## Context

Would be nice to be able to pass in shorthand sha to the pipeline event filter. The original limits the sha length to 40 (https://github.com/screwdriver-cd/data-schema/blob/master/models/event.js#L42).

## Objective

This PR relaxes the query param validation schema for pipeline events sha filter.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/3088

## License

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
