### PR TITLE
fix(2981): remote join wait on downsream jobs during restart

### DIFF
--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -2,7 +2,7 @@
 
 const logger = require('screwdriver-logger');
 const { JoinBase } = require('./joinBase');
-const { getParallelBuilds, getBuildsForGroupEvent, mergeParentBuilds, subsequentJobFilter } = require('./helpers');
+const { getParallelBuilds, getBuildsForGroupEvent, mergeParentBuilds } = require('./helpers');
 
 /**
  * @typedef {import('screwdriver-models').EventFactory} EventFactory

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -2,7 +2,7 @@
 
 const logger = require('screwdriver-logger');
 const { JoinBase } = require('./joinBase');
-const { getParallelBuilds, getBuildsForGroupEvent, mergeParentBuilds } = require('./helpers');
+const { getParallelBuilds, getBuildsForGroupEvent, mergeParentBuilds, subsequentJobFilter } = require('./helpers');
 
 /**
  * @typedef {import('screwdriver-models').EventFactory} EventFactory
@@ -87,7 +87,15 @@ class AndTrigger extends JoinBase {
             nextBuild = relatedBuilds.find(b => b.jobId === nextJobId && b.eventId > this.currentEvent.id);
         }
 
-        const newParentBuilds = mergeParentBuilds(parentBuilds, relatedBuilds, this.currentEvent);
+        const ignoreJobs = subsequentJobFilter(this.currentEvent.workflowGraph, this.currentEvent.startFrom);
+
+        const newParentBuilds = mergeParentBuilds(
+            parentBuilds,
+            relatedBuilds,
+            this.currentEvent,
+            undefined,
+            ignoreJobs
+        );
         let nextEvent = this.currentEvent;
 
         if (nextBuild) {

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -86,16 +86,7 @@ class AndTrigger extends JoinBase {
             // If the build to join is in the child event, its event id is greater than current event.
             nextBuild = relatedBuilds.find(b => b.jobId === nextJobId && b.eventId > this.currentEvent.id);
         }
-
-        const ignoreJobs = subsequentJobFilter(this.currentEvent.workflowGraph, this.currentEvent.startFrom);
-
-        const newParentBuilds = mergeParentBuilds(
-            parentBuilds,
-            relatedBuilds,
-            this.currentEvent,
-            undefined,
-            ignoreJobs
-        );
+        const newParentBuilds = mergeParentBuilds(parentBuilds, relatedBuilds, this.currentEvent, undefined);
         let nextEvent = this.currentEvent;
 
         if (nextBuild) {

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -1049,12 +1049,8 @@ function subsequentJobFilter(workflowGraph, startNode) {
         return [];
     }
 
-    let start = startNode;
-
     // startNode can be a PR job in PR events, so trim PR prefix from node name
-    if (startNode.match(/^PR-[0-9]+:/)) {
-        start = startNode.split(':')[1];
-    }
+    const start = trimJobName(startNode);
 
     const visiting = [start];
 
@@ -1062,7 +1058,7 @@ function subsequentJobFilter(workflowGraph, startNode) {
 
     if (edges.length) {
         while (visiting.length) {
-            const cur = visiting.shift();
+            const cur = visiting.pop();
 
             edges.forEach(e => {
                 if (e.src === cur && !visited.has(e.dest)) {

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -689,7 +689,7 @@ async function getParallelBuilds({ eventFactory, parentEventId, pipelineId }) {
  *     },
  * }
  */
