### PR TITLE
fix: change the name of the sd functional x1

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -64,7 +64,7 @@ jobs:
             K8S_ENV_KEY: DATASTORE_DYNAMODB_PREFIX
             K8S_ENV_VALUE: beta_rc2_
             TEST_USERNAME: sd-buildbot-functional
-            TEST_USERNAME_X1: sd-buildbot-functional-X1
+            TEST_USERNAME_X1: sd-buildbot-functional-beta-X1
             TEST_ORG: screwdriver-cd-test
         secrets:
             # Access key for functional tests


### PR DESCRIPTION
## Context

Wrong test username 

## Objective

Fix with the right github username 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3182

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
