### PR TITLE
fix: Increase the issue similarity threshold [skip ci]

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -15,7 +15,7 @@ jobs:
         if: (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'triage')) || (github.event.action == 'opened')
         uses: actions-cool/issues-similarity-analysis@main
         with:
-          filter-threshold: 0.3
+          filter-threshold: 0.8
           title-excludes: 'bug, not, 1234'
           comment-title: '### Similar issues'
           comment-body: '${index}. ${similarity} #${number}'


### PR DESCRIPTION
## Context

The workflow to find similar issues has a low threshold causing unrelated issues to be identified as similar. 

## Objective

Increase the threshold to improve accuracy of finding similar issues so it is more meaningful. 

## License

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
