### PR TITLE
fix(3171): upgrade to latest command validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "screwdriver-artifact-bookend": "^2.0.0",
     "screwdriver-build-bookend": "^4.0.0",
     "screwdriver-cache-bookend": "^3.0.0",
-    "screwdriver-command-validator": "^3.0.0",
+    "screwdriver-command-validator": "^4.0.0",
     "screwdriver-config-parser": "^11.0.0",
     "screwdriver-coverage-bookend": "^2.0.0",
     "screwdriver-coverage-sonar": "^4.1.1",


### PR DESCRIPTION
## Context

Move pipeline template workflowGraph out of config into a new field

## Objective

Upgrade to latest command validator

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
