### PR TITLE
fix: Stabilize functional test

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -16,7 +16,7 @@ Feature: User Collections
             | name          | permission  |
             | calvin        | admin       |
 #            | miss wormwood | no access   |
-        And an existing pipeline with that repository
+        And an existing pipeline for collections
 
     Scenario: Check Default Collection
         And "calvin" is logged in
@@ -25,34 +25,34 @@ Feature: User Collections
 
     Scenario: Create New Collection
         And "calvin" is logged in
-        When they create a new collection "myCollection" with that pipeline
+        When they create a new collection "CreateTestCollection" with that pipeline
         Then they can see that collection
         And the collection contains that pipeline
 
     Scenario: Update Existing Collection
         And "calvin" is logged in
-        When they create a new collection "myCollection"
+        When they create a new collection "UpdateTestCollection"
         Then they can see that collection
         And the collection is empty
-        When they update the collection "myCollection" with that pipeline
+        When they update the collection "UpdateTestCollection" with that pipeline
         Then they can see that collection
         And the collection contains that pipeline
 
     Scenario: Listing A User's Collection
         And "calvin" is logged in
-        And they have a collection "myCollection"
-        And they have a collection "anotherCollection"
+        And they have a collection "TestCollection"
+        And they have a collection "AnotherTestCollection"
         When they fetch all their collections
         Then they can see those collections and the default collection
 
     Scenario: Deleting A Collection
         And "calvin" is logged in
-        And they have a collection "myCollection"
+        And they have a collection "DeleteTestCollection"
         When they delete that collection
         Then that collection no longer exists
 
     Scenario: Collections Are Unique
         And "calvin" is logged in
-        And they have a collection "myCollection"
-        When they create another collection with the same name "myCollection"
+        And they have a collection "TestCollection"
+        When they create another collection with the same name "TestCollection"
         Then they receive an error regarding unique collections

--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -55,24 +55,33 @@ Before('@collections', function hook() {
     this.repoOrg = this.testOrg;
     this.repoName = 'functional-collections';
     this.pipelineId = null;
-    this.firstCollectionId = null;
-    this.secondCollectionId = null;
+    this.collectionId = null;
+    this.collectionName = null;
+    this.anotherCollectionId = null;
 });
 
+Given(
+    /^an existing pipeline for collections$/,
+    {
+        timeout: TIMEOUT
+    },
+    function step() {
+        return this.ensurePipelineExists({ repoName: this.repoName });
+    }
+);
+
 When(/^they check the default collection$/, { timeout: TIMEOUT }, function step() {
-    return this.ensurePipelineExists({ repoName: this.repoName }).then(() =>
-        request({
-            url: `${this.instance}/${this.namespace}/collections`,
-            method: 'GET',
-            context: {
-                token: this.jwt
-            }
-        }).then(response => {
-            Assert.strictEqual(response.statusCode, 200);
-            this.defaultCollectionId = response.body.find(collection => collection.type === 'default').id;
-            Assert.notEqual(this.defaultCollectionId, undefined);
-        })
-    );
+    return request({
+        url: `${this.instance}/${this.namespace}/collections`,
+        method: 'GET',
+        context: {
+            token: this.jwt
+        }
+    }).then(response => {
+        Assert.strictEqual(response.statusCode, 200);
+        this.defaultCollectionId = response.body.find(collection => collection.type === 'default').id;
+        Assert.notEqual(this.defaultCollectionId, undefined);
+    });
 });
 
 Then(/^they can see the default collection contains that pipeline$/, { timeout: TIMEOUT }, function step() {
@@ -88,36 +97,39 @@ Then(/^they can see the default collection contains that pipeline$/, { timeout: 
         Assert.strictEqual(response.statusCode, 200);
         // TODO: May need to change back
         // Assert.deepEqual(response.body.pipelineIds, [pipelineId]);
-        Assert.include(response.body.pipelineIds, pipelineId);
+        const { pipelineIds } = response.body;
+
+        Assert.include(
+            pipelineIds,
+            pipelineId,
+            `AssertionError: expected ${JSON.stringify(pipelineIds)} to include ${pipelineId}`
+        );
     });
 });
 
