### PR TITLE
feat(3124): Extend job template steps in pipeline template validation [3]

### DIFF
--- a/plugins/pipelines/templates/validate.js
+++ b/plugins/pipelines/templates/validate.js
@@ -3,7 +3,7 @@
 const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
 const templateSchema = schema.api.templateValidator;
-const pipelineValidator = require('screwdriver-template-validator').parsePipelineTemplate;
+const pipelineValidator = require('screwdriver-template-validator').validatePipelineTemplate;
 
 module.exports = () => ({
     method: 'POST',
@@ -15,8 +15,8 @@ module.exports = () => ({
         handler: async (request, h) => {
             try {
                 const { yaml: templateString } = request.payload;
-
-                const result = await pipelineValidator(templateString);
+                const { templateFactory } = request.server.app;
+                const result = await pipelineValidator(templateString, templateFactory);
 
                 return h.response(result);
             } catch (err) {

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -83,6 +83,7 @@ describe('pipeline plugin test', () => {
     let bannerMock;
     let screwdriverAdminDetailsMock;
     let scmMock;
+    let templateFactoryMock;
     let pipelineTemplateFactoryMock;
     let pipelineTemplateVersionFactoryMock;
     let pipelineTemplateTagFactoryMock;
@@ -160,6 +161,9 @@ describe('pipeline plugin test', () => {
             create: sinon.stub(),
             remove: sinon.stub()
         };
+        templateFactoryMock = {
+            getTemplate: sinon.stub().resolves({ templateId: 1234 })
+        };
         pipelineTemplateVersionFactoryMock = {
             create: sinon.stub(),
             list: sinon.stub(),
@@ -192,6 +196,7 @@ describe('pipeline plugin test', () => {
             tokenFactory: tokenFactoryMock,
             bannerFactory: bannerFactoryMock,
             secretFactory: secretFactoryMock,
+            templateFactory: templateFactoryMock,
             pipelineTemplateFactory: pipelineTemplateFactoryMock,
             pipelineTemplateVersionFactory: pipelineTemplateVersionFactoryMock,
             pipelineTemplateTagFactory: pipelineTemplateTagFactoryMock,


### PR DESCRIPTION
## Context

The is displaying only the configurations stored in the database without extending the job template. It would be nice if it would merge template steps if the pipeline template is using a template.

## Objective

This PR adds a new function for pipeline template validator to show users flattened job template steps.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3124

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
