### PR TITLE
fix(2957): Fix event where a restarted join build is run

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -93,7 +93,7 @@ async function triggerNextJobs(config, app) {
     for (const [nextJobName, nextJob] of Object.entries(currentPipelineNextJobs)) {
         const nextJobId = nextJob.id || (await getJobId(nextJobName, currentPipeline.id, jobFactory));
         const { isVirtual: isNextJobVirtual, stageName: nextJobStageName } = nextJob;
-        const resource = `pipeline:${currentPipeline.id}:event:${currentEvent.id}`;
+        const resource = `pipeline:${currentPipeline.id}:groupEvent:${currentEvent.groupEventId}`;
         let lock;
         let nextBuild;
 

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -69,7 +69,7 @@ class AndTrigger extends JoinBase {
         let nextBuild = relatedBuilds.find(b => b.jobId === nextJobId && b.eventId === this.currentEvent.id);
 
         if (!nextBuild) {
-            // If the build to join fails and it succeeds on restart, depending on the timing, the latest build will be that of a child event.
+            // If the build to join restart, depending on the timing, the latest build will be that of a child event.
             // In that case, `nextBuild` will be null and will not be triggered even though there is a build that should be triggered.
             // Now we need to check for the existence of a build that should be triggered in its own event.
             nextBuild = await this.buildFactory.get({
@@ -82,11 +82,21 @@ class AndTrigger extends JoinBase {
             }
         }
 
+        if (!nextBuild) {
+            // If the build to join is in the child event, its event id is greater than current event.
+            nextBuild = relatedBuilds.find(b => b.jobId === nextJobId && b.eventId > this.currentEvent.id);
+        }
+
         const newParentBuilds = mergeParentBuilds(parentBuilds, relatedBuilds, this.currentEvent);
+        let nextEvent = this.currentEvent;
+
+        if (nextBuild) {
+            nextEvent = await this.eventFactory.get({ id: nextBuild.eventId });
+        }
 
         return this.processNextBuild({
             pipelineId: this.pipelineId,
-            event: this.currentEvent,
+            event: nextEvent,
             nextBuild,
             nextJobName,
             nextJobId,

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -69,7 +69,7 @@ class AndTrigger extends JoinBase {
         let nextBuild = relatedBuilds.find(b => b.jobId === nextJobId && b.eventId === this.currentEvent.id);
 
         if (!nextBuild) {
-            // If the build to join restart, depending on the timing, the latest build will be that of a child event.
+            // If the build to join fails and it succeeds on restart, depending on the timing, the latest build will be that of a child event.
             // In that case, `nextBuild` will be null and will not be triggered even though there is a build that should be triggered.
             // Now we need to check for the existence of a build that should be triggered in its own event.
             nextBuild = await this.buildFactory.get({

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -931,6 +931,7 @@ describe('trigger tests', () => {
         await event.getBuildOf('b').complete('SUCCESS');
         await event.getBuildOf('c').complete('SUCCESS');
 
+        assert.isNull(event.getBuildOf('target'));
         assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
     });
 
@@ -950,6 +951,7 @@ describe('trigger tests', () => {
         await restartEvent.getBuildOf('a').complete('SUCCESS');
         await event.getBuildOf('c').complete('SUCCESS');
 
+        assert.isNull(event.getBuildOf('target'));
         assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
     });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR fixes some cases of the [issue](https://github.com/screwdriver-cd/screwdriver/issues/2957).

It corrects the join build to be properly restarted and executed on the event in the following two test cases that have been added:
- In the case where `[a, b]` are in the requires, `a` fails but succeeds after `a` restart, and then `b` succeeds.
- In the case where `[a, b, c]` are in the requires, `a` fails but succeeds after `a` restart, and then `b` and `c` succeed.

However, the following test case, which is also exemplified in the original issue, still requires fixing:
- In the case where `[a, b, c]` are in the requires, `a` fails, `a` is restarted, then `b` succeeds, `a` succeeds, and finally `c` succeeds.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Find trigger build in child event after current event has no trigger build.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#2957 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
