### PR TITLE
Skip execution of jobs between stage setup and event startFrom

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1628,6 +1628,81 @@ describe('build plugin test', () => {
                     });
                 });
 
+                it('triggers the startFrom job after the stage setup job if the startFrom job is a non-setup stage job', () => {
+                    const status = 'SUCCESS';
+                    const options = {
+                        method: 'PUT',
+                        url: `/builds/${id}`,
+                        auth: {
+                            credentials: {
+                                username: id,
+                                scope: ['build']
+                            },
+                            strategy: ['token']
+                        },
+                        payload: {
+                            status
+                        }
+                    };
+
+                    jobMock = {
+                        id: 1234,
+                        name: 'stage@alpha:setup',
+                        pipelineId,
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ],
+                        pipeline: sinon.stub().resolves(pipelineMock)(),
+                        getLatestBuild: sinon.stub().resolves(buildMock)
+                    };
+                    buildMock.job = sinon.stub().resolves(jobMock)();
+                    buildMock.parentBuilds = {
+                        123: { eventId: '8888', jobs: { '~commit': 7777, C: 7778, D: 7779 } }
+                    };
+                    eventMock.getBuilds.resolves([
+                        {
+                            id: 1,
+                            eventId: '8888',
+                            jobId: 1,
+                            status: 'FAILURE'
+                        },
+                        {
+                            id: 7777,
+                            eventId: '8888',
+                            jobId: 4,
+                            status: 'SUCCESS'
+                        },
+                        {
+                            id: 7778,
+                            eventId: '8888',
+                            jobId: 5,
+                            status: 'SUCCESS'
+                        },
+                        {
+                            id: 7779,
+                            eventId: '8888',
+                            jobId: 6,
+                            status: 'SUCCESS'
+                        }
+                    ]);
+
+                    eventMock.workflowGraph = testWorkflowGraphWithStages;
+                    eventMock.startFrom = 'alpha-certify';
+                    eventFactoryMock.get.resolves(eventMock);
+
+                    return server.inject(options).then(reply => {
+                        assert.equal(reply.statusCode, 200);
+                        assert.calledWith(jobFactoryMock.get, {
+                            name: eventMock.startFrom,
+                            pipelineId
+                        });
+                    });
+                });
+
                 it('triggers next job in the stage workflow if current is successful stage teardown and stageBuild is success', () => {
                     const stageBuildMock = {
                         id: 1,


### PR DESCRIPTION

## Context

The job after the stage setup was being executed regardless of the startFrom being from the middle of stage or not

## Objective

The startFrom job will be triggered next if the current job is stage setup and the startFrom is a non setup job in that stage

## References

https://github.com/screwdriver-cd/screwdriver/issues/3143

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
