### PR TITLE
feat: run prod job after all beta done

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -101,7 +101,7 @@ jobs:
     # Deploy to our prod environment and run tests
     prod:
         image: node:18
-        requires: [beta]
+        requires: [beta-additional-tests]
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh


### PR DESCRIPTION
## Context

`beta-additional-tests` and `prod` jobs run in parallel. 

## Objective

fix `prod` to run `beta-additional-tests` job completed. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3182

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
