### PR TITLE
feat: add stage join trigger case and stabilize stages test [2]

### DIFF
--- a/features/stages.feature
+++ b/features/stages.feature
@@ -129,6 +129,7 @@ Feature: Stage
         Given an existing pipeline on branch "twoStageSuccess" with the workflow jobs:
             | job       | requires      |
             | target    | stage@simple_success2:teardown  |
+            | join-target    | stage@simple_success1:teardown, stage@simple_success2:teardown  |
             | stage@simple_success2:setup | stage@simple_success1:teardown  |
             | stage@simple_success1:setup | ~hub |
         And the pipeline has the following stages:
@@ -152,3 +153,5 @@ Feature: Stage
         And the "stage@simple_success2" stageBuild status is "SUCCESS"
         And the "target" job is triggered
         And the "target" build succeeded
+        And the "join-target" job is triggered
+        And the "join-target" build succeeded

--- a/features/stages.feature
+++ b/features/stages.feature
@@ -144,6 +144,7 @@ Feature: Stage
         And the "b" build succeeded
         And the "stage@simple_success1:teardown" job is triggered
         Then the "stage@simple_success1" stageBuild status is "SUCCESS"
+        And the "join-target" job is not triggered
         And the "c" job is triggered
         And the "c" build succeeded
         And the "d" job is triggered

--- a/features/step_definitions/stage.js
+++ b/features/step_definitions/stage.js
@@ -2,7 +2,6 @@
 
 const Assert = require('chai').assert;
 const { Before, Given, Then } = require('@cucumber/cucumber');
-const sdapi = require('../support/sdapi');
 
 const TIMEOUT = 240 * 1000;
 
@@ -38,16 +37,13 @@ Given(
 Then(
     /^the "(?:stage@([\w-]+))" stageBuild status is "(SUCCESS|FAILURE)"$/,
     { timeout: TIMEOUT },
-    async function step(stage, stageBuildStatus) {
+    async function step(_, stageBuildStatus) {
         const config = {
             eventId: this.eventId,
-            jwt: this.jwt,
-            stageId: this.stageId,
-            instance: this.instance,
-            desiredStatus: stageBuildStatus
+            stageId: this.stageId
         };
 
-        return sdapi.waitForStageBuildStatus(config).then(stageBuild => {
+        return this.waitForStageBuild(config).then(stageBuild => {
             Assert.equal(stageBuild.status, stageBuildStatus);
 
             this.stageBuildId = stageBuild.id;

--- a/features/support/sdapi.js
+++ b/features/support/sdapi.js
@@ -255,43 +255,6 @@ function searchForBuilds(config) {
 }
 
 /**
- * Waits for a specific stageBuild to reach a desired status. If a stageBuild is found to not be
- * in the desired state, it waits an arbitrarily short amount of time before querying
- * the stageBuild status again.
- *
- * @method waitForStageBuildStatus
- * @param  {Object}  config               Configuration object
- * @param  {Number}  config.eventId       Event ID
- * @param  {String}  config.instance      Screwdriver instance to test against
- * @param  {Number}  config.stageId       Stage ID
- * @param  {String}  config.jwt           JWT
- * @param  {String}  config.desiredStatus Desired status
- * @return {Object}                       StageBuild data
- */
-function waitForStageBuildStatus(config) {
-    const { eventId, desiredStatus, instance, jwt, stageId } = config;
-
-    return request({
-        method: 'GET',
-        url: `${instance}/v4/events/${eventId}/stageBuilds`,
-        context: {
-            token: jwt
-        }
-    }).then(response => {
-        const stageBuildData = response.body;
-
-        // Find stageBuild for stage
-        const stageBuild = stageBuildData.find(sb => sb.stageId === stageId);
-
-        if (stageBuild && stageBuild.status === desiredStatus) {
-            return stageBuild;
-        }
-
-        return promiseToWait(WAIT_TIME).then(() => waitForStageBuildStatus(config));
-    });
-}
-
-/**
  * Remove the test token
  * @method cleanupToken
  * @param  {Object}  config
@@ -405,6 +368,5 @@ module.exports = {
     findEventBuilds,
     searchForBuild,
     searchForBuilds,
-    waitForStageBuildStatus,
     promiseToWait
 };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Stage trigger has supported join case. https://github.com/screwdriver-cd/screwdriver/issues/3066
But this tests are not implemented in stages functest.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Add `requires: [ stage@foo, stage@bar ]` test case in the stages functest.
- Replace `waitForStageBuildStatus` as https://github.com/screwdriver-cd/screwdriver/pull/3172
  - `waitForStageBuildStatus` waits forever until the desired status is reached

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

The test repository will be fixed by https://github.com/screwdriver-cd-test/functional-stage/pull/1 .

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
