### PR TITLE
fix: The first admin's GitHub rate limit is consumed excessively

### DIFF
--- a/plugins/events/index.js
+++ b/plugins/events/index.js
@@ -27,10 +27,10 @@ const eventsPlugin = {
          * @return {Promise}                Updates the pipeline admins and throws an error if not an admin
          */
         server.expose('updateAdmins', ({ permissions, pipeline, username }) => {
-            const newAdmins = pipeline.admins;
-
             // Delete user from admin list if bad permissions
             if (!permissions.push) {
+                const newAdmins = pipeline.admins;
+
                 delete newAdmins[username];
                 // This is needed to make admins dirty and update db
                 pipeline.admins = newAdmins;
@@ -40,16 +40,18 @@ const eventsPlugin = {
                 });
             }
 
-            // Add user as admin if permissions good and does not already exist
-            if (!pipeline.admins[username]) {
-                newAdmins[username] = true;
-                // This is needed to make admins dirty and update db
-                pipeline.admins = newAdmins;
+            // Put current user at the head of admins to use its SCM token after this
+            // SCM token is got from the first pipeline admin
+            const newAdminNames = [username, ...Object.keys(pipeline.admins)];
+            const newAdmins = {};
 
-                return pipeline.update();
-            }
+            newAdminNames.forEach(name => {
+                newAdmins[name] = true;
+            });
 
-            return Promise.resolve();
+            pipeline.admins = newAdmins;
+
+            return pipeline.update();
         });
 
         server.route([

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -926,6 +926,23 @@ describe('event plugin test', () => {
             });
         });
 
+        it('update the current user permission and put the current user at the head of admins', () => {
+            pipelineMock.admins = {
+                foo: true,
+                myself: false,
+                bar: true,
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 201);
+
+                const { admins } = pipelineMock;
+
+                assert.deepEqual({ myself: true, foo: true, bar: true }, admins);
+                assert.deepEqual(['myself', 'foo', 'bar'], Object.keys(admins));
+            });
+        });
+
         it('returns 500 when the model encounters an error', () => {
             const testError = new Error('datastoreSaveError');
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -930,7 +930,7 @@ describe('event plugin test', () => {
             pipelineMock.admins = {
                 foo: true,
                 myself: false,
-                bar: true,
+                bar: true
             };
 
             return server.inject(options).then(reply => {

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1683,6 +1683,23 @@ describe('startHookEvent test', () => {
             });
         });
 
+        it('update the current user permission and put the current user at the head of admins', () => {
+            pipelineMock.admins = {
+                foo: true,
+                baxterthehacker: false,
+                bar: true,
+            };
+
+            return startHookEvent(request, responseHandler, parsed).then(reply => {
+                assert.equal(reply.statusCode, 201);
+
+                const { admins } = pipelineMock;
+
+                assert.deepEqual({ baxterthehacker: true, foo: true, bar: true }, admins);
+                assert.deepEqual(['baxterthehacker', 'foo', 'bar'], Object.keys(admins));
+            });
+        });
+
         it('throws error when failed', () => {
             eventFactoryMock.create.rejects(new Error('Failed to start'));
 

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1687,7 +1687,7 @@ describe('startHookEvent test', () => {
             pipelineMock.admins = {
                 foo: true,
                 baxterthehacker: false,
-                bar: true,
+                bar: true
             };
 
             return startHookEvent(request, responseHandler, parsed).then(reply => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, SD API uses pipeline admin's token due to access GitHub when start builds.
[The first of `pipeline.admins` is used as pipeline admin](https://github.com/screwdriver-cd/models/blob/4d6d9e7dfa5425a9ddd2e73625de623d370c1377/lib/pipeline.js#L1181), but admins list is not sorted anywhere.
As a result, the first admin's token is always used even if other admin started builds.

There is no problem to check user's permission, but the first admins's GitHub API rate limit is consumed excessively.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Put current user at the head of pipeline admins when update pipeline admins.
This sort update is applied when start builds, thus other admin's token will not be used.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
