### PR TITLE
fix: init octokit for all functions in github api

### DIFF
--- a/features/step_definitions/subscribe.js
+++ b/features/step_definitions/subscribe.js
@@ -13,7 +13,6 @@ Before(
         tags: '@subscribe'
     },
     function hook() {
-        github.getOctokit();
         this.repoOrg = this.testOrg;
         this.pipelines = {};
         this.pipelineId = null;

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -91,7 +91,9 @@ function removeBranch(repoOwner, repoName, branchName) {
         repo: repoName,
         ref: `heads/${branchName}`
     };
+
     octokit = getOctokit();
+
     return octokit.git.getRef(branchParams).then(() => octokit.git.deleteRef(branchParams));
 }
 
@@ -127,6 +129,7 @@ function createBranch(branch, repoOwner, repoName, ref = 'heads/master') {
     const repo = repoName || 'functional-git';
 
     octokit = getOctokit();
+
     return octokit.git
         .getRef({
             owner,
@@ -169,6 +172,7 @@ function createFile(branch, repoOwner, repoName, directoryName, commitMessage) {
     const message = commitMessage || new Date().toString(); // default commit message is the current time
 
     octokit = getOctokit();
+
     return octokit.repos.createOrUpdateFileContents({
         owner,
         repo,
@@ -189,8 +193,8 @@ function createFile(branch, repoOwner, repoName, directoryName, commitMessage) {
  * @return {Promise}
  */
 function createPullRequest(sourceBranch, targetBranch, repoOwner, repoName) {
-
     octokit = getOctokit();
+
     return octokit.pulls.create({
         owner: repoOwner,
         repo: repoName,
@@ -214,6 +218,7 @@ function createTag(tag, branch, repoOwner, repoName) {
     const repo = repoName || 'functional-git';
 
     octokit = getOctokit();
+
     return octokit.git
         .getRef({
             owner,
@@ -343,6 +348,7 @@ function getStatus(repoOwner, repoName, sha) {
  */
 function mergePullRequest(repoOwner, repoName, prNumber) {
     octokit = getOctokit();
+
     return octokit.pulls.merge({
         owner: repoOwner,
         repo: repoName,

--- a/features/support/github.js
+++ b/features/support/github.js
@@ -59,6 +59,8 @@ function cleanUpRepository(branch, tags, repoOwner, repoName) {
         ref: `heads/${branch}`
     };
 
+    octokit = getOctokit();
+
     const removeTagPromises = tags.map(tag => {
         const tagParams = {
             owner: repoOwner,
@@ -89,7 +91,7 @@ function removeBranch(repoOwner, repoName, branchName) {
         repo: repoName,
         ref: `heads/${branchName}`
     };
-
+    octokit = getOctokit();
     return octokit.git.getRef(branchParams).then(() => octokit.git.deleteRef(branchParams));
 }
 
@@ -102,6 +104,8 @@ function removeBranch(repoOwner, repoName, branchName) {
  * @return {Promise}
  */
 function closePullRequest(repoOwner, repoName, prNumber) {
+    octokit = getOctokit();
+
     return octokit.pulls.update({
         owner: repoOwner,
         repo: repoName,
@@ -122,6 +126,7 @@ function createBranch(branch, repoOwner, repoName, ref = 'heads/master') {
     const owner = repoOwner || 'screwdriver-cd-test';
     const repo = repoName || 'functional-git';
 
+    octokit = getOctokit();
     return octokit.git
         .getRef({
             owner,
@@ -163,6 +168,7 @@ function createFile(branch, repoOwner, repoName, directoryName, commitMessage) {
     const filePath = directoryName || 'testfiles';
     const message = commitMessage || new Date().toString(); // default commit message is the current time
 
+    octokit = getOctokit();
     return octokit.repos.createOrUpdateFileContents({
         owner,
         repo,
@@ -183,6 +189,8 @@ function createFile(branch, repoOwner, repoName, directoryName, commitMessage) {
  * @return {Promise}
  */
 function createPullRequest(sourceBranch, targetBranch, repoOwner, repoName) {
+
+    octokit = getOctokit();
     return octokit.pulls.create({
         owner: repoOwner,
         repo: repoName,
@@ -205,6 +213,7 @@ function createTag(tag, branch, repoOwner, repoName) {
     const owner = repoOwner || 'screwdriver-cd-test';
     const repo = repoName || 'functional-git';
 
+    octokit = getOctokit();
     return octokit.git
         .getRef({
             owner,
@@ -238,6 +247,8 @@ function createTag(tag, branch, repoOwner, repoName) {
 function createAnnotatedTag(tag, branch, repoOwner, repoName) {
     const owner = repoOwner || 'screwdriver-cd-test';
     const repo = repoName || 'functional-git';
+
+    octokit = getOctokit();
 
     return octokit.git
         .getRef({
@@ -289,6 +300,8 @@ function createRelease(tagName, repoOwner, repoName) {
     const owner = repoOwner || 'screwdriver-cd-test';
     const repo = repoName || 'functional-git';
 
+    octokit = getOctokit();
+
     return octokit.repos
         .createRelease({
             owner,
@@ -311,6 +324,8 @@ function createRelease(tagName, repoOwner, repoName) {
  * @return {Promise}
  */
 function getStatus(repoOwner, repoName, sha) {
+    octokit = getOctokit();
+
     return octokit.repos.getCombinedStatusForRef({
         owner: repoOwner,
         repo: repoName,
@@ -327,6 +342,7 @@ function getStatus(repoOwner, repoName, sha) {
  * @return {Promise}
  */
 function mergePullRequest(repoOwner, repoName, prNumber) {
+    octokit = getOctokit();
     return octokit.pulls.merge({
         owner: repoOwner,
         repo: repoName,
@@ -345,6 +361,5 @@ module.exports = {
     createRelease,
     getStatus,
     mergePullRequest,
-    removeBranch,
-    getOctokit
+    removeBranch
 };

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1435,7 +1435,7 @@ describe('startHookEvent test', () => {
                         branch: Promise.resolve('master')
                     })
                 ]);
-            const pipelineMock2 = Object.assign({}, pipelineMock);
+            const pipelineMock2 = { ...pipelineMock };
 
             pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['commit'] }];
             pipelineFactoryMock.list
@@ -2008,7 +2008,7 @@ describe('startHookEvent test', () => {
                             branch: Promise.resolve('master')
                         })
                     ]);
-                const pipelineMock2 = Object.assign({}, pipelineMock);
+                const pipelineMock2 = { ...pipelineMock };
 
                 pipelineMock2.subscribedScmUrlsWithActions = [{ scmUri: 'github.com:789123:master', actions: ['pr'] }];
                 pipelineFactoryMock.list


### PR DESCRIPTION
## Context

When octokit is set as const at the beginning of module, like [this](https://github.com/screwdriver-cd/screwdriver/blob/a20a5fb2bd06bfc2d085121fe38f840c3ceee913/features/support/github.js#L5-L11), it is possible that the env variables involved are not initialized. Hence causing an unauthorized access to Github API. 

## Objective

Octokit should be inited on the function that needs it. 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
