### PR TITLE
feat(3146): Get repository data from scmRepo without GitHub access from UI start

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -136,7 +136,7 @@ module.exports = () => ({
             let permissions;
 
             try {
-                permissions = await user.getPermissions(scmUri);
+                permissions = await user.getPermissions(scmUri, pipeline.scmContext, pipeline.scmRepo);
             } catch (err) {
                 if (err.statusCode === 403 && pipeline.scmRepo && pipeline.scmRepo.private) {
                     throw boom.notFound();
@@ -155,6 +155,7 @@ module.exports = () => ({
                 prNum,
                 scmContext: pipeline.scmContext,
                 scmUri: pipeline.scmUri,
+                scmRepo: pipeline.scmRepo,
                 token
             };
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -291,29 +291,19 @@ describe('event plugin test', () => {
         let expectedLocation;
         let scmConfig;
         let userMock;
+        let pipelineMock;
         let meta;
         const username = 'myself';
         const parentBuildId = 12345;
         const pipelineId = 123;
         const scmContext = 'github:github.com';
+        const scmRepo = {
+            branch: 'branch',
+            url: 'https://github.com/org/repo/tree/branch',
+            name: 'org/repo'
+        };
         const scmUri = 'github.com:12345:branchName';
         const checkoutUrl = 'git@github.com:screwdriver-cd/data-model.git#master';
-        const pipelineMock = {
-            id: pipelineId,
-            checkoutUrl,
-            scmContext: 'github:github.com',
-            update: sinon.stub().resolves(),
-            admins: { foo: true, bar: true },
-            admin: Promise.resolve({
-                username: 'foo',
-                unsealToken: sinon.stub().resolves('token')
-            }),
-            scmUri,
-            chainPR: false,
-            annotations: {
-                'screwdriver.cd/restrictPR': 'none'
-            }
-        };
         const parentBuilds = { 123: { eventId: 8888, jobs: { main: 12345 } } };
         const prInfo = {
             sha: testBuild.sha,
@@ -330,10 +320,28 @@ describe('event plugin test', () => {
                 unsealToken: sinon.stub().resolves('iamtoken'),
                 getFullDisplayName: sinon.stub().returns('Memys Elfandi')
             };
+            pipelineMock = {
+                id: pipelineId,
+                checkoutUrl,
+                scmContext: 'github:github.com',
+                scmRepo,
+                update: sinon.stub().resolves(),
+                admins: { foo: true, bar: true },
+                admin: Promise.resolve({
+                    username: 'foo',
+                    unsealToken: sinon.stub().resolves('token')
+                }),
+                scmUri,
+                chainPR: false,
+                annotations: {
+                    'screwdriver.cd/restrictPR': 'none'
+                }
+            };
             scmConfig = {
                 prNum: null,
                 scmContext: 'github:github.com',
                 scmUri,
+                scmRepo,
                 token: 'iamtoken'
             };
             meta = {
@@ -409,6 +417,7 @@ describe('event plugin test', () => {
                 };
                 assert.calledWith(buildFactoryMock.get, 1234);
                 assert.calledWith(jobFactoryMock.get, 222);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
@@ -440,6 +449,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(eventFactoryMock.scm.getCommitSha, scmConfig);
@@ -471,6 +481,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(eventFactoryMock.scm.getCommitSha, scmConfig);
@@ -487,6 +498,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(eventFactoryMock.scm.getCommitSha, scmConfig);
@@ -505,6 +517,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(eventFactoryMock.scm.getCommitSha, scmConfig);
@@ -527,6 +540,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
@@ -567,6 +581,7 @@ describe('event plugin test', () => {
                 };
                 assert.calledWith(buildFactoryMock.get, 1234);
                 assert.calledWith(jobFactoryMock.get, 222);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
@@ -609,6 +624,7 @@ describe('event plugin test', () => {
                 };
                 assert.calledWith(buildFactoryMock.get, 1234);
                 assert.calledWith(jobFactoryMock.get, 222);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
@@ -645,6 +661,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
@@ -681,6 +698,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
@@ -700,6 +718,7 @@ describe('event plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
@@ -720,6 +739,7 @@ describe('event plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
@@ -740,6 +760,7 @@ describe('event plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
@@ -875,6 +896,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
@@ -898,6 +920,7 @@ describe('event plugin test', () => {
                     pathname: `${options.url}/12345`
                 };
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledWith(eventFactoryMock.scm.getCommitSha, scmConfig);
@@ -919,6 +942,7 @@ describe('event plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -722,6 +722,7 @@ describe('event plugin test', () => {
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, { ...scmConfig, prNum: eventConfig.prNum });
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
             });
         });
@@ -743,6 +744,10 @@ describe('event plugin test', () => {
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, {
+                    ...scmConfig,
+                    prNum: Number(options.payload.prNum)
+                });
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
             });
         });
@@ -764,6 +769,7 @@ describe('event plugin test', () => {
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, { ...scmConfig, prNum: eventConfig.prNum });
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
             });
         });
@@ -901,6 +907,7 @@ describe('event plugin test', () => {
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, { ...scmConfig, prNum: eventConfig.prNum });
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
             });
         });
@@ -946,6 +953,7 @@ describe('event plugin test', () => {
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledOnce(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, { ...scmConfig, prNum: eventConfig.prNum });
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
             });
         });
@@ -1030,6 +1038,7 @@ describe('event plugin test', () => {
                 assert.notCalled(eventFactoryMock.create);
                 assert.notCalled(eventFactoryMock.scm.getCommitSha);
                 assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, { ...scmConfig, prNum: '1' });
                 assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This is a continuation of the following PR.
https://github.com/screwdriver-cd/screwdriver/pull/3147
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Allow to pass scmRepo argument into methods that using lookupScmUri method inside even at the start of the event.
Thus reducing the number of API accesses to GitHub.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3146
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
