### PR TITLE
fix(3123): Restrict overwriting username on create Event

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -79,6 +79,9 @@ module.exports = () => ({
 
             if (creator) {
                 payload.creator = creator;
+                if (creator.username !== 'sd:scheduler') {
+                    payload.creator.username = username;
+                }
             } else if (scope.includes('pipeline')) {
                 payload.creator = {
                     name: 'Pipeline Access Token', // Display name


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, when create event, users can impersonate the user who created the event.
So API restricts overwriting username to restrict impersonate the user who created the event.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
If the event is created by not sd:scheduler user, the username of the event's creator is set by the username of the token that called the API.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

#3123 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
