### PR TITLE
fix: need to init a value when key does not exist in an object

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -289,7 +289,7 @@ webhooks:
   maxBytes: 1048576 # 1MB
 
 coverage:
-  # default: true
+  default: true
   # plugin: sonar
   # sonar:
   #   sdApiUrl: https://api.screwdriver.cd

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -289,15 +289,15 @@ webhooks:
   maxBytes: 1048576 # 1MB
 
 coverage:
-  default: "false"
-  plugin: sonar
-  sonar:
-    sdApiUrl: https://api.screwdriver.cd
-    sonarHost: https://sonar.screwdriver.cd
-    adminToken: your-sonar-admin-token
-    sdUiUrl: https://cd.screwdriver.cd
-    sonarEnterprise: false
-    sonarGitAppName: "Screwdriver Sonar PR Checks"
+  # default: true
+  # plugin: sonar
+  # sonar:
+  #   sdApiUrl: https://api.screwdriver.cd
+  #   sonarHost: https://sonar.screwdriver.cd
+  #   adminToken: your-sonar-admin-token
+  #   sdUiUrl: https://cd.screwdriver.cd
+  #   sonarEnterprise: false
+  #   sonarGitAppName: "Screwdriver Sonar PR Checks"
 
 multiBuildCluster:
   # Enabled multi build cluster feature or not

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -289,15 +289,15 @@ webhooks:
   maxBytes: 1048576 # 1MB
 
 coverage:
-  default: true
-  # plugin: sonar
-  # sonar:
-  #   sdApiUrl: https://api.screwdriver.cd
-  #   sonarHost: https://sonar.screwdriver.cd
-  #   adminToken: your-sonar-admin-token
-  #   sdUiUrl: https://cd.screwdriver.cd
-  #   sonarEnterprise: false
-  #   sonarGitAppName: "Screwdriver Sonar PR Checks"
+  default: "false"
+  plugin: sonar
+  sonar:
+    sdApiUrl: https://api.screwdriver.cd
+    sonarHost: https://sonar.screwdriver.cd
+    adminToken: your-sonar-admin-token
+    sdUiUrl: https://cd.screwdriver.cd
+    sonarEnterprise: false
+    sonarGitAppName: "Screwdriver Sonar PR Checks"
 
 multiBuildCluster:
   # Enabled multi build cluster feature or not

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -686,8 +686,8 @@ function getSubsequentJobs(workflowGraph, startNode) {
     const nodeToEdgeDestsMap = Object.fromEntries(nodes.map(node => [node.name, []]));
 
     let start = trimJobName(startNode);
-    // In rare cases, WorkflowGraph and startNode may have different start tildes
 
+    // In rare cases, WorkflowGraph and startNode may have different start tildes
     if (!(start in nodeToEdgeDestsMap)) {
         if (start.startsWith('~')) {
             start = start.slice(1);
@@ -700,11 +700,18 @@ function getSubsequentJobs(workflowGraph, startNode) {
         return [];
     }
 
+    console.log('edges: ', edges);
+
     const visiting = [start];
 
     const visited = new Set(visiting);
 
-    edges.forEach(edge => nodeToEdgeDestsMap[edge.src].push(edge.dest));
+    edges.forEach(edge => {
+        if (!nodeToEdgeDestsMap[edge.src]) {
+            nodeToEdgeDestsMap[edge.src] = [];
+        }
+        nodeToEdgeDestsMap[edge.src].push(edge.dest);
+    });
     if (edges.length) {
         while (visiting.length) {
             const currentNode = visiting.pop();

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -700,8 +700,6 @@ function getSubsequentJobs(workflowGraph, startNode) {
         return [];
     }
 
-    console.log('edges: ', edges);
-
     const visiting = [start];
 
     const visited = new Set(visiting);

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -705,6 +705,8 @@ function getSubsequentJobs(workflowGraph, startNode) {
     const visited = new Set(visiting);
 
     edges.forEach(edge => {
+        // this is a temporary fix for the issue where the edge.src is not in the nodes array
+        // TODO: https://github.com/screwdriver-cd/screwdriver/issues/3206
         if (!nodeToEdgeDestsMap[edge.src]) {
             nodeToEdgeDestsMap[edge.src] = [];
         }


### PR DESCRIPTION
## Context

Observed this scenario of workflowgraph
```
const workflowGraph = {
    nodes: [
        {
            name: '~pr'
        },
        {
            name: '~commit'
        },
        {
            name: '~sd@123:deploy-db',
            id: 573500
        },
        {
            name: 'sd@123:deploy-api',
            id: 573501
        }
    ],
    edges: [
        {
            src: '~pr',
            dest: 'pr'
        },
        {
            src: '~commit',
            dest: 'component'
        },
        {
            src: '~sd@123:deploy-db',
            dest: 'certify-db'
        },
        {
            src: 'certify-db',
            dest: 'sd@123:deploy-api'
        },
        ### entry below comes from two remote pipelines
        ### is this possible?
        {
            src: '~sd@123:deploy-api',
            dest: 'sd@456:mysql'
        }
    ]
};
```

## Objective

When edges have src entry that slightly differ from the nodes entry, in this case with `~` then the key won't be found in the object causing to be undefined and hence resulting in error. 

## References

https://github.com/screwdriver-cd/screwdriver/pull/3178

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
