### PR TITLE
fix: check original job is not archived

### DIFF
--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -335,14 +335,14 @@ async function createInternalBuild(config) {
 
     if (ref) {
         // Whether a job is enabled is determined by the state of the original job.
-        // If the original job does not exist, it will be enabled.
+        // If the original job does not exist or archived, it will be enabled.
         const originalJobName = job.parsePRJobName('job');
         const originalJob = await jobFactory.get({
             name: originalJobName,
             pipelineId
         });
 
-        jobState = originalJob ? originalJob.state : Status.ENABLED;
+        jobState = originalJob && !originalJob.archived ? originalJob.state : Status.ENABLED;
     }
 
     if (Status.isEnabled(jobState)) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Now, it checks original job state to decide that the PR job is executable.
But the PR job is not able to be triggered if original job was deleted still it had been disabled.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix to check if the original job was deleted in the same way as `eventFactory`.

https://github.com/screwdriver-cd/models/blob/8291226e30963ad0a53acc222693c86e976437e9/lib/eventFactory.js#L154-L163

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
