### PR TITLE
fix: functional tests on stages timeout error

### DIFF
--- a/features/stages.feature
+++ b/features/stages.feature
@@ -120,7 +120,6 @@ Feature: Stage
         And the "b" build succeeded
         And the "c" job is triggered
         And the "c" build succeeded
-        Then the "stage@teardown_fail" stageBuild status is "FAILURE"
         And the "stage@teardown_fail:teardown" job is triggered
         And the "stage@teardown_fail:teardown" build failed
         And the "stage@teardown_fail" stageBuild status is "FAILURE"

--- a/features/stages.feature
+++ b/features/stages.feature
@@ -120,7 +120,7 @@ Feature: Stage
         And the "b" build succeeded
         And the "c" job is triggered
         And the "c" build succeeded
-        Then the "stage@teardown_fail" stageBuild status is "SUCCESS"
+        Then the "stage@teardown_fail" stageBuild status is "FAILURE"
         And the "stage@teardown_fail:teardown" job is triggered
         And the "stage@teardown_fail:teardown" build failed
         And the "stage@teardown_fail" stageBuild status is "FAILURE"

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -159,10 +159,7 @@ Then(
     {
         timeout: TIMEOUT
     },
-    async function step(jobName) {
-        if (jobName.endsWith('teardown')) {
-            await new Promise(resolve => setTimeout(resolve, 1000));
-        }
+    function step(jobName) {
         const config = {
             instance: this.instance,
             pipelineId: this.pipelineId,
@@ -175,14 +172,21 @@ Then(
             config.desiredSha = this.sha;
         }
 
-        return sdapi.searchForBuild(config).then(build => {
-            this.eventId = build.eventId;
-            const job = this.jobs.find(j => j.name === jobName);
+        const sleepTime = jobName.endsWith('teardown') ? 1000 : 0;
 
-            Assert.equal(build.jobId, job.id);
+        return new Promise(resolve => {
+            setTimeout(resolve, sleepTime);
+        }).then(() => {
+            return sdapi.searchForBuild(config).then(build => {
+                this.eventId = build.eventId;
+                const job = this.jobs.find(j => j.name === jobName);
 
-            this.buildId = build.id;
+                Assert.equal(build.jobId, job.id);
+
+                this.buildId = build.id;
+            });
         });
+
     }
 );
 

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -159,7 +159,10 @@ Then(
     {
         timeout: TIMEOUT
     },
-    function step(jobName) {
+    async function step(jobName) {
+        if (jobName.endsWith('teardown')) {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+        }
         const config = {
             instance: this.instance,
             pipelineId: this.pipelineId,

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -186,7 +186,6 @@ Then(
                 this.buildId = build.id;
             });
         });
-
     }
 );
 

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -305,7 +305,6 @@ module.exports = () => ({
             let stageBuildHasFailure = false;
 
             if (stage) {
-                console.log('stage: ', stage);
                 const stageBuild = await stageBuildFactory.get({
                     stageId: stage.id,
                     eventId: newEvent.id
@@ -351,7 +350,6 @@ module.exports = () => ({
                 const stageTeardownName = getFullStageJobName({ stageName: stage.name, jobName: 'teardown' });
                 const stageTeardownJob = await jobFactory.get({ pipelineId: pipeline.id, name: stageTeardownName });
 
-                await new Promise(resolve => setTimeout(resolve, 1000));
                 const stageTeardownBuild = await buildFactory.get({ eventId: newEvent.id, jobId: stageTeardownJob.id });
 
                 // Start stage teardown build if stage is done

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -305,6 +305,7 @@ module.exports = () => ({
             let stageBuildHasFailure = false;
 
             if (stage) {
+                console.log('stage: ', stage);
                 const stageBuild = await stageBuildFactory.get({
                     stageId: stage.id,
                     eventId: newEvent.id
@@ -349,6 +350,8 @@ module.exports = () => ({
             if (stage && FINISHED_STATUSES.includes(newBuild.status)) {
                 const stageTeardownName = getFullStageJobName({ stageName: stage.name, jobName: 'teardown' });
                 const stageTeardownJob = await jobFactory.get({ pipelineId: pipeline.id, name: stageTeardownName });
+
+                await new Promise(resolve => setTimeout(resolve, 1000));
                 const stageTeardownBuild = await buildFactory.get({ eventId: newEvent.id, jobId: stageTeardownJob.id });
 
                 // Start stage teardown build if stage is done

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -349,7 +349,6 @@ module.exports = () => ({
             if (stage && FINISHED_STATUSES.includes(newBuild.status)) {
                 const stageTeardownName = getFullStageJobName({ stageName: stage.name, jobName: 'teardown' });
                 const stageTeardownJob = await jobFactory.get({ pipelineId: pipeline.id, name: stageTeardownName });
-
                 const stageTeardownBuild = await buildFactory.get({ eventId: newEvent.id, jobId: stageTeardownJob.id });
 
                 // Start stage teardown build if stage is done


### PR DESCRIPTION
## Context

Functional tests on the stages feature have been failing due to a timeout error.

## Objective

Fix the functional tests on the stages feature by making the following change:

- Remove the check of [intermediary status in the teardownFail branch](https://github.com/screwdriver-cd/screwdriver/blob/master/features/stages.feature#L123) because the stages status propagates too quickly, making it unrealistic to capture.

- Add a sleep before checking for a teardown build because I have noticed locally that checking it too quickly can cause a timeout error.


## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
