### PR TITLE
fix: run tests into different steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "./bin/server",
     "debug": "node --nolazy ./bin/server",
     "profile": "node --prof ./bin/server",
-    "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta)' --retry 2 --fail-fast --exit",
+    "functional": "cucumber-js --format=progress --tags '(not @ignore) and (not @beta) and (not @pipelinetemplate)' --retry 2 --fail-fast --exit",
     "functional-beta": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and (not @x1) and (not @pipelinetemplate)' --retry 2 --fail-fast --exit",
     "functional-beta-x1": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod) and @x1' --retry 2 --fail-fast --exit",
     "functional-dev": "cucumber-js --format=progress --tags '(not @ignore) and (not @prod)' --retry 2 --fail-fast --exit",

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,19 +5,6 @@ shared:
     environment:
         DOCKER_REPO: screwdrivercd/screwdriver
         DOCKER_MULTI_PLATFORM_BUILDS_ENABLED: 1
-    annotations:
-        beta_config: &beta_config
-            image: node:18
-            environment:
-                K8S_CONTAINER: screwdriver-api
-                K8S_IMAGE: screwdrivercd/screwdriver
-                K8S_HOST: kubernetes.default.svc
-                K8S_DEPLOYMENT: sdapi-beta
-                SD_API_HOST: beta.api.screwdriver.cd
-                K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
-                K8S_ENV_VALUE: beta_rc2_
-                TEST_USERNAME: sd-buildbot-functional
-                TEST_ORG: screwdriver-cd-test
 
 jobs:
     main:
@@ -67,41 +54,41 @@ jobs:
     # Deploy to our beta environment and run tests
     beta:
         requires: [docker-publish]
-        <<: *beta_config
+        image: node:18
+        environment:
+            K8S_CONTAINER: screwdriver-api
+            K8S_IMAGE: screwdrivercd/screwdriver
+            K8S_HOST: kubernetes.default.svc
+            K8S_DEPLOYMENT: sdapi-beta
+            SD_API_HOST: beta.api.screwdriver.cd
+            K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
+            K8S_ENV_VALUE: beta_rc2_
+            TEST_USERNAME: sd-buildbot-functional
+            TEST_USERNAME_X1: sd-buildbot-functional-X1
+            TEST_ORG: screwdriver-cd-test
         secrets:
             # Access key for functional tests
             - SD_API_TOKEN_BETA
             # Git access token
             - GIT_TOKEN_BETA
-            # Talking to Kubernetes
-            - K8S_TOKEN        
-        steps:
-            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
-            - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
-            - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
-            - test: |
-                npm install
-                GIT_TOKEN=${GIT_TOKEN_BETA} SD_API_TOKEN=${SD_API_TOKEN_BETA} npm run functional-beta
-    beta-additional-tests:
-        requires: [beta]
-        steps:
-            - change-user: export TEST_USERNAME=sd-buildbot-functional-beta-X1
-            - test: |
-                npm install
-                GIT_TOKEN=${GIT_TOKEN_BETA_X1} SD_API_TOKEN=${SD_API_TOKEN_BETA_X1} npm run functional-beta-x1
-        <<: *beta_config
-        secrets:
             # Access key for functional tests
             - SD_API_TOKEN_BETA_X1
             # Git access token
             - GIT_TOKEN_BETA_X1
             # Talking to Kubernetes
-            - K8S_TOKEN 
+            - K8S_TOKEN
+        steps:
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
+            - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh
+            - deploy-k8s: K8S_TAG=`meta get docker_tag` ./ci/k8s-deploy.sh
+            - npm-install: npm install
+            - test: GIT_TOKEN=${GIT_TOKEN_BETA} SD_API_TOKEN=${SD_API_TOKEN_BETA} npm run functional-beta
+            - test-x1: TEST_USERNAME=${TEST_USERNAME_X1} GIT_TOKEN=${GIT_TOKEN_BETA_X1} SD_API_TOKEN=${SD_API_TOKEN_BETA_X1} npm run functional-beta-x1
 
     # Deploy to our prod environment and run tests
     prod:
         image: node:18
-        requires: [beta-additional-tests]
+        requires: [beta]
         steps:
             - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
             - wait-docker: DOCKER_TAG=`meta get docker_tag` ./ci/docker-wait.sh


### PR DESCRIPTION
## Context

As of now, the beta additional tests are run in different job and the pipeline template functional tests failing on the prod instance. 

## Objective

- run beta tests in different steps instead of different jobs
- turned off pipeline template functional tests in the meantime

## References

https://github.com/screwdriver-cd/screwdriver/issues/3182

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
