### PR TITLE
fix(3115): Pull in latest config-parser with workflowGraph support for pipeline template validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "screwdriver-build-bookend": "^4.0.0",
     "screwdriver-cache-bookend": "^3.0.0",
     "screwdriver-command-validator": "^3.0.0",
-    "screwdriver-config-parser": "^10.0.0",
+    "screwdriver-config-parser": "^10.4.1",
     "screwdriver-coverage-bookend": "^2.0.0",
     "screwdriver-coverage-sonar": "^4.1.1",
     "screwdriver-data-schema": "^23.2.0",

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -414,7 +414,21 @@ describe('pipeline plugin test', () => {
                                         sourcePaths: []
                                     }
                                 },
-                                parameters: {}
+                                parameters: {},
+                                workflowGraph: {
+                                    edges: [],
+                                    nodes: [
+                                        {
+                                            name: '~pr'
+                                        },
+                                        {
+                                            name: '~commit'
+                                        },
+                                        {
+                                            name: 'main'
+                                        }
+                                    ]
+                                }
                             }
                         }
                     });


### PR DESCRIPTION
## Context

Latest config-parser supports showing workflowGraph in pipeline template validation.

## Objective

This PR updates test to reflect new changes.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3115

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
