### PR TITLE
fix(3042): Stage functional test regex

### DIFF
--- a/features/step_definitions/stage.js
+++ b/features/step_definitions/stage.js
@@ -36,7 +36,7 @@ Given(
 );
 
 Then(
-    /^the "(?:stage@(simple_fail|incomplete_fail|simple_success))" stageBuild status is "(SUCCESS|FAILURE)"$/,
+    /^the "(?:stage@([\w-]+))" stageBuild status is "(SUCCESS|FAILURE)"$/,
     { timeout: TIMEOUT },
     async function step(stage, stageBuildStatus) {
         const config = {


### PR DESCRIPTION
## Context

Stage functional test is failing with the error:
```
19:46:51    ? Then the "stage@setup_fail" stageBuild status is "FAILURE"
19:46:51        Undefined. Implement with the following snippet:
19:46:51 
19:46:51          Then('the {string} stageBuild status is {string}', function (string, string2) {
19:46:51            // Write code here that turns the phrase above into concrete actions
19:46:51            return 'pending';
19:46:51          });
```
## Objective

This PR relaxes regex for stage functional test.

## References

Related to https://github.com/screwdriver-cd/screwdriver/pull/3061, https://github.com/screwdriver-cd/screwdriver/issues/3042

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
