### PR TITLE
fix(3012): Trigger remote join job in restart when the last remote join job is successful

### DIFF
--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -31,15 +31,6 @@ class RemoteJoin extends JoinBase {
      * @returns {Promise<Build|null>}
      */
     async execute(externalEvent, nextJobName, nextJobId, parentBuilds, groupEventBuilds, joinListNames) {
-        // fetch builds created due to trigger
-        const parallelBuilds = await getParallelBuilds({
-            eventFactory: this.eventFactory,
-            parentEventId: externalEvent.id,
-            pipelineId: externalEvent.pipelineId
-        });
-
-        groupEventBuilds.push(...parallelBuilds);
-
         // When restart case, should we create a new build ?
         const nextBuild = groupEventBuilds.find(b => b.jobId === nextJobId && b.eventId === externalEvent.id);
 

--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getParallelBuilds, mergeParentBuilds, getParentBuildIds } = require('./helpers');
+const { mergeParentBuilds, getParentBuildIds } = require('./helpers');
 const { JoinBase } = require('./joinBase');
 
 /**

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -1652,7 +1652,7 @@ describe('trigger tests', () => {
 
         const downstreamRestartEvent = await downstreamEvent.restartFrom('b');
 
-        assert.equal(await downstreamRestartEvent.getBuildOf('a'), null);
+        assert.isNull(downstreamRestartEvent.getBuildOf('a'));
         await downstreamRestartEvent.getBuildOf('b').complete('SUCCESS');
 
         const upstreamRestartEvent = upstreamPipeline.getLatestEvent();

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -2596,7 +2596,7 @@ describe('trigger tests', () => {
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 1);
     });
 
-    it.only('[ ~sd@2:a, sd@2:a, sd@2:b ] is triggered in restart event when only sd@1:a restarts', async () => {
+    it('[ ~sd@2:a, sd@2:a, sd@2:b ] is triggered in restart event when only sd@1:a restarts', async () => {
         const upstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:a_sd@2:b-upstream.yaml');
         const downstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:a_sd@2:b-downstream.yaml');
 

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -1634,6 +1634,34 @@ describe('trigger tests', () => {
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 1);
     });
 
+    it('[ sd@2:a, sd@2:b ] is triggered in restart event when only sd@2:b restarts', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_sd@2:b-upstream.yaml');
+        const downstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_sd@2:b-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        await upstreamEvent.run();
+
+        const downstreamEvent = downstreamPipeline.getLatestEvent();
+
+        await downstreamEvent.getBuildOf('a').complete('SUCCESS');
+        await downstreamEvent.getBuildOf('b').complete('SUCCESS');
+
+        const downstreamRestartEvent = await downstreamEvent.restartFrom('b');
+
+        assert.equal(await downstreamRestartEvent.getBuildOf('a'), null);
+        await downstreamRestartEvent.getBuildOf('b').complete('SUCCESS');
+
+        const upstreamRestartEvent = upstreamPipeline.getLatestEvent();
+
+        assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
+    });
+
     it('Multiple [ sd@2:a, sd@2:b ] is triggered', async () => {
         const upstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_sd@2:b-multiple-upstream.yaml');
         const downstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_sd@2:b-downstream.yaml');
@@ -1850,6 +1878,30 @@ describe('trigger tests', () => {
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 1);
     });
 
+    it('[ sd@2:a, b ] is triggered in restart event when only b restarts', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_b-upstream.yaml');
+        const downstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_b-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        await upstreamEvent.run();
+
+        const downstreamEvent = downstreamPipeline.getLatestEvent();
+
+        await downstreamEvent.getBuildOf('a').complete('SUCCESS');
+
+        const upstreamRestartEvent = await upstreamEvent.restartFrom('b');
+
+        await upstreamRestartEvent.getBuildOf('b').complete('SUCCESS');
+
+        assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
+    });
+
     it('[ sd@2:a, sd@3:a ] is triggered', async () => {
         const upstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-upstream.yaml');
         const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
@@ -1951,6 +2003,35 @@ describe('trigger tests', () => {
         assert.equal(upstreamEvent, upstreamPipeline.getLatestEvent());
         assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 1);
+    });
+
+    it('[ sd@2:a, sd@3:a ] is triggered in restart event when only sd@3:a restarts', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-upstream.yaml');
+        const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+        const downstreamPipeline2 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        await upstreamEvent.run();
+
+        const downstreamEvent1 = downstreamPipeline1.getLatestEvent();
+        const downstreamEvent2 = downstreamPipeline2.getLatestEvent();
+
+        await downstreamEvent1.getBuildOf('a').complete('SUCCESS');
+        await downstreamEvent2.getBuildOf('a').complete('SUCCESS');
+
+        const downstreamRestartEvent2 = await downstreamEvent2.restartFrom('a');
+
+        await downstreamRestartEvent2.getBuildOf('a').complete('SUCCESS');
+
+        const upstreamRestartEvent = upstreamPipeline.getLatestEvent();
+
+        assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
     });
 
     it('[ ~sd@2:a, sd@2:b, sd@2:c ] is triggered when sd@2:a succeeds', async () => {
@@ -2059,6 +2140,35 @@ describe('trigger tests', () => {
         assert.equal(upstreamEvent, upstreamPipeline.getLatestEvent());
         assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 1);
+    });
+
+    it('[ ~sd@2:a, sd@2:b, sd@2:c ] is triggered in restart event when only sd@2:c restarts', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:b_sd@2:c-upstream.yaml');
+        const downstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:b_sd@2:c-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        await upstreamEvent.run();
+
+        const downstreamEvent = downstreamPipeline.getLatestEvent();
+
+        await downstreamEvent.getBuildOf('a').complete('SUCCESS');
+        await downstreamEvent.getBuildOf('b').complete('SUCCESS');
+        await downstreamEvent.getBuildOf('c').complete('SUCCESS');
+
+        const downstreamRestartEvent = await downstreamEvent.restartFrom('c');
+
+        assert.equal(await downstreamRestartEvent.getBuildOf('b'), null);
+        await downstreamRestartEvent.getBuildOf('c').complete('SUCCESS');
+
+        const upstreamRestartEvent = upstreamPipeline.getLatestEvent();
+
+        assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
     });
 
     it('[ ~sd@2:a, b, c ] is triggered', async () => {
@@ -2484,6 +2594,33 @@ describe('trigger tests', () => {
         assert.equal(upstreamEvent.id, upstreamPipeline.getLatestEvent().id);
         assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 1);
+    });
+
+    it.only('[ ~sd@2:a, sd@2:a, sd@2:b ] is triggered in restart event when only sd@1:a restarts', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:a_sd@2:b-upstream.yaml');
+        const downstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:a_sd@2:b-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        await upstreamEvent.run();
+
+        const downstreamEvent = downstreamPipeline.getLatestEvent();
+
+        await downstreamEvent.getBuildOf('a').complete('SUCCESS');
+        await downstreamEvent.getBuildOf('b').complete('SUCCESS');
+
+        const downstreamRestartEvent = await downstreamEvent.restartFrom('a');
+
+        await downstreamRestartEvent.getBuildOf('a').complete('SUCCESS');
+
+        const upstreamRestartEvent = upstreamPipeline.getLatestEvent();
+
+        assert.equal(upstreamEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
     });
 
     it('[ sd@3:a, sd@3:b ] is triggered in second stream pipeline', async () => {

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -2161,7 +2161,7 @@ describe('trigger tests', () => {
 
         const downstreamRestartEvent = await downstreamEvent.restartFrom('c');
 
-        assert.equal(await downstreamRestartEvent.getBuildOf('b'), null);
+        assert.isNull(downstreamRestartEvent.getBuildOf('b'));
         await downstreamRestartEvent.getBuildOf('c').complete('SUCCESS');
 
         const upstreamRestartEvent = upstreamPipeline.getLatestEvent();


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Followup this PR
https://github.com/screwdriver-cd/screwdriver/pull/3122

Remote Join job should be triggered on the new event on upstream when restart from an event downstream of the event in which Remote Join is successful.
However, the event and build are created but not triggered.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix the function call location so that the build can be fetched and triggered from the new event that was created.
In addition, add a test for this scenario. (In other words, make sure that it is triggered twice in total by start and restart)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
