### PR TITLE
feat(3068): remove shared from pipeline template functional test

### DIFF
--- a/features/pipeline-templates.feature
+++ b/features/pipeline-templates.feature
@@ -21,10 +21,9 @@ Feature: Pipeline Templates
         template: node/test@1
 
     The user's config would be translated to:
-        shared:
-            image: node:18
         jobs:
             main:
+                image: node:18
                 steps:
                     - init: npm install
                     - test: npm test

--- a/features/step_definitions/pipeline-template.js
+++ b/features/step_definitions/pipeline-template.js
@@ -5,6 +5,7 @@ const fs = require('mz/fs');
 const Assert = require('chai').assert;
 const request = require('screwdriver-request');
 const { Before, Given, Then, When } = require('@cucumber/cucumber');
+const { error } = require('console');
 
 const TIMEOUT = 240 * 1000;
 
@@ -29,8 +30,7 @@ Before(
                 branch: this.branchName,
                 shouldNotDeletePipeline: true
             })
-                .then(() =>
-                    request({
+                .then(() => request({
                         url: `${this.instance}/${this.namespace}/events`,
                         method: 'POST',
                         json: {
@@ -292,6 +292,9 @@ Then(
             } else {
                 Assert.equal(length, this.numOfTemplate);
             }
+        }).catch(error => {
+            const errorMessage = error.message; // Get the error message
+            Assert.include(errorMessage, "Template does not exist");
         });
     }
 );

--- a/features/step_definitions/pipeline-template.js
+++ b/features/step_definitions/pipeline-template.js
@@ -5,7 +5,6 @@ const fs = require('mz/fs');
 const Assert = require('chai').assert;
 const request = require('screwdriver-request');
 const { Before, Given, Then, When } = require('@cucumber/cucumber');
-const { error } = require('console');
 
 const TIMEOUT = 240 * 1000;
 
@@ -30,7 +29,8 @@ Before(
                 branch: this.branchName,
                 shouldNotDeletePipeline: true
             })
-                .then(() => request({
+                .then(() =>
+                    request({
                         url: `${this.instance}/${this.namespace}/events`,
                         method: 'POST',
                         json: {
@@ -283,19 +283,22 @@ Then(
             context: {
                 token: this.jwt
             }
-        }).then(response => {
-            Assert.equal(response.statusCode, 200);
-            const { length } = response.body;
+        })
+            .then(response => {
+                Assert.equal(response.statusCode, 200);
+                const { length } = response.body;
 
-            if (stored === 'is') {
-                Assert.equal(length, this.numOfTemplate + 1);
-            } else {
-                Assert.equal(length, this.numOfTemplate);
-            }
-        }).catch(error => {
-            const errorMessage = error.message; // Get the error message
-            Assert.include(errorMessage, "Template does not exist");
-        });
+                if (stored === 'is') {
+                    Assert.equal(length, this.numOfTemplate + 1);
+                } else {
+                    Assert.equal(length, this.numOfTemplate);
+                }
+            })
+            .catch(error => {
+                const errorMessage = error.message; // Get the error message
+
+                Assert.include(errorMessage, 'Template does not exist');
+            });
     }
 );
 

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -794,7 +794,7 @@ describe('auth plugin test', () => {
 
                 describe('gheCloud flag', async () => {
                     beforeEach(async () => {
-                        const scmsTemp = Object.assign({}, scm.scms['github:github.com']);
+                        const scmsTemp = { ...scm.scms['github:github.com'] };
 
                         await server.register({
                             plugin,


### PR DESCRIPTION
## Context

Shared config is flattened into jobs in pipeline template. 

## Objective

Remove shared config from pipeline template functional test. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3068

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
