### PR TITLE
fix(3163): Add sort and sortby query params for pipeline list events

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -107,6 +107,7 @@ Query Params:
 * `page` - *Optional* Specific page of the set to return
 * `count` - *Optional* Number of items per page
 * `sort` - *Optional* Sort rangekey by `ascending` or `descending` (default `descending`)
+* `sortBy` - *Optional* Field to sort by
 * `type` - *Optional* Get pipeline or pr events (default `pipeline`)
 * `prNum` - *Optional* Return only PR events of specified PR number
 * `sha` - *Optional* Search `sha` and `configPipelineSha` for events
@@ -115,7 +116,8 @@ Query Params:
 `GET /pipelines/{id}/events?page={pageNumber}&count={countNumber}&sort={sort}&type={type}&prNum={prNumber}&sha={sha}`
 
 `GET /pipelines/{id}/events?id=gt:{eventId}&count={countNumber}` (greater than eventId)
-`GET /pipelines/{id}/events?id=lt:{eventId}&count={countNumber}` (less than eventId)
+
+`GET /pipelines/{id}/events?id=lt:{eventId}&count={countNumber}&sort=ascending` (less than eventId)
 
 #### Get all pipeline builds
 `page`, `count`, `sort`, `latest`, `sortBy`, `fetchSteps`, `readOnly`, and `groupEventId` are optional

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -17,7 +17,7 @@ const INEQUALITY_SIGNS = /^(gt|lt):([\d]+)$/;
 const queryIdSchema = joi
     .alternatives()
     .try(pipelineIdSchema, joi.string().regex(INEQUALITY_SIGNS))
-    .label('Query ID schema')
+    .description('Event ID; alternatively can use greater than or less than prefix (gt:/lt:)')
     .example('gt:12345');
 
 module.exports = () => ({
@@ -34,7 +34,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const factory = request.server.app.pipelineFactory;
-            const { page, count, sha, prNum, id } = request.query;
+            const { page, count, sha, prNum, id, sort, sortBy } = request.query;
 
             return factory
                 .get(request.params.id)
@@ -44,13 +44,17 @@ module.exports = () => ({
                     }
 
                     const eventType = request.query.type || 'pipeline';
-                    const config = { params: { type: eventType } };
+                    const config = { params: { type: eventType }, sort };
 
                     if (page || count) {
                         config.paginate = {
                             page,
                             count
                         };
+                    }
+
+                    if (sortBy) {
+                        config.sortBy = sortBy;
                     }
 
                     if (prNum) {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1536,7 +1536,7 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.calledOnce(pipelineMock.getEvents);
-                assert.calledWith(pipelineMock.getEvents, { params: { type: 'pr' } });
+                assert.calledWith(pipelineMock.getEvents, { params: { type: 'pr' }, sort: 'descending' });
                 assert.deepEqual(reply.result, testEvents);
                 assert.equal(reply.statusCode, 200);
             });
@@ -1549,7 +1549,8 @@ describe('pipeline plugin test', () => {
                 assert.calledOnce(pipelineMock.getEvents);
                 assert.calledWith(pipelineMock.getEvents, {
                     params: { type: 'pr' },
-                    paginate: { page: undefined, count: 30 }
+                    paginate: { page: undefined, count: 30 },
+                    sort: 'descending'
                 });
                 assert.deepEqual(reply.result, testEvents);
                 assert.equal(reply.statusCode, 200);
@@ -1561,20 +1562,22 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.calledOnce(pipelineMock.getEvents);
-                assert.calledWith(pipelineMock.getEvents, { params: { prNum: 4, type: 'pr' } });
+                assert.calledWith(pipelineMock.getEvents, { params: { prNum: 4, type: 'pr' }, sort: 'descending' });
                 assert.deepEqual(reply.result, testEvents);
                 assert.equal(reply.statusCode, 200);
             });
         });
 
         it('returns 200 for getting events with id less than 888', () => {
-            options.url = `/pipelines/${id}/events?id=lt:888&count=5`;
+            options.url = `/pipelines/${id}/events?id=lt:888&count=5&sort=ascending&sortBy=createTime`;
 
             return server.inject(options).then(reply => {
                 assert.calledOnce(pipelineMock.getEvents);
                 assert.calledWith(pipelineMock.getEvents, {
                     params: { id: 'lt:888', type: 'pipeline' },
-                    paginate: { page: undefined, count: 5 }
+                    paginate: { page: undefined, count: 5 },
+                    sort: 'ascending',
+                    sortBy: 'createTime'
                 });
                 assert.deepEqual(reply.result, testEvents);
                 assert.equal(reply.statusCode, 200);
@@ -1591,7 +1594,8 @@ describe('pipeline plugin test', () => {
                     search: {
                         field: ['sha', 'configPipelineSha'],
                         keyword: 'ccc49349d3cffbd12ea9e3d41521480b4aa5de5f%'
-                    }
+                    },
+                    sort: 'descending'
                 });
                 assert.deepEqual(reply.result, testEvents);
                 assert.equal(reply.statusCode, 200);


### PR DESCRIPTION
## Context

We need to be able to sort in a different order than descending.

## Objective

This PR adds sort and sortBy to pipeline list events endpoint. Also updates joi schema for event ID query param for Swagger.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3163

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
