### PR TITLE
fix: no lodash for cloning

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "js-yaml": "^3.14.1",
     "jsonwebtoken": "^9.0.0",
     "license-checker": "^25.0.1",
-    "lodash": "^4.17.21",
     "lodash.mergewith": "^4.6.2",
     "ndjson": "^2.0.0",
     "node-env-file": "^0.1.8",

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1435,7 +1435,7 @@ describe('startHookEvent test', () => {
                         branch: Promise.resolve('master')
                     })
                 ]);
-            const pipelineMock2 = { ...pipelineMock };
+            const pipelineMock2 = JSON.parse(JSON.stringify(pipelineMock));
 
             pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['commit'] }];
             pipelineFactoryMock.list
@@ -2008,7 +2008,7 @@ describe('startHookEvent test', () => {
                             branch: Promise.resolve('master')
                         })
                     ]);
-                const pipelineMock2 = { ...pipelineMock };
+                const pipelineMock2 = JSON.parse(JSON.stringify(pipelineMock));
 
                 pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['pr'] }];
                 pipelineFactoryMock.list

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1435,7 +1435,7 @@ describe('startHookEvent test', () => {
                         branch: Promise.resolve('master')
                     })
                 ]);
-            const pipelineMock2 = JSON.parse(JSON.stringify(pipelineMock));
+            const pipelineMock2 = structuredClone(pipelineMock);
 
             pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['commit'] }];
             pipelineFactoryMock.list

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -5,7 +5,6 @@ const sinon = require('sinon');
 const rewire = require('rewire');
 const { assert } = chai;
 const hoek = require('@hapi/hoek');
-const _ = require('lodash');
 
 chai.use(require('chai-as-promised'));
 
@@ -1436,7 +1435,7 @@ describe('startHookEvent test', () => {
                         branch: Promise.resolve('master')
                     })
                 ]);
-            const pipelineMock2 = _.cloneDeep(pipelineMock);
+            const pipelineMock2 = { ...pipelineMock };
 
             pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['commit'] }];
             pipelineFactoryMock.list
@@ -2009,7 +2008,7 @@ describe('startHookEvent test', () => {
                             branch: Promise.resolve('master')
                         })
                     ]);
-                const pipelineMock2 = _.cloneDeep(pipelineMock);
+                const pipelineMock2 = { ...pipelineMock };
 
                 pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['pr'] }];
                 pipelineFactoryMock.list

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1435,7 +1435,7 @@ describe('startHookEvent test', () => {
                         branch: Promise.resolve('master')
                     })
                 ]);
-            const pipelineMock2 = structuredClone(pipelineMock);
+            const pipelineMock2 = Object.assign({}, pipelineMock);
 
             pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['commit'] }];
             pipelineFactoryMock.list
@@ -2008,7 +2008,7 @@ describe('startHookEvent test', () => {
                             branch: Promise.resolve('master')
                         })
                     ]);
-                const pipelineMock2 = JSON.parse(JSON.stringify(pipelineMock));
+                const pipelineMock2 = Object.assign({}, pipelineMock);
 
                 pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['pr'] }];
                 pipelineFactoryMock.list


### PR DESCRIPTION
## Context

Removing lodash because deep clone can be natively done in JS

## Objective

Implement deep clone natively instead of using lodash 

## References
https://github.com/screwdriver-cd/screwdriver/pull/3095#discussion_r1589653340

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
