### PR TITLE
feat(3087): Show that events was executed using Pipeline Access Token

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -21,7 +21,7 @@ module.exports = () => ({
         handler: async (request, h) => {
             const { buildFactory, jobFactory, eventFactory, pipelineFactory, userFactory } = request.server.app;
             const { buildId, causeMessage, creator } = request.payload;
-            const { scmContext, username } = request.auth.credentials;
+            const { scmContext, username, scope } = request.auth.credentials;
             const { scm } = eventFactory;
             const { isValidToken } = request.server.plugins.pipelines;
             const { updateAdmins } = request.server.plugins.events;
@@ -79,6 +79,11 @@ module.exports = () => ({
 
             if (creator) {
                 payload.creator = creator;
+            } else if (scope.includes('pipeline')) {
+                payload.creator = {
+                    name: 'Pipeline Access Token', // Display name
+                    username
+                };
             }
 
             // Check for startFrom


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, someone in pipeline admins is displayed in "Started by" when user executes events with pipeline access token.
Hence the user cannot know whether the event was executed by the user or by the token.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Display "Started by: Pipeline Access Token" when the event executed with pipeline access token.

![ex](https://github.com/screwdriver-cd/screwdriver/assets/43719835/10c95f3f-3aac-48d8-9a05-808e64773d1b)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3087

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
