### PR TITLE
fix(3012): trigger stage teardown job when some stage builds failed

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -294,7 +294,7 @@ const buildsPlugin = {
 
                         //   if nextBuild is stage teardown, just return nextBuild
                         if (current.stage) {
-                            const buildDeletePromises = handleStageFailure({
+                            const buildDeletePromises = await handleStageFailure({
                                 nextJobName,
                                 current,
                                 buildConfig,

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -2753,6 +2753,24 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('stage@red:teardown').status, 'RUNNING');
     });
 
+    it('stage teardown is triggered when some stage builds fail', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('stage.yaml');
+
+        const event = await eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.getBuildOf('hub').complete('SUCCESS');
+        await event.getBuildOf('a').complete('SUCCESS');
+        await event.getBuildOf('stage@red:setup').complete('SUCCESS');
+        await event.getBuildOf('target1').complete('SUCCESS');
+        await event.getBuildOf('target2').complete('SUCCESS');
+        await event.getBuildOf('target3').complete('FAILURE');
+
+        assert.equal(event.getBuildOf('stage@red:teardown').status, 'RUNNING');
+    });
+
     it('[ ~stage@red:setup ] is triggered', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~stage@red:setup.yaml');
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Followup this PR
https://github.com/screwdriver-cd/screwdriver/pull/3122

Stage teardown jobs should be triggered when stage builds are complete regardless of build status.
But after merged PR, stage teardown jobs aren't triggered when some builds are failed.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Stage teardown jobs are triggered.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/pull/3122

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
