### PR TITLE
feat(3156): New endpoint to delete specific version of a command

### DIFF
--- a/plugins/commands/README.md
+++ b/plugins/commands/README.md
@@ -1,4 +1,5 @@
 # Commands Plugin
+
 > Hapi commands plugin for the Screwdriver API
 
 ## Usage
@@ -12,17 +13,20 @@ const commandsPlugin = require('./');
 
 server.connection({ port: 3000 });
 
-server.register({
-    register: commandsPlugin,
-    options: {}
-}, () => {
-    server.start((err) => {
-        if (err) {
-            throw err;
-        }
-        console.log('Server running at:', server.info.uri);
-    });
-});
+server.register(
+    {
+        register: commandsPlugin,
+        options: {}
+    },
+    () => {
+        server.start(err => {
+            if (err) {
+                throw err;
+            }
+            console.log('Server running at:', server.info.uri);
+        });
+    }
+);
 ```
 
 ### Routes
@@ -61,10 +65,10 @@ You can get a single command by providing the command namespace, name and the sp
 
 'namespace', 'name', 'tag' or 'version'
 
-* `namespace` - Namespace of the command
-* `name` - Name of the command
-* `tag` - Tag of the command (e.g. `stable`, `latest`, etc)
-* `version` - Version of the command
+-   `namespace` - Namespace of the command
+-   `name` - Name of the command
+-   `tag` - Tag of the command (e.g. `stable`, `latest`, etc)
+-   `version` - Version of the command
 
 ##### Create a command
 
@@ -72,7 +76,7 @@ Creating a command will store the command data (`namespace`, `name`, `version`, 
 
 `version` will be auto-bumped. For example, if `foo/bar@1.0.0` already exists and the version passed in is `1.0`, the newly created command will be version `1.0.1`.
 
-*Note: This endpoint only accessible in `build` scope and the permission is tied to the pipeline that first creates the command.*
+_Note: This endpoint only accessible in `build` scope and the permission is tied to the pipeline that first creates the command._
 
 `POST /commands`
 
@@ -80,51 +84,79 @@ Creating a command will store the command data (`namespace`, `name`, `version`, 
 
 'namespace', 'name', 'version', 'description', 'maintainer', 'format', commandFormat (`habitat` or `docker` or `binary`)
 
-* `namespace` - Namespace of the command
-* `name` - Name of the command
-* `version` - Version of the command
-* `description` - Description of the command
-* `maintainer` - Maintainer of the command
-* `format` - `habitat` or `docker` or `binary`
-* `habitat` or `docker` or `binary` - Config of the command. This field is an object that includes properties of each command format.
+-   `namespace` - Namespace of the command
+-   `name` - Name of the command
+-   `version` - Version of the command
+-   `description` - Description of the command
+-   `maintainer` - Maintainer of the command
+-   `format` - `habitat` or `docker` or `binary`
+-   `habitat` or `docker` or `binary` - Config of the command. This field is an object that includes properties of each command format.
 
 Example payload:
+
 ```json
 {
-  "namespace": "foo",
-  "name": "bar",
-  "version": "1.7",
-  "description": "this is a command",
-  "maintainer": "foo@bar.com",
-  "format": "habitat",
-  "habitat": {
-     "mode": "remote",
-     "package": "core/git/2.14.1",
-     "command": "git"
-  }
+    "namespace": "foo",
+    "name": "bar",
+    "version": "1.7",
+    "description": "this is a command",
+    "maintainer": "foo@bar.com",
+    "format": "habitat",
+    "habitat": {
+        "mode": "remote",
+        "package": "core/git/2.14.1",
+        "command": "git"
+    }
 }
 ```
 
 ##### Delete a command
+
 Deleting a command will delete a command and all of its associated tags and versions.
 
-`DELETE /commands/{name}`
+`DELETE /commands/{namespace}/{name}`
 
 ###### Arguments
 
-* `name` - Name of the command
+-   `namespace` - Namespace of the command
+-   `name` - Name of the command
+
+##### Delete a version of a command
+
+Deleting a specific version of a command also deletes the associated tags for that version.
+
+`DELETE /commands/{namespace}/{name}/versions/{version}`
+
+###### Arguments
+
+-   `namespace` - Namespace of the command
+-   `name` - Name of the command
+-   `version` - Version of the command
 
 #### Command Tag
+
 Command Tag allows fetching on command version by tag. For example, command `mynamespace/mycommand@1.2.0` as `stable`.
 
 ##### Create/Update a tag
 
 If the command tag already exists, it will update the tag with the version. If the command tag doesn't exist yet, this endpoint will create the tag.
 
-You can also call this endpoint with tag instead of the exact version. In this case, same version will have two tags.  (e.g. version 1.0.0 tagged with both latest and stable)
+You can also call this endpoint with tag instead of the exact version. In this case, same version will have two tags. (e.g. version 1.0.0 tagged with both latest and stable)
 
-*Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the command.*
+_Note: This endpoint is only accessible in `build` scope and the permission is tied to the pipeline that creates the command._
 
 `PUT /commands/{namespace}/{name}/tags/{tagName}` with the following payload
 
-* `version` - Exact version or tag of the command (ex: `1.1.0`, `latest`)
+-   `version` - Exact version or tag of the command (ex: `1.1.0`, `latest`)
+
+##### Delete a tag
+
+Delete a specific tag of a command.
+
+`DELETE /commands/{namespace}/{name}/tags/{tagName}`
+
+###### Arguments
+
+-   `namespace` - Namespace of the command
+-   `name` - Name of the command
+-   `tagName` - Tag of the command (e.g. `stable`, `latest`, etc)

--- a/plugins/commands/index.js
+++ b/plugins/commands/index.js
@@ -7,6 +7,7 @@ const getRoute = require('./get');
 const listRoute = require('./list');
 const removeRoute = require('./remove');
 const removeTagRoute = require('./removeTag');
+const removeVersionRoute = require('./removeVersion');
 const listTagsRoute = require('./listTags');
 const listVersionsRoute = require('./listVersions');
 const updateTrustedRoute = require('./updateTrusted');
@@ -80,6 +81,7 @@ const commandsPlugin = {
             getRoute(),
             removeRoute(),
             removeTagRoute(),
+            removeVersionRoute(),
             listRoute(),
             listVersionsRoute(),
             listTagsRoute(),

--- a/plugins/commands/removeVersion.js
+++ b/plugins/commands/removeVersion.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const commandBaseSchema = schema.models.command.base;
+
+module.exports = () => ({
+    method: 'DELETE',
+    path: '/commands/{namespace}/{name}/versions/{version}',
+    options: {
+        description: 'Delete the specified version of commands and the tags associated with it',
+        notes: 'Returns null if successful',
+        tags: ['api', 'commands'],
+        auth: {
+            strategies: ['token'],
+            scope: ['build', 'user', '!guest']
+        },
+        handler: async (request, h) => {
+            const { namespace, name, version } = request.params;
+            const { credentials } = request.auth;
+            const { commandFactory, commandTagFactory } = request.server.app;
+            const { canRemove } = request.server.plugins.commands;
+
+            return Promise.all([
+                commandFactory.get({ namespace, name, version }),
+                commandTagFactory.list({ params: { namespace, name, version } })
+            ])
+                .then(async ([command, tags]) => {
+                    if (!command) {
+                        throw boom.notFound(
+                            `Command ${name} with version ${version} in namespace ${namespace} does not exist`
+                        );
+                    }
+
+                    await canRemove(credentials, command, 'admin', request.server.app);
+
+                    const promises = command.remove();
+                    const tagPromises = tags.map(tag => tag.remove());
+
+                    await Promise.all([promises, ...tagPromises]);
+
+                    return h.response().code(204);
+                })
+                .catch(err => {
+                    throw err;
+                });
+        },
+        validate: {
+            params: joi.object({
+                name: commandBaseSchema.extract('name'),
+                namespace: commandBaseSchema.extract('namespace'),
+                version: commandBaseSchema.extract('version')
+            })
+        }
+    }
+});

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -1485,7 +1485,7 @@ describe('command plugin test', () => {
             pipeline = getPipelineMocks(testpipeline);
             pipelineFactoryMock.get.withArgs(pipelineId).resolves(pipeline);
 
-            commandFactoryMock.list.resolves([testCommand]);
+            commandFactoryMock.get.resolves(testCommand);
             commandTagFactoryMock.list.resolves([testCommandTag]);
             requestMock.resolves({ statusCode: 204 });
         });
@@ -1502,6 +1502,149 @@ describe('command plugin test', () => {
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
                 assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 403 when user does not have admin permissions', () => {
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'User myself does not have admin access for this command'
+            };
+
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: false });
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 404 when user does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: 'User myself does not exist'
+            };
+
+            userFactoryMock.get.withArgs({ username, scmContext }).resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 404 when pipeline does not exist', () => {
+            const error = {
+                statusCode: 404,
+                error: 'Not Found',
+                message: `Pipeline ${pipelineId} does not exist`
+            };
+
+            pipelineFactoryMock.get.withArgs(pipelineId).resolves(null);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('deletes command if user has pipeline admin credentials and command exists', () => {
+            userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(testCommand.remove);
+                assert.calledOnce(testCommandTag.remove);
+                assert.equal(reply.statusCode, 204);
+            });
+        });
+
+        it('deletes command if user has Screwdriver admin credentials and command exists', () => {
+            options.auth.credentials.scope.push('admin');
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(testCommand.remove);
+                assert.calledOnce(testCommandTag.remove);
+                assert.equal(reply.statusCode, 204);
+            });
+        });
+
+        it('returns 403 when build credential pipelineId does not match target pipelineId', () => {
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'Not allowed to remove this command'
+            };
+
+            options = {
+                method: 'DELETE',
+                url: '/commands/foo/bar/versions/1.0.0',
+                auth: {
+                    credentials: {
+                        username,
+                        scmContext,
+                        pipelineId: 1337,
+                        scope: ['build']
+                    },
+                    strategy: 'token'
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 403 if it is a PR build', () => {
+            const error = {
+                statusCode: 403,
+                error: 'Forbidden',
+                message: 'Not allowed to remove this command'
+            };
+
+            options = {
+                method: 'DELETE',
+                url: '/commands/foo/bar/versions/1.0.0',
+                auth: {
+                    credentials: {
+                        isPR: true,
+                        username,
+                        scmContext,
+                        pipelineId,
+                        scope: ['build']
+                    },
+                    strategy: 'token'
+                }
+            };
+            options.auth.credentials.isPR = true;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 403);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('deletes command if build credentials provided and pipelineIds match', () => {
+            options = {
+                method: 'DELETE',
+                url: '/commands/foo/bar/versions/1.0.0',
+                auth: {
+                    credentials: {
+                        username,
+                        scmContext,
+                        pipelineId,
+                        scope: ['build']
+                    },
+                    strategy: 'token'
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(testCommand.remove);
+                assert.calledOnce(testCommandTag.remove);
+                assert.equal(reply.statusCode, 204);
             });
         });
     });

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -1648,5 +1648,4 @@ describe('command plugin test', () => {
             });
         });
     });
-
 });

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -1440,4 +1440,6 @@ describe('command plugin test', () => {
             });
         });
     });
+
+    describe('', () => {});
 });


### PR DESCRIPTION
## Context

While there is API endpoints to [delete a command](https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/commands/remove.js) and [a tag from a command](https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/commands/removeTag.js), there is no endpoint to allow the deletion of specific version of a command. And it will be useful to allow specific command and its associated tag to be deleted because bad commits happen sometimes. 

## Objective

This PR implements a new endpoint to allow specific version of a command to be deleted. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3156

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
