### PR TITLE
feat(3146): Get repository data from scmRepo without GitHub access [4]

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -87,7 +87,7 @@ async function updateAdmins(userFactory, username, scmContext, pipeline, pipelin
 
     try {
         const user = await userFactory.get({ username, scmContext });
-        const userPermissions = await user.getPermissions(pipeline.scmUri);
+        const userPermissions = await user.getPermissions(pipeline.scmUri, user.scmContext, pipeline.scmRepo);
 
         // Delete user from admin list if bad permissions
         if (!userPermissions.push) {
@@ -999,6 +999,7 @@ async function createEvents(
                 const scmConfig = {
                     scmUri: pTuple.pipeline.scmUri,
                     token,
+                    scmRepo: pTuple.pipeline.scmRepo,
                     scmContext
                 };
                 // obtain pipeline's latest commit sha for branch specific job

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -267,6 +267,11 @@ describe('startHookEvent test', () => {
     const latestSha = 'a402964c054c610757794d9066c96cee1772daed';
     const username = 'baxterthehacker';
     const scmContext = 'github:github.com';
+    const scmRepo = {
+        branch: 'branch',
+        url: 'https://github.com/org/repo/tree/branch',
+        name: 'org/repo'
+    };
     const token = 'iamtoken';
     const prRef = 'pull/1/merge';
     const scmDisplayName = 'github';
@@ -410,6 +415,8 @@ describe('startHookEvent test', () => {
         pipelineMock = getPipelineMocks({
             id: pipelineId,
             scmUri,
+            token,
+            scmRepo,
             annotations: {},
             admins: {
                 baxterthehacker: false
@@ -1107,6 +1114,12 @@ describe('startHookEvent test', () => {
             startHookEvent(request, responseHandler, parsed).then(reply => {
                 assert.equal(reply.statusCode, 201);
                 assert.notCalled(pipelineFactoryMock.scm.getCommitRefSha);
+                assert.calledWith(pipelineFactoryMock.scm.getCommitSha, {
+                    scmUri,
+                    token,
+                    scmContext,
+                    scmRepo
+                });
                 assert.calledWith(eventFactoryMock.create, {
                     pipelineId,
                     type: 'pipeline',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We will be able to get repository data from `pipeline.scmRepo` by the following PR.
https://github.com/screwdriver-cd/scm-github/pull/231

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Pass `scmRepo` to skip GitHub access and get repository data from it.
(This PR's target is only webhook process.)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Prior PRs
- https://github.com/screwdriver-cd/data-schema/pull/570
- https://github.com/screwdriver-cd/scm-github/pull/231

Issue
- https://github.com/screwdriver-cd/screwdriver/issues/3146

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
