### PR TITLE
fix(3203): Deep merge build meta into event meta

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -5,6 +5,7 @@ const hoek = require('@hapi/hoek');
 const schema = require('screwdriver-data-schema');
 const joi = require('joi');
 const idSchema = schema.models.build.base.extract('id');
+const merge = require('lodash.mergewith');
 const { getScmUri, getUserPermissions, getFullStageJobName } = require('../helper');
 const STAGE_TEARDOWN_PATTERN = /^stage@([\w-]+)(?::teardown)$/;
 const TERMINAL_STATUSES = ['FAILURE', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
@@ -247,7 +248,7 @@ module.exports = () => ({
                 build.statusMessage = statusMessage || build.statusMessage;
             } else if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(desiredStatus)) {
                 build.meta = request.payload.meta || {};
-                event.meta = { ...event.meta, ...build.meta };
+                merge(event.meta, build.meta);
                 build.endTime = new Date().toISOString();
             } else if (desiredStatus === 'RUNNING') {
                 build.startTime = new Date().toISOString();

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1078,10 +1078,6 @@ describe('build plugin test', () => {
             });
 
             it('saves status, statusMessage, meta updates, and merge event meta', () => {
-                const meta = {
-                    foo: 'bar',
-                    hello: 'bye'
-                };
                 const status = 'SUCCESS';
                 const statusMessage = 'Oh the build passed';
                 const options = {
@@ -1095,7 +1091,14 @@ describe('build plugin test', () => {
                         strategy: ['token']
                     },
                     payload: {
-                        meta,
+                        meta: {
+                            foo: 'bar',
+                            hello: 'bye',
+                            deployedAppVersion: {
+                                ui: '2.4.67',
+                                api: '6.9.5'
+                            }
+                        },
                         status,
                         statusMessage,
                         stats: {
@@ -1106,7 +1109,11 @@ describe('build plugin test', () => {
 
                 eventMock.meta = {
                     foo: 'oldfoo',
-                    oldmeta: 'oldmetastuff'
+                    oldmeta: 'oldmetastuff',
+                    deployedAppVersion: {
+                        ui: '2.4.67',
+                        store: '4.0.1'
+                    }
                 };
 
                 return server.inject(options).then(reply => {
@@ -1114,14 +1121,19 @@ describe('build plugin test', () => {
                     assert.calledWith(buildFactoryMock.get, id);
                     assert.calledOnce(buildMock.update);
                     assert.strictEqual(buildMock.status, status);
-                    assert.deepEqual(buildMock.meta, meta);
+                    assert.deepEqual(buildMock.meta, options.payload.meta);
                     assert.deepEqual(buildMock.statusMessage, statusMessage);
                     assert.isDefined(buildMock.endTime);
                     assert.calledOnce(eventMock.update);
                     assert.deepEqual(eventMock.meta, {
                         foo: 'bar',
                         hello: 'bye',
-                        oldmeta: 'oldmetastuff'
+                        oldmeta: 'oldmetastuff',
+                        deployedAppVersion: {
+                            ui: '2.4.67',
+                            store: '4.0.1',
+                            api: '6.9.5'
+                        }
                     });
                     assert.deepEqual(buildMock.stats, {
                         hostname: 'node123.mycluster.com'


### PR DESCRIPTION
## Context

Whenever a `build` is updated, its `meta` is merged with `event` `meta`. But, this merge is shallow (one level). Due to this nested `meta` set by previous builds of this `event` could be lost when the latest `build` `meta` is merged. This is more common when the builds are triggered and executed in parallel.

## Objective

`build` `meta` should be deep merged (recursively) into `event` `meta`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3203

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