-When(/^they create a new collection "myCollection" with that pipeline$/, { timeout: TIMEOUT }, function step() {
-    return this.ensurePipelineExists({ repoName: this.repoName })
-        .then(() => {
-            const requestBody = {
-                name: 'myCollection',
-                pipelineIds: [this.pipelineId]
-            };
+When(/^they create a new collection "CreateTestCollection" with that pipeline$/, { timeout: TIMEOUT }, function step() {
+    const requestBody = {
+        name: 'CreateTestCollection',
+        pipelineIds: [this.pipelineId]
+    };
 
-            return createCollection.call(this, requestBody);
-        })
-        .then(response => {
-            Assert.strictEqual(response.statusCode, 201);
-            this.firstCollectionId = response.body.id;
-        });
+    return createCollection.call(this, requestBody).then(response => {
+        Assert.strictEqual(response.statusCode, 201);
+        this.collectionId = response.body.id;
+        this.collectionName = 'CreateTestCollection';
+    });
 });
 
 Then(/^they can see that collection$/, { timeout: TIMEOUT }, function step() {
     return request({
-        url: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        url: `${this.instance}/${this.namespace}/collections/${this.collectionId}`,
         method: 'GET',
         context: {
             token: this.jwt
         }
     }).then(response => {
         Assert.strictEqual(response.statusCode, 200);
-        Assert.strictEqual(response.body.name, 'myCollection');
+        Assert.strictEqual(response.body.name, this.collectionName);
     });
 });
 
@@ -125,27 +137,28 @@ Then(/^the collection contains that pipeline$/, { timeout: TIMEOUT }, function s
     const pipelineId = parseInt(this.pipelineId, 10);
 
     return request({
-        url: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        url: `${this.instance}/${this.namespace}/collections/${this.collectionId}`,
         method: 'GET',
         context: {
             token: this.jwt
         }
     }).then(response => {
         Assert.strictEqual(response.statusCode, 200);
-        Assert.deepEqual(response.body.pipelineIds, [pipelineId]);
+        Assert.oneOf(pipelineId, response.body.pipelineIds);
     });
 });
 
-When(/^they create a new collection "myCollection"$/, { timeout: TIMEOUT }, function step() {
-    return createCollection.call(this, { name: 'myCollection' }).then(response => {
+When(/^they create a new collection "UpdateTestCollection"$/, { timeout: TIMEOUT }, function step() {
+    return createCollection.call(this, { name: 'UpdateTestCollection' }).then(response => {
         Assert.strictEqual(response.statusCode, 201);
-        this.firstCollectionId = response.body.id;
+        this.collectionId = response.body.id;
+        this.collectionName = 'UpdateTestCollection';
     });
 });
 
 Then(/^the collection is empty$/, { timeout: TIMEOUT }, function step() {
     return request({
-        url: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        url: `${this.instance}/${this.namespace}/collections/${this.collectionId}`,
         method: 'GET',
         context: {
             token: this.jwt
@@ -156,56 +169,55 @@ Then(/^the collection is empty$/, { timeout: TIMEOUT }, function step() {
     });
 });
 
-When(/^they update the collection "myCollection" with that pipeline$/, { timeout: TIMEOUT }, function step() {
-    return this.ensurePipelineExists({ repoName: this.repoName }).then(() => {
-        const pipelineId = parseInt(this.pipelineId, 10);
+When(/^they update the collection "UpdateTestCollection" with that pipeline$/, { timeout: TIMEOUT }, function step() {
+    const pipelineId = parseInt(this.pipelineId, 10);
 
-        return request({
-            url: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
-            method: 'PUT',
-            context: {
-                token: this.jwt
-            },
-            json: {
-                pipelineIds: [pipelineId]
-            }
-        }).then(response => {
-            Assert.strictEqual(response.statusCode, 200);
-        });
+    return request({
+        url: `${this.instance}/${this.namespace}/collections/${this.collectionId}`,
+        method: 'PUT',
+        context: {
+            token: this.jwt
+        },
+        json: {
+            pipelineIds: [pipelineId]
+        }
+    }).then(response => {
+        Assert.strictEqual(response.statusCode, 200);
     });
 });
 
-Given(/^they have a collection "myCollection"$/, { timeout: TIMEOUT }, function step() {
+Given(/^they have a collection "TestCollection"$/, { timeout: TIMEOUT }, function step() {
     return createCollection
-        .call(this, { name: 'myCollection' })
+        .call(this, { name: 'TestCollection' })
         .then(response => {
             Assert.strictEqual(response.statusCode, 201);
 
-            this.firstCollectionId = response.body.id;
+            this.collectionId = response.body.id;
         })
         .catch(err => {
+            // Collection already exists
             Assert.strictEqual(err.statusCode, 409);
 
             const [, str] = err.message.split(': ');
 
-            [this.firstCollectionId] = str.match(ID);
+            [this.collectionId] = str.match(ID);
         });
 });
 
-Given(/^they have a collection "anotherCollection"$/, { timeout: TIMEOUT }, function step() {
+Given(/^they have a collection "AnotherTestCollection"$/, { timeout: TIMEOUT }, function step() {
     return createCollection
-        .call(this, { name: 'anotherCollection' })
+        .call(this, { name: 'AnotherTestCollection' })
         .then(response => {
             Assert.strictEqual(response.statusCode, 201);
 
-            this.secondCollectionId = response.body.id;
+            this.anotherCollectionId = response.body.id;
         })
         .catch(err => {
             Assert.strictEqual(err.statusCode, 409);
 
             const [, str] = err.message.split(': ');
 
-            [this.secondCollectionId] = str.match(ID);
+            [this.anotherCollectionId] = str.match(ID);
         });
 });
 
@@ -226,15 +238,32 @@ Then(/^they can see those collections and the default collection$/, function ste
     const normalCollectionNames = this.collections.filter(c => c.type === 'normal').map(c => c.name);
     const defaultCollection = this.collections.filter(c => c.type === 'default');
 
-    Assert.strictEqual(normalCollectionNames.length, 2);
     Assert.strictEqual(defaultCollection.length, 1);
-    Assert.ok(normalCollectionNames.includes('myCollection'));
-    Assert.ok(normalCollectionNames.includes('anotherCollection'));
+    Assert.ok(normalCollectionNames.includes('TestCollection'));
+    Assert.ok(normalCollectionNames.includes('AnotherTestCollection'));
+});
+
+Given(/^they have a collection "DeleteTestCollection"$/, { timeout: TIMEOUT }, function step() {
+    return createCollection
+        .call(this, { name: 'DeleteTestCollection' })
+        .then(response => {
+            Assert.strictEqual(response.statusCode, 201);
+
+            this.collectionId = response.body.id;
+        })
+        .catch(err => {
+            // Collection already exists
+            Assert.strictEqual(err.statusCode, 409);
+
+            const [, str] = err.message.split(': ');
+
+            [this.collectionId] = str.match(ID);
+        });
 });
 
 When(/^they delete that collection$/, { timeout: TIMEOUT }, function step() {
     return request({
-        url: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        url: `${this.instance}/${this.namespace}/collections/${this.collectionId}`,
         method: 'DELETE',
         context: {
             token: this.jwt
@@ -246,7 +275,7 @@ When(/^they delete that collection$/, { timeout: TIMEOUT }, function step() {
 
 Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step() {
     return request({
-        url: `${this.instance}/${this.namespace}/collections/${this.firstCollectionId}`,
+        url: `${this.instance}/${this.namespace}/collections/${this.collectionId}`,
         method: 'GET',
         context: {
             token: this.jwt
@@ -257,8 +286,8 @@ Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step()
     });
 });
 
-When(/^they create another collection with the same name "myCollection"$/, { timeout: TIMEOUT }, function step() {
-    return createCollection.call(this, { name: 'myCollection' }).catch(err => {
+When(/^they create another collection with the same name "TestCollection"$/, { timeout: TIMEOUT }, function step() {
+    return createCollection.call(this, { name: 'TestCollection' }).catch(err => {
         Assert.isOk(err, 'Error should be returned');
         this.lastResponse = err;
     });
@@ -266,15 +295,13 @@ When(/^they create another collection with the same name "myCollection"$/, { tim
 
 Then(/^they receive an error regarding unique collections$/, function step() {
     Assert.strictEqual(this.lastResponse.statusCode, 409);
-    Assert.isTrue(
-        this.lastResponse.message.includes(`Collection already exists with the ID: ${this.firstCollectionId}`)
-    );
+    Assert.isTrue(this.lastResponse.message.includes(`Collection already exists with the ID: ${this.collectionId}`));
 });
 
 After('@collections', function hook() {
     // Delete the collections created in the functional tests if they exist
     return Promise.all([
-        deleteCollection.call(this, this.firstCollectionId),
-        deleteCollection.call(this, this.secondCollectionId)
+        deleteCollection.call(this, this.collectionId),
+        deleteCollection.call(this, this.anotherCollectionId)
     ]);
 });

--- a/features/step_definitions/collection.js
+++ b/features/step_definitions/collection.js
@@ -282,7 +282,7 @@ Then(/^that collection no longer exists$/, { timeout: TIMEOUT }, function step()
         }
     }).catch(err => {
         Assert.strictEqual(err.statusCode, 404);
-        this.firstCollectionId = null;
+        this.collectionId = null;
     });
 });
 

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -346,19 +346,9 @@ Then(
         timeout: TIMEOUT
     },
     function step() {
-        const desiredStatus = ['ABORTED', 'SUCCESS', 'FAILURE'];
-
-        return sdapi
-            .waitForBuildStatus({
-                buildId: this.previousBuildId,
-                instance: this.instance,
-                desiredStatus,
-                jwt: this.jwt
-            })
-            .then(buildData => {
-                // TODO: save the status so the next step can verify the github status
-                Assert.oneOf(buildData.status, desiredStatus);
-            });
+        return this.waitForBuild(this.previousBuildId).then(resp => {
+            Assert.oneOf(resp.body.status, ['ABORTED', 'SUCCESS', 'FAILURE']);
+        });
     }
 );
 

--- a/features/step_definitions/sd-cmd.js
+++ b/features/step_definitions/sd-cmd.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Assert = require('chai').assert;
-const { Before, Given, When, Then } = require('@cucumber/cucumber');
+const { Before, Given, When, Then, After } = require('@cucumber/cucumber');
 const request = require('screwdriver-request');
 
 const TIMEOUT = 240 * 1000;
@@ -422,5 +422,14 @@ Then(
             Assert.equal(response.statusCode, 200);
             Assert.equal(response.body[0].trusted, trust === 'trusted');
         });
+    }
+);
+
+After(
+    {
+        tags: '@sd-cmd'
+    },
+    function hook() {
+        return this.stopBuild(this.buildId).catch(() => {});
     }
 );

--- a/features/step_definitions/sd-setup-scm.js
+++ b/features/step_definitions/sd-setup-scm.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Assert = require('chai').assert;
-const { Before, Given, When } = require('@cucumber/cucumber');
+const { Before, Given, When, After } = require('@cucumber/cucumber');
 const github = require('../support/github');
 
 const TIMEOUT = 240 * 1000;
@@ -110,5 +110,14 @@ When(
             .catch(() => {
                 Assert.fail('Failed to create the Pull Request.');
             });
+    }
+);
+
+After(
+    {
+        tags: '@sd-setup-scm'
+    },
+    function hook() {
+        return this.stopBuild(this.buildId).catch(() => {});
     }
 );

--- a/features/step_definitions/templates.js
+++ b/features/step_definitions/templates.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('mz/fs');
 const Assert = require('chai').assert;
 const request = require('screwdriver-request');
-const { Before, Given, Then, When } = require('@cucumber/cucumber');
+const { Before, Given, Then, When, After } = require('@cucumber/cucumber');
 
 const TIMEOUT = 240 * 1000;
 
@@ -410,5 +410,14 @@ Then(
                 Assert.include(result.command, expectedStep.command);
             });
         });
+    }
+);
+
+After(
+    {
+        tags: '@templates'
+    },
+    function hook() {
+        return this.stopBuild(this.buildId).catch(() => {});
     }
 );

--- a/features/step_definitions/user-teardown-step.js
+++ b/features/step_definitions/user-teardown-step.js
@@ -23,8 +23,7 @@ Given(
         return this.ensurePipelineExists({
             repoName: this.repoName,
             branch: this.branchName,
-            table,
-            shouldNotDeletePipeline: true
+            table
         });
     }
 );

--- a/features/step_definitions/workflow.js
+++ b/features/step_definitions/workflow.js
@@ -341,11 +341,14 @@ Then(
                 const joinJob = this.jobs.find(j => j.name === joinJobName);
                 const joinBuild = this.builds.find(b => b.jobId === joinJob.id);
 
+                // parentBuildId is array or integer
+                const parentBuildId = [joinBuild.parentBuildId].flat();
+
                 [parentJobName1, parentJobName2].forEach(jobName => {
                     const parentJob = this.jobs.find(j => j.name === jobName);
                     const parentBuild = this.builds.find(b => b.jobId === parentJob.id);
 
-                    Assert.oneOf(parentBuild.id, joinBuild.parentBuildId);
+                    Assert.oneOf(parentBuild.id, parentBuildId);
                 });
             });
     }
@@ -503,7 +506,12 @@ After(
     },
     function hook() {
         if (this.pipelineId) {
-            return this.deletePipeline(this.pipelineId);
+            return this.deletePipeline(this.pipelineId).catch(err => {
+                // Pipeline already deleted
+                if (err.statusCode !== 404) {
+                    throw err;
+                }
+            });
         }
 
         return false;

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -255,38 +255,6 @@ function searchForBuilds(config) {
 }
 
 /**
- * Waits for a specific build to reach a desired status. If a build is found to not be
- * in the desired state, it waits an arbitrarily short amount of time before querying
- * the build status again.
- *
- * @method waitForBuildStatus
- * @param  {Object}  config               Configuration object
- * @param  {String}  config.instance      Screwdriver instance to test against
- * @param  {String}  config.buildId       Build ID to find the build in
- * @param  {Array}   config.desiredStatus Array of status strings. The status of the build to wait for
- * @return {Object}                       Build data
- */
-function waitForBuildStatus(config) {
-    const { buildId, desiredStatus, instance } = config;
-
-    return request({
-        method: 'GET',
-        url: `${instance}/v4/builds/${buildId}`,
-        context: {
-            token: config.jwt
-        }
-    }).then(response => {
-        const buildData = response.body;
-
-        if (desiredStatus.includes(buildData.status)) {
-            return buildData;
-        }
-
-        return promiseToWait(WAIT_TIME).then(() => waitForBuildStatus(config));
-    });
-}
-
-/**
  * Waits for a specific stageBuild to reach a desired status. If a stageBuild is found to not be
  * in the desired state, it waits an arbitrarily short amount of time before querying
  * the stageBuild status again.
@@ -437,7 +405,6 @@ module.exports = {
     findEventBuilds,
     searchForBuild,
     searchForBuilds,
-    waitForBuildStatus,
     waitForStageBuildStatus,
     promiseToWait
 };

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -251,7 +251,7 @@ function CustomWorld({ attach, parameters }) {
     };
     this.stopBuild = async buildId => {
         const response = await request({
-            url: `${this.instance}/${this.namespace}/builds/${buildID}`,
+            url: `${this.instance}/${this.namespace}/builds/${buildId}`,
             method: 'GET',
             retry: {
                 statusCodes: [200],

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -7,20 +7,7 @@ const { setWorldConstructor } = require('@cucumber/cucumber');
 const request = require('screwdriver-request');
 const { ID } = require('./constants');
 
-/**
- * Retry until the build has finished
- * @method buildRetryStrategy
- * @param  {Object}     response
- * @param  {Function}   retryWithMergedOptions
- * @return {Object}     Build response
- */
-function buildRetryStrategy(response) {
-    if (response.body.status === 'QUEUED' || response.body.status === 'RUNNING') {
-        throw new Error('Retry limit reached');
-    }
-
-    return response;
-}
+const RETRY_COUNT_LIMIT = 30;
 
 /**
  * Promise to wait a certain number of seconds
@@ -234,8 +221,36 @@ function CustomWorld({ attach, parameters }) {
             method: 'GET',
             url: `${this.instance}/${this.namespace}/auth/token?api_token=${apiToken}`
         });
-    this.waitForBuild = buildID =>
-        request({
+    this.waitForBuild = async buildId => {
+        let lastStatus = '';
+
+        for (let i = 0; i < RETRY_COUNT_LIMIT; i += 1) {
+            await promiseToWait(i + 10);
+
+            const response = await request({
+                url: `${this.instance}/${this.namespace}/builds/${buildId}`,
+                method: 'GET',
+                retry: {
+                    statusCodes: [200],
+                    limit: 30,
+                    calculateDelay: ({ computedValue }) => (computedValue ? 15000 : 0)
+                },
+                context: {
+                    token: this.jwt
+                }
+            });
+
+            lastStatus = response.body.status;
+
+            if (!['CREATED', 'BLOCKED', 'QUEUED', 'RUNNING'].includes(lastStatus)) {
+                return response;
+            }
+        }
+
+        throw new Error(`Expect the build "${buildId}" to be complete. Actual "${lastStatus}".`);
+    };
+    this.stopBuild = async buildId => {
+        const response = await request({
             url: `${this.instance}/${this.namespace}/builds/${buildID}`,
             method: 'GET',
             retry: {
@@ -243,13 +258,31 @@ function CustomWorld({ attach, parameters }) {
                 limit: 25,
                 calculateDelay: ({ computedValue }) => (computedValue ? 15000 : 0)
             },
-            hooks: {
-                afterResponse: [buildRetryStrategy]
-            },
             context: {
                 token: this.jwt
             }
         });
+
+        if (!['CREATED', 'BLOCKED', 'QUEUED', 'RUNNING'].includes(response.body.status)) {
+            return response;
+        }
+
+        return request({
+            url: `${this.instance}/${this.namespace}/builds/${buildId}`,
+            method: 'PUT',
+            retry: {
+                statusCodes: [200],
+                limit: 30,
+                calculateDelay: ({ computedValue }) => (computedValue ? 15000 : 0)
+            },
+            context: {
+                token: this.jwt
+            },
+            json: {
+                status: 'ABORTED'
+            }
+        });
+    };
     this.loginWithToken = apiToken =>
         request({
             url: `${this.instance}/${this.namespace}/auth/logout`,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The functional tests may fail if the workload is high and processing is slow or if it is run continuously.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Prevent functional tests fail for the above reasons.
- Rename the collections for each scenario, as adding to the pipeline the same collection at the same time may cause one or the other to fail to be added.
- Ensures that the build executed at the end of the scenario is stopped.
  - If a build is still running when a timeout or other failure occurs, it will fail if functional tests are restarted immediately.
- Replace waitForBuildStatus with waitForBuilds
  - waitForBuildStatus waits forever until the desired status is reached, so if the status transitions before waitForBuildStatus is executed, the loop continues.
  - Fixed waitForBuild to wait for build completion by assuming CREATED and BLOCKED are also running.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
