### PR TITLE
fix(3203): Create new event meta when deep merging build meta into event meta

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -248,7 +248,7 @@ module.exports = () => ({
                 build.statusMessage = statusMessage || build.statusMessage;
             } else if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(desiredStatus)) {
                 build.meta = request.payload.meta || {};
-                merge(event.meta, build.meta);
+                event.meta = merge({}, event.meta, build.meta);
                 build.endTime = new Date().toISOString();
             } else if (desiredStatus === 'RUNNING') {
                 build.startTime = new Date().toISOString();


### PR DESCRIPTION
## Context

Need some minor adjustment to the changes made in https://github.com/screwdriver-cd/screwdriver/pull/3204

## Objective

Create a new event meta object when deep merging build meta into event meta

## References

https://github.com/screwdriver-cd/screwdriver/issues/3203

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
