### PR TITLE
feat(3143): Prevent event creation when started from a stage teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "screwdriver-scm-github": "^12.6.0",
     "screwdriver-scm-gitlab": "^3.1.0",
     "screwdriver-scm-router": "^7.1.0",
-    "screwdriver-template-validator": "^8.0.0",
+    "screwdriver-template-validator": "^8.1.0",
     "screwdriver-workflow-parser": "^4.1.1",
     "sqlite3": "^5.1.4",
     "stream": "0.0.2",

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -29,7 +29,7 @@ module.exports = () => ({
             let { pipelineId, startFrom, parentBuildId, parentBuilds, groupEventId, parentEventId, prNum } =
                 request.payload;
 
-            // Validation: Prevent event creation of startFrom is a stage teardown and parentEventID does not exist (start case)
+            // Validation: Prevent event creation if startFrom is a stage teardown and parentEventID does not exist (start case)
             if (isStageTeardown(startFrom) && !parentEventId) {
                 throw boom.badRequest('Event cannot be started from a stage teardown');
             }

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const dayjs = require('dayjs');
 const STAGE_PREFIX = 'stage@';
+const STAGE_TEARDOWN_PATTERN = /^stage@([\w-]+)(?::teardown)$/;
 
 /**
  * Set default start time and end time
@@ -113,11 +114,21 @@ function getFullStageJobName({ stageName, jobName }) {
     return `${STAGE_PREFIX}${stageName}:${jobName}`;
 }
 
+/**
+ * Check if the job is teardown job with teardown suffix
+ * @param  {String} jobName                 Job name
+ * @return {Boolean}
+ */
+function isStageTeardown(jobName) {
+    return STAGE_TEARDOWN_PATTERN.test(jobName);
+}
+
 module.exports = {
     getReadOnlyInfo,
     getScmUri,
     getUserPermissions,
     setDefaultTimeRange,
     validTimeRange,
-    getFullStageJobName
+    getFullStageJobName,
+    isStageTeardown
 };

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -3,7 +3,7 @@
 const boom = require('@hapi/boom');
 const dayjs = require('dayjs');
 const STAGE_PREFIX = 'stage@';
-const STAGE_TEARDOWN_PATTERN = /^stage@([\w-]+)(?::teardown)$/;
+const STAGE_TEARDOWN_PATTERN = /^stage@([\w-]+):teardown$/;
 
 /**
  * Set default start time and end time

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1022,6 +1022,58 @@ describe('event plugin test', () => {
             });
         });
 
+        it('returns 400 bad request error when startFrom is teardown', () => {
+            options.payload.startFrom = 'stage@integration:teardown';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 400);
+            });
+        });
+
+        it('returns 201 when it successfully creates an event with parent event and the startFrom is a stage teardown', () => {
+            eventConfig.parentEventId = parentEventId;
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            eventConfig.startFrom = 'stage@integration:teardown';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startFrom = 'stage@integration:teardown';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it successfully creates an event with parent event and the startFrom is not a stage teardown', () => {
+            eventConfig.parentEventId = parentEventId;
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            options.payload.parentEventId = parentEventId;
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
         it('returns 403 forbidden error when user does not have push permission and is not author of PR', () => {
             options.payload.startFrom = 'PR-1:main';
             userMock.getPermissions.resolves({ push: false });

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -632,6 +632,58 @@ describe('event plugin test', () => {
             });
         });
 
+        it('returns 400 bad request error when startFrom is teardown', () => {
+            options.payload.startFrom = 'stage@integration:teardown';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 400);
+            });
+        });
+
+        it('returns 201 when it successfully creates an event with parent event and the startFrom is a stage teardown', () => {
+            eventConfig.parentEventId = parentEventId;
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            eventConfig.startFrom = 'stage@integration:teardown';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startFrom = 'stage@integration:teardown';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it successfully creates an event with parent event and the startFrom is not a stage teardown', () => {
+            eventConfig.parentEventId = parentEventId;
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            options.payload.parentEventId = parentEventId;
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
         it('returns 201 when it creates an event with parent event for child pipeline', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
@@ -1019,58 +1071,6 @@ describe('event plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 400);
-            });
-        });
-
-        it('returns 400 bad request error when startFrom is teardown', () => {
-            options.payload.startFrom = 'stage@integration:teardown';
-
-            return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 400);
-            });
-        });
-
-        it('returns 201 when it successfully creates an event with parent event and the startFrom is a stage teardown', () => {
-            eventConfig.parentEventId = parentEventId;
-            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
-            eventConfig.sha = getEventMock(testEvent).sha;
-            eventConfig.baseBranch = 'master';
-            eventConfig.startFrom = 'stage@integration:teardown';
-            options.payload.parentEventId = parentEventId;
-            options.payload.startFrom = 'stage@integration:teardown';
-
-            return server.inject(options).then(reply => {
-                expectedLocation = {
-                    host: reply.request.headers.host,
-                    port: reply.request.headers.port,
-                    protocol: reply.request.server.info.protocol,
-                    pathname: `${options.url}/12345`
-                };
-                assert.equal(reply.statusCode, 201);
-                assert.calledWith(eventFactoryMock.create, eventConfig);
-                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
-                assert.notCalled(eventFactoryMock.scm.getPrInfo);
-            });
-        });
-
-        it('returns 201 when it successfully creates an event with parent event and the startFrom is not a stage teardown', () => {
-            eventConfig.parentEventId = parentEventId;
-            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
-            eventConfig.sha = getEventMock(testEvent).sha;
-            eventConfig.baseBranch = 'master';
-            options.payload.parentEventId = parentEventId;
-
-            return server.inject(options).then(reply => {
-                expectedLocation = {
-                    host: reply.request.headers.host,
-                    port: reply.request.headers.port,
-                    protocol: reply.request.server.info.protocol,
-                    pathname: `${options.url}/12345`
-                };
-                assert.equal(reply.statusCode, 201);
-                assert.calledWith(eventFactoryMock.create, eventConfig);
-                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
-                assert.notCalled(eventFactoryMock.scm.getPrInfo);
             });
         });
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -632,7 +632,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 400 bad request error when startFrom is teardown', () => {
+        it('returns 400 bad request error when startFrom is stage teardown and parent event is not specified', () => {
             options.payload.startFrom = 'stage@integration:teardown';
 
             return server.inject(options).then(reply => {


### PR DESCRIPTION
## Context

Not allow users to start an event form a stage teardown

## Objective

throw an error if the user tries to start an event from a stage teardown

## References

[https://github.com/screwdriver-cd/screwdriver/issues/3143](url)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
