### PR TITLE
fix: set the correct secrets and disable pipeline-template

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",
     "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
-    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and (not @x1)' --retry 2 --fail-fast --exit",
+    "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and (not @x1) and (not @pipelinetemplate)' --retry 2 --fail-fast --exit",
     "functional-beta-x1": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and @x1' --retry 2 --fail-fast --exit",
     "functional-dev": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",
     "create-test-user": "node -e 'require(\"./features/scripts/create-test-user.js\")()'",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -88,7 +88,7 @@ jobs:
             - change-user: export TEST_USERNAME=sd-buildbot-functional-beta-X1
             - test: |
                 npm install
-                GIT_TOKEN=${GIT_TOKEN_BETA} SD_API_TOKEN=${SD_API_TOKEN_BETA} npm run functional-beta-x1
+                GIT_TOKEN=${GIT_TOKEN_BETA_X1} SD_API_TOKEN=${SD_API_TOKEN_BETA_X1} npm run functional-beta-x1
         <<: *beta_config
         secrets:
             # Access key for functional tests


### PR DESCRIPTION
## Context

- Pipeline template functional tests have been failing consistently
- The new headless Github user needs the correct API and Github token 

## Objective
- Correct the API and Github token for `sd-buildbot-functional-beta-X1`
- Disable pipeline template functional tests to ensure that the new user is working as intended

## References
https://github.com/screwdriver-cd/screwdriver/issues/3182

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