-function mergeParentBuilds(parentBuilds, relatedBuilds, currentEvent, nextEvent, ignoreJobs) {
+function mergeParentBuilds(parentBuilds, relatedBuilds, currentEvent, nextEvent, ignoreJobs = []) {
     const newParentBuilds = {};
 
     Object.entries(parentBuilds).forEach(([pipelineId, { jobs, eventId }]) => {

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -673,8 +673,9 @@ async function getParallelBuilds({ eventFactory, parentEventId, pipelineId }) {
  * @param {ParentBuilds} parentBuilds parent builds
  * @param {Build[]} relatedBuilds Related builds which is used to fill parentBuilds data
  * @param {Event} currentEvent Current event
- * @param {Event} nextEvent Next triggered event (Remote trigger or Same pipeline event triggered as external) * @returns {ParentBuilds} Merged parent builds { "${pipelineId}": { jobs: { "${jobName}": ${buildId} }, eventId: 123 }  }
+ * @param {Event} nextEvent Next triggered event (Remote trigger or Same pipeline event triggered as external)
  * @param {string[]} ignoreJobs Names of job that may be run on current event
+ * @returns {ParentBuilds} Merged parent builds { "${pipelineId}": { jobs: { "${jobName}": ${buildId} }, eventId: 123 }  }
  *
  * @example
  * >>> mergeParentBuilds(...)

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -673,8 +673,8 @@ async function getParallelBuilds({ eventFactory, parentEventId, pipelineId }) {
  * @param {ParentBuilds} parentBuilds parent builds
  * @param {Build[]} relatedBuilds Related builds which is used to fill parentBuilds data
  * @param {Event} currentEvent Current event
- * @param {string[]} ignoreJobs Names of job that may be run on current event
  * @param {Event} nextEvent Next triggered event (Remote trigger or Same pipeline event triggered as external) * @returns {ParentBuilds} Merged parent builds { "${pipelineId}": { jobs: { "${jobName}": ${buildId} }, eventId: 123 }  }
+ * @param {string[]} ignoreJobs Names of job that may be run on current event
  *
  * @example
  * >>> mergeParentBuilds(...)

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -676,12 +676,8 @@ async function getParallelBuilds({ eventFactory, parentEventId, pipelineId }) {
  * @param   {String}  [startNode]            Starting/trigger node
  * @returns {Array<String>}                   subsequent job names
  */
-function subsequentJobFilter(workflowGraph, startNode) {
+function getSubsequentJobs(workflowGraph, startNode) {
     const { nodes, edges } = workflowGraph;
-
-    if (!nodes.length) {
-        return [];
-    }
 
     // startNode can be a PR job in PR events, so trim PR prefix from node name
     if (!startNode || !nodes.length) {
@@ -753,8 +749,8 @@ function mergeParentBuilds(parentBuilds, relatedBuilds, currentEvent, nextEvent)
 
     const ignoreJobs =
         nextEvent && currentEvent.startFrom.startsWith('~')
-            ? subsequentJobFilter(nextEvent.workflowGraph, nextEvent.startFrom)
-            : subsequentJobFilter(currentEvent.workflowGraph, currentEvent.startFrom);
+            ? getSubsequentJobs(nextEvent.workflowGraph, nextEvent.startFrom)
+            : getSubsequentJobs(currentEvent.workflowGraph, currentEvent.startFrom);
 
     Object.entries(parentBuilds).forEach(([pipelineId, { jobs, eventId }]) => {
         const newBuilds = {

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -693,10 +693,10 @@ function subsequentJobFilter(workflowGraph, startNode) {
     // In rare cases, WorkflowGraph and startNode may have different start tildes
 
     if (!(start in nodeToEdgeDestsMap)) {
-        if (startNode.startsWith('~')) {
-            start = startNode.slice(1);
+        if (start.startsWith('~')) {
+            start = start.slice(1);
         } else {
-            start = `~${startNode}`;
+            start = `~${start}`;
         }
     }
 
@@ -752,7 +752,7 @@ function mergeParentBuilds(parentBuilds, relatedBuilds, currentEvent, nextEvent)
     const newParentBuilds = {};
 
     const ignoreJobs =
-        nextEvent !== undefined && currentEvent.startFrom.startsWith('~')
+        nextEvent && currentEvent.startFrom.startsWith('~')
             ? subsequentJobFilter(nextEvent.workflowGraph, nextEvent.startFrom)
             : subsequentJobFilter(currentEvent.workflowGraph, currentEvent.startFrom);
 

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -1056,14 +1056,18 @@ function subsequentJobFilter(workflowGraph, startNode) {
 
     const visited = new Set(visiting);
 
+    const nodeToEdgeDestsMap = Object.fromEntries(nodes.map(node => [node.name, []]));
+
+    edges.forEach(edge => nodeToEdgeDestsMap[edge.src].push(edge.dest));
     if (edges.length) {
         while (visiting.length) {
-            const cur = visiting.pop();
+            const currentNode = visiting.pop();
+            const dests = nodeToEdgeDestsMap[currentNode];
 
-            edges.forEach(e => {
-                if (e.src === cur && !visited.has(e.dest)) {
-                    visiting.push(e.dest);
-                    visited.add(e.dest);
+            dests.forEach(dest => {
+                if (!visited.has(dest)) {
+                    visiting.push(dest);
+                    visited.add(dest);
                 }
             });
         }

--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { mergeParentBuilds, getParentBuildIds, subsequentJobFilter } = require('./helpers');
+const { mergeParentBuilds, getParentBuildIds } = require('./helpers');
 const { JoinBase } = require('./joinBase');
 
 /**

--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -45,15 +45,7 @@ class RemoteJoin extends JoinBase {
         // When restart case, should we create a new build ?
         const nextBuild = groupEventBuilds.find(b => b.jobId === nextJobId && b.eventId === externalEvent.id);
 
-        const ignoreJobs = subsequentJobFilter(this.currentEvent.workflowGraph, this.currentEvent.startFrom);
-
-        const newParentBuilds = mergeParentBuilds(
-            parentBuilds,
-            groupEventBuilds,
-            this.currentEvent,
-            externalEvent,
-            ignoreJobs
-        );
+        const newParentBuilds = mergeParentBuilds(parentBuilds, groupEventBuilds, this.currentEvent, externalEvent);
 
         const parentBuildId = getParentBuildIds({
             currentBuildId: this.currentBuild.id,

--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { mergeParentBuilds, getParentBuildIds } = require('./helpers');
+const { mergeParentBuilds, getParentBuildIds, subsequentJobFilter } = require('./helpers');
 const { JoinBase } = require('./joinBase');
 
 /**
@@ -45,7 +45,15 @@ class RemoteJoin extends JoinBase {
         // When restart case, should we create a new build ?
         const nextBuild = groupEventBuilds.find(b => b.jobId === nextJobId && b.eventId === externalEvent.id);
 
-        const newParentBuilds = mergeParentBuilds(parentBuilds, groupEventBuilds, this.currentEvent, externalEvent);
+        const ignoreJobs = subsequentJobFilter(this.currentEvent.workflowGraph, this.currentEvent.startFrom);
+
+        const newParentBuilds = mergeParentBuilds(
+            parentBuilds,
+            groupEventBuilds,
+            this.currentEvent,
+            externalEvent,
+            ignoreJobs
+        );
 
         const parentBuildId = getParentBuildIds({
             currentBuildId: this.currentBuild.id,

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -455,7 +455,8 @@ describe('build plugin test', () => {
                 pr: {},
                 getBuilds: sinon.stub(),
                 update: sinon.stub(),
-                toJson: sinon.stub().returns({ id: 123 })
+                toJson: sinon.stub().returns({ id: 123 }),
+                startFrom: '~commit'
             };
             eventFactoryMock.get.resolves(eventMock);
             eventMock.update.resolves(eventMock);

--- a/test/plugins/data/trigger/a_sd@2:a_sd@3:a-upstream.yaml
+++ b/test/plugins/data/trigger/a_sd@2:a_sd@3:a-upstream.yaml
@@ -1,0 +1,12 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  hub:
+    requires: [ ~commit, ~pr ]
+  a:
+    requires: [ ~hub ]
+  target:
+    requires: [ a, sd@2:a, sd@3:a ]

--- a/test/plugins/data/trigger/b_sd@2:a_sd@3:a-upstream.yaml
+++ b/test/plugins/data/trigger/b_sd@2:a_sd@3:a-upstream.yaml
@@ -1,0 +1,14 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  hub:
+    requires: [ ~commit, ~pr ]
+  a:
+    requires: [ ~hub ]
+  b:
+    requires: [ ~a ]
+  target:
+    requires: [ b, sd@2:a, sd@3:a ]

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -724,15 +724,22 @@ describe('mergeParentBuilds function', () => {
             id: 2,
             pipelineId: 2,
             workflowGraph: {
-                nodes: [{ name: 'jobA', id: 10 }]
-            }
+                nodes: [{ name: '~commit' }, { name: 'jobA', id: 10 }],
+                edges: [
+                    { src: '~commit', dest: 'jobA' },
+                    { src: 'jobA', dest: 'sd@1:jobC' }
+                ]
+            },
+            startFrom: '~commit'
         };
         const nextEvent = {
             id: 3,
             pipelineId: 1,
             workflowGraph: {
-                nodes: [{ name: 'sd@1:jobC', id: 21 }]
-            }
+                nodes: [{ name: 'sd@1:jobC', id: 21 }],
+                edges: [{ src: 'sd@2:jobA', dest: 'sd@1:jobC' }]
+            },
+            startFrom: '~sd@2:jobA'
         };
 
         const result = mergeParentBuilds(parentBuilds, relatedBuilds, currentEvent, nextEvent);

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -2100,6 +2100,122 @@ describe('trigger tests', () => {
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
     });
 
+    xit('[ sd@2:a, sd@3:a ] is triggered when restarts upstream and wait for downstream restart builds', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('a_sd@2:a_sd@3:a-upstream.yaml');
+        const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+        const downstreamPipeline2 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        // run all builds
+        await upstreamEvent.run();
+
+        const downstreamEvent1 = downstreamPipeline1.getLatestEvent();
+        const downstreamEvent2 = downstreamPipeline2.getLatestEvent();
+
+        await downstreamEvent1.getBuildOf('a').complete('SUCCESS');
+        await downstreamEvent2.getBuildOf('a').complete('SUCCESS');
+        await upstreamEvent.getBuildOf('target').complete('SUCCESS');
+
+        const upstreamRestartEvent = await upstreamEvent.restartFrom('a');
+
+        assert.isNull(upstreamRestartEvent.getBuildOf('target'));
+
+        await upstreamRestartEvent.getBuildOf('a').complete('SUCCESS');
+
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'CREATED');
+
+        const downstreamRestartEvent1 = downstreamPipeline1.getLatestEvent();
+        const downstreamRestartEvent2 = downstreamPipeline2.getLatestEvent();
+
+        await downstreamRestartEvent1.getBuildOf('a').complete('SUCCESS');
+        await downstreamRestartEvent2.getBuildOf('a').complete('SUCCESS');
+
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
+    });
+
+    it('[ a, sd@2:a, sd@3:a ] is triggered when restarts a and wait for downstream restart builds', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('a_sd@2:a_sd@3:a-upstream.yaml');
+        const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+        const downstreamPipeline2 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        // run all builds
+        await upstreamEvent.run();
+
+        const downstreamEvent1 = downstreamPipeline1.getLatestEvent();
+        const downstreamEvent2 = downstreamPipeline2.getLatestEvent();
+
+        await downstreamEvent1.getBuildOf('a').complete('SUCCESS');
+        await downstreamEvent2.getBuildOf('a').complete('SUCCESS');
+        await upstreamEvent.getBuildOf('target').complete('SUCCESS');
+
+        const upstreamRestartEvent = await upstreamEvent.restartFrom('a');
+
+        assert.isNull(upstreamRestartEvent.getBuildOf('target'));
+
+        await upstreamRestartEvent.getBuildOf('a').complete('SUCCESS');
+
+        const downstreamRestartEvent1 = downstreamPipeline1.getLatestEvent();
+        const downstreamRestartEvent2 = downstreamPipeline2.getLatestEvent();
+
+        await downstreamRestartEvent1.getBuildOf('a').complete('SUCCESS');
+        await downstreamRestartEvent2.getBuildOf('a').complete('SUCCESS');
+
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
+    });
+
+    it('[ b, sd@2:a, sd@3:a ] is triggered when restarts a and wait for downstream restart builds', async () => {
+        const upstreamPipeline = await pipelineFactoryMock.createFromFile('b_sd@2:a_sd@3:a-upstream.yaml');
+        const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+        const downstreamPipeline2 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+
+        const upstreamEvent = await eventFactoryMock.create({
+            pipelineId: upstreamPipeline.id,
+            startFrom: 'hub'
+        });
+
+        // run all builds
+        await upstreamEvent.run();
+
+        const downstreamEvent1 = downstreamPipeline1.getLatestEvent();
+        const downstreamEvent2 = downstreamPipeline2.getLatestEvent();
+
+        await downstreamEvent1.getBuildOf('a').complete('SUCCESS');
+        await downstreamEvent2.getBuildOf('a').complete('SUCCESS');
+        await upstreamEvent.getBuildOf('target').complete('SUCCESS');
+
+        const upstreamRestartEvent = await upstreamEvent.restartFrom('hub');
+
+        await upstreamRestartEvent.getBuildOf('hub').complete('SUCCESS');
+
+        assert.isNull(upstreamRestartEvent.getBuildOf('target'));
+
+        await upstreamRestartEvent.getBuildOf('a').complete('SUCCESS');
+
+        const downstreamRestartEvent1 = downstreamPipeline1.getLatestEvent();
+        const downstreamRestartEvent2 = downstreamPipeline2.getLatestEvent();
+
+        await upstreamRestartEvent.getBuildOf('b').complete('SUCCESS');
+        await downstreamRestartEvent1.getBuildOf('a').complete('SUCCESS');
+        await downstreamRestartEvent2.getBuildOf('a').complete('SUCCESS');
+
+        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+
+        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
+    });
+
     it('[ ~sd@2:a, sd@2:b, sd@2:c ] is triggered when sd@2:a succeeds', async () => {
         const upstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:b_sd@2:c-upstream.yaml');
         const downstreamPipeline = await pipelineFactoryMock.createFromFile('~sd@2:a_sd@2:b_sd@2:c-downstream.yaml');
@@ -2743,6 +2859,26 @@ describe('trigger tests', () => {
         assert.equal(firstPipeline.getBuildsOf('target').length, 1);
     });
 
+    it('[ a, c ] is triggered when restart a b and only a was completed', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a_c.yaml');
+
+        const event = await eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        // run all builds
+        await buildFactoryMock.run();
+
+        const restartEvent = await event.restartFrom('hub');
+
+        await restartEvent.getBuildOf('hub').complete('SUCCESS');
+        await restartEvent.getBuildOf('a').complete('SUCCESS');
+
+        assert.isNull(restartEvent.getBuildOf('c')); // restart build b is not triggered yet
+        assert.equal(restartEvent.getBuildOf('target').status, 'CREATED');
+    });
+
     it('[ ~pr ] is triggered', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('~pr.yaml');
 
@@ -3119,24 +3255,52 @@ describe('trigger tests', () => {
     });
 
     describe('Tests for behavior not ideal', () => {
-        it('[ a, c ] is triggered when restart a b and only a was completed', async () => {
-            const pipeline = await pipelineFactoryMock.createFromFile('a_c.yaml');
+        it('[ sd@2:a, sd@3:a ] is triggered when restarts a and wait for downstream restart builds', async () => {
+            const upstreamPipeline = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-upstream.yaml');
+            const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
+            const downstreamPipeline2 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
 
-            const event = await eventFactoryMock.create({
-                pipelineId: pipeline.id,
+            const upstreamEvent = await eventFactoryMock.create({
+                pipelineId: upstreamPipeline.id,
                 startFrom: 'hub'
             });
 
             // run all builds
-            await buildFactoryMock.run();
+            await upstreamEvent.run();
 
-            const restartEvent = await event.restartFrom('hub');
+            const downstreamEvent1 = downstreamPipeline1.getLatestEvent();
+            const downstreamEvent2 = downstreamPipeline2.getLatestEvent();
 
-            await restartEvent.getBuildOf('hub').complete('SUCCESS');
-            await restartEvent.getBuildOf('a').complete('SUCCESS');
+            await downstreamEvent1.getBuildOf('a').complete('SUCCESS');
+            await downstreamEvent2.getBuildOf('a').complete('SUCCESS');
+            await upstreamEvent.getBuildOf('target').complete('SUCCESS');
 
-            assert.isNull(restartEvent.getBuildOf('c')); // restart build b is not triggered yet
-            assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+            const upstreamRestartEvent = await upstreamEvent.restartFrom('hub');
+
+            await upstreamRestartEvent.getBuildOf('hub').complete('SUCCESS');
+
+            assert.isNull(upstreamRestartEvent.getBuildOf('target'));
+
+            await upstreamRestartEvent.getBuildOf('a').complete('SUCCESS');
+
+            const downstreamRestartEvent1 = downstreamPipeline1.getLatestEvent();
+            const downstreamRestartEvent2 = downstreamPipeline2.getLatestEvent();
+
+            await downstreamRestartEvent1.getBuildOf('a').complete('SUCCESS');
+            await downstreamRestartEvent2.getBuildOf('a').complete('SUCCESS');
+
+            // expected target job triggerd in restart event and number of target builds are 2 (start and restart).
+            // https://github.com/screwdriver-cd/screwdriver/issues/3177
+            // expected
+            // assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
+            // assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
+
+            // actual
+            const upstreamRemoteTriggerEvent = upstreamPipeline.getLatestEvent();
+
+            assert.isNull(upstreamRestartEvent.getBuildOf('target'));
+            assert.equal(upstreamRemoteTriggerEvent.getBuildOf('target').status, 'RUNNING');
+            assert.equal(upstreamPipeline.getBuildsOf('target').length, 3);
         });
     });
 });

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -983,7 +983,7 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target').status, 'RUNNING');
     });
 
-    xit('[ a, c ] is not triggered when restart a b and only a was completed', async () => {
+    it.only('[ a, c ] is not triggered when restart a b and only a was completed', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('a_c.yaml');
 
         const event = await eventFactoryMock.create({
@@ -2818,26 +2818,6 @@ describe('trigger tests', () => {
         assert.equal(firstEvent.id, firstPipeline.getLatestEvent().id);
         assert.equal(firstEvent.getBuildOf('target').status, 'RUNNING');
         assert.equal(firstPipeline.getBuildsOf('target').length, 1);
-    });
-
-    it('[ a, c ] is triggered when restart a b and only a was completed', async () => {
-        const pipeline = await pipelineFactoryMock.createFromFile('a_c.yaml');
-
-        const event = await eventFactoryMock.create({
-            pipelineId: pipeline.id,
-            startFrom: 'hub'
-        });
-
-        // run all builds
-        await buildFactoryMock.run();
-
-        const restartEvent = await event.restartFrom('hub');
-
-        await restartEvent.getBuildOf('hub').complete('SUCCESS');
-        await restartEvent.getBuildOf('a').complete('SUCCESS');
-
-        assert.isNull(restartEvent.getBuildOf('c')); // restart build b is not triggered yet
-        assert.equal(restartEvent.getBuildOf('target').status, 'CREATED');
     });
 
     it('[ ~pr ] is triggered', async () => {

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -983,7 +983,7 @@ describe('trigger tests', () => {
         assert.equal(event.getBuildOf('target').status, 'RUNNING');
     });
 
-    it.only('[ a, c ] is not triggered when restart a b and only a was completed', async () => {
+    it('[ a, c ] is not triggered when restart a b and only a was completed', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('a_c.yaml');
 
         const event = await eventFactoryMock.create({

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -2100,45 +2100,6 @@ describe('trigger tests', () => {
         assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
     });
 
-    xit('[ sd@2:a, sd@3:a ] is triggered when restarts upstream and wait for downstream restart builds', async () => {
-        const upstreamPipeline = await pipelineFactoryMock.createFromFile('a_sd@2:a_sd@3:a-upstream.yaml');
-        const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
-        const downstreamPipeline2 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');
-
-        const upstreamEvent = await eventFactoryMock.create({
-            pipelineId: upstreamPipeline.id,
-            startFrom: 'hub'
-        });
-
-        // run all builds
-        await upstreamEvent.run();
-
-        const downstreamEvent1 = downstreamPipeline1.getLatestEvent();
-        const downstreamEvent2 = downstreamPipeline2.getLatestEvent();
-
-        await downstreamEvent1.getBuildOf('a').complete('SUCCESS');
-        await downstreamEvent2.getBuildOf('a').complete('SUCCESS');
-        await upstreamEvent.getBuildOf('target').complete('SUCCESS');
-
-        const upstreamRestartEvent = await upstreamEvent.restartFrom('a');
-
-        assert.isNull(upstreamRestartEvent.getBuildOf('target'));
-
-        await upstreamRestartEvent.getBuildOf('a').complete('SUCCESS');
-
-        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'CREATED');
-
-        const downstreamRestartEvent1 = downstreamPipeline1.getLatestEvent();
-        const downstreamRestartEvent2 = downstreamPipeline2.getLatestEvent();
-
-        await downstreamRestartEvent1.getBuildOf('a').complete('SUCCESS');
-        await downstreamRestartEvent2.getBuildOf('a').complete('SUCCESS');
-
-        assert.equal(upstreamRestartEvent.getBuildOf('target').status, 'RUNNING');
-
-        assert.equal(upstreamPipeline.getBuildsOf('target').length, 2);
-    });
-
     it('[ a, sd@2:a, sd@3:a ] is triggered when restarts a and wait for downstream restart builds', async () => {
         const upstreamPipeline = await pipelineFactoryMock.createFromFile('a_sd@2:a_sd@3:a-upstream.yaml');
         const downstreamPipeline1 = await pipelineFactoryMock.createFromFile('sd@2:a_sd@3:a-downstream.yaml');


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix #2981
When an upstream job of the remote-join job is restarted, remote-join job immediately runs reusing build status from previous event.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
When a remote join job's upstream jobs are restarted, the remote join job will use the post-restart build status as the trigger for jobs that may run from the restart job.

Enumerate jobs started after the restart job, referring to [the subgraph filter in the UI](https://github.com/screwdriver-cd/ui/blob/8a764ea1a6db38e29e85588a8cc7fcc56d770869/app/utils/graph-tools.js#L454), and do not use the recent build status of the group event.

- About the test
We found another bug related to remote join while working on this. (#3177)
Therefore, a test has been added to the “Tests for behavior not ideal” section
Also, with this fix, the test that was originally in “Tests for behavior not ideal” works as expected so that it will be removed and the test that was xit will be executed.

## References
#2981
#3177

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
