### PR TITLE
fix(3209): Honor freeze windows for virtual jobs

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -243,7 +243,7 @@ async function triggerNextJobs(config, app) {
         // Skip trigger process if createExternalEvent fails
         if (externalEvent) {
             for (const [nextJobName, nextJobInfo] of Object.entries(joinedPipeline.jobs)) {
-                const nextJob = await getJob(nextJobName, currentPipeline.id, jobFactory);
+                const nextJob = await getJob(nextJobName, joinedPipelineId, jobFactory);
                 const { isVirtual: isNextJobVirtual, stageName: nextJobStageName } = nextJobInfo;
 
                 const { parentBuilds } = parseJobInfo({

--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -52,21 +52,20 @@ class AndTrigger extends JoinBase {
 
     /**
      * Trigger the next jobs of the current job
-     * @param {String} nextJobName
-     * @param {String} nextJobId
+     * @param {Job} nextJob
      * @param {Record<String, Object>} parentBuilds
      * @param {String[]} joinListNames
      * @param {Boolean} isNextJobVirtual
      * @param {String} nextJobStageName
      * @returns {Promise<Build>}
      */
-    async execute(nextJobName, nextJobId, parentBuilds, joinListNames, isNextJobVirtual, nextJobStageName) {
+    async execute(nextJob, parentBuilds, joinListNames, isNextJobVirtual, nextJobStageName) {
         logger.info(`Fetching finished builds for event ${this.currentEvent.id}`);
 
         const relatedBuilds = await this.fetchRelatedBuilds();
 
         // Find the next build from the related builds for this event
-        let nextBuild = relatedBuilds.find(b => b.jobId === nextJobId && b.eventId === this.currentEvent.id);
+        let nextBuild = relatedBuilds.find(b => b.jobId === nextJob.id && b.eventId === this.currentEvent.id);
 
         if (!nextBuild) {
             // If the build to join fails and it succeeds on restart, depending on the timing, the latest build will be that of a child event.
@@ -74,7 +73,7 @@ class AndTrigger extends JoinBase {
             // Now we need to check for the existence of a build that should be triggered in its own event.
             nextBuild = await this.buildFactory.get({
                 eventId: this.currentEvent.id,
-                jobId: nextJobId
+                jobId: nextJob.id
             });
 
             if (nextBuild) {
@@ -84,7 +83,7 @@ class AndTrigger extends JoinBase {
 
         if (!nextBuild) {
             // If the build to join is in the child event, its event id is greater than current event.
-            nextBuild = relatedBuilds.find(b => b.jobId === nextJobId && b.eventId > this.currentEvent.id);
+            nextBuild = relatedBuilds.find(b => b.jobId === nextJob.id && b.eventId > this.currentEvent.id);
         }
         const newParentBuilds = mergeParentBuilds(parentBuilds, relatedBuilds, this.currentEvent, undefined);
         let nextEvent = this.currentEvent;
@@ -97,8 +96,7 @@ class AndTrigger extends JoinBase {
             pipelineId: this.pipelineId,
             event: nextEvent,
             nextBuild,
-            nextJobName,
-            nextJobId,
+            nextJob,
             parentBuilds: newParentBuilds,
             parentBuildId: this.currentBuild.id,
             joinListNames,

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -599,13 +599,13 @@ async function getParentBuildStatus({ newBuild, joinListNames, pipelineId, build
  * @param {Boolean} arg.done If the build is done or not
  * @param {Boolean} arg.hasFailure If the build has a failure or not
  * @param {Build} arg.newBuild Next build
- * @param {String|undefined} arg.jobName Job name
+ * @param {Job} arg.job Next job
  * @param {String|undefined} arg.pipelineId Pipeline ID
  * @param {String|undefined} arg.stageName Stage name
  * @param {Boolean} arg.isVirtualJob If the job is virtual or not
  * @returns {Promise<Build|null>} The newly updated/created build
  */
-async function handleNewBuild({ done, hasFailure, newBuild, jobName, pipelineId, stageName, isVirtualJob }) {
+async function handleNewBuild({ done, hasFailure, newBuild, job, pipelineId, stageName, isVirtualJob }) {
     if (!done || Status.isStarted(newBuild.status)) {
         return null;
     }
@@ -615,9 +615,9 @@ async function handleNewBuild({ done, hasFailure, newBuild, jobName, pipelineId,
         const stageTeardownName = stageName ? getFullStageJobName({ stageName, jobName: 'teardown' }) : '';
 
         // New build is not stage teardown job
-        if (jobName !== stageTeardownName) {
+        if (job.name !== stageTeardownName) {
             logger.info(
-                `Failure occurred in upstream job, removing new build - build:${newBuild.id} pipeline:${pipelineId}-${jobName} event:${newBuild.eventId} `
+                `Failure occurred in upstream job, removing new build - build:${newBuild.id} pipeline:${pipelineId}-${job.name} event:${newBuild.eventId} `
             );
             await newBuild.remove();
         }
@@ -626,7 +626,9 @@ async function handleNewBuild({ done, hasFailure, newBuild, jobName, pipelineId,
     }
 
     // Bypass execution of the build if the job is virtual
-    if (isVirtualJob) {
+    const hasFreezeWindows = job.permutations[0].freezeWindows && job.permutations[0].freezeWindows.length > 0;
+
+    if (isVirtualJob && !hasFreezeWindows) {
         newBuild.status = Status.SUCCESS;
 
         return newBuild.update();
@@ -1035,19 +1037,17 @@ function extractExternalJoinData(joinedPipelines, currentPipelineId) {
 }
 
 /**
- * Get job id from job name
+ * Get job from job name
  * @param {String} jobName Job name
  * @param {String} pipelineId Pipeline id
  * @param {JobFactory} jobFactory Job factory
- * @returns {Promise<Number>}
+ * @returns {Promise<Job>}
  */
-async function getJobId(jobName, pipelineId, jobFactory) {
-    const job = await jobFactory.get({
+async function getJob(jobName, pipelineId, jobFactory) {
+    return jobFactory.get({
         name: jobName,
         pipelineId
     });
-
-    return job.id;
 }
 
 /**
@@ -1152,7 +1152,7 @@ module.exports = {
     strToInt,
     createEvent,
     deleteBuild,
-    getJobId,
+    getJob,
     isOrTrigger,
     extractCurrentPipelineJoinData,
     extractExternalJoinData,

--- a/plugins/builds/triggers/joinBase.js
+++ b/plugins/builds/triggers/joinBase.js
@@ -39,8 +39,7 @@ class JoinBase {
      * @param {Number} pipelineId
      * @param {Event} event
      * @param {Build} nextBuild
-     * @param {String} nextJobName
-     * @param {String} nextJobId
+     * @param {Job} nextJob
      * @param {import('./helpers').ParentBuilds} parentBuilds
      * @param {String} parentBuildId
      * @param {String[]} joinListNames
@@ -52,8 +51,7 @@ class JoinBase {
         pipelineId,
         event,
         nextBuild,
-        nextJobName,
-        nextJobId,
+        nextJob,
         parentBuilds,
         parentBuildId,
         joinListNames,
@@ -68,8 +66,8 @@ class JoinBase {
                 jobFactory: this.jobFactory,
                 buildFactory: this.buildFactory,
                 pipelineId,
-                jobName: nextJobName,
-                jobId: nextJobId,
+                jobName: nextJob.name,
+                jobId: nextJob.id,
                 username: this.username,
                 scmContext: this.scmContext,
                 event, // this is the parentBuild for the next build
@@ -87,7 +85,7 @@ class JoinBase {
         }
 
         if (!newBuild) {
-            logger.error(`No build found for ${pipelineId}:${nextJobName}`);
+            logger.error(`No build found for ${pipelineId}:${nextJob.name}`);
 
             return null;
         }
@@ -104,7 +102,7 @@ class JoinBase {
             done,
             hasFailure,
             newBuild,
-            jobName: nextJobName,
+            job: nextJob,
             pipelineId,
             isVirtualJob: isNextJobVirtual,
             stageName: nextJobStageName

--- a/plugins/builds/triggers/or.js
+++ b/plugins/builds/triggers/or.js
@@ -12,14 +12,13 @@ class OrTrigger extends OrBase {
      * Trigger the next jobs of the current job
      * @param {Event} event
      * @param {Number} pipelineId
-     * @param {String} nextJobName
-     * @param {Number} nextJobId
+     * @param {Job} nextJob
      * @param {import('./helpers').ParentBuilds} parentBuilds
      * @param {Boolean} isNextJobVirtual
      * @return {Promise<Build|null>}
      */
-    async execute(event, pipelineId, nextJobName, nextJobId, parentBuilds, isNextJobVirtual) {
-        return this.trigger(event, pipelineId, nextJobName, nextJobId, parentBuilds, isNextJobVirtual);
+    async execute(event, pipelineId, nextJob, parentBuilds, isNextJobVirtual) {
+        return this.trigger(event, pipelineId, nextJob, parentBuilds, isNextJobVirtual);
     }
 }
 

--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -23,8 +23,7 @@ class RemoteJoin extends JoinBase {
     /**
      * Trigger the next external jobs of the current job
      * @param {Event} externalEvent Downstream pipeline's event
-     * @param {String} nextJobName
-     * @param {Number} nextJobId
+     * @param {Job} nextJob
      * @param {import('./helpers').ParentBuilds} parentBuilds
      * @param {Build[]} groupEventBuilds Builds of the downstream pipeline, where only the latest ones for each job are included that have the same groupEventId as the externalEvent
      * @param {String[]} joinListNames
@@ -34,8 +33,7 @@ class RemoteJoin extends JoinBase {
      */
     async execute(
         externalEvent,
-        nextJobName,
-        nextJobId,
+        nextJob,
         parentBuilds,
         groupEventBuilds,
         joinListNames,
@@ -43,7 +41,7 @@ class RemoteJoin extends JoinBase {
         nextJobStageName
     ) {
         // When restart case, should we create a new build ?
-        const nextBuild = groupEventBuilds.find(b => b.jobId === nextJobId && b.eventId === externalEvent.id);
+        const nextBuild = groupEventBuilds.find(b => b.jobId === nextJob.id && b.eventId === externalEvent.id);
 
         const newParentBuilds = mergeParentBuilds(parentBuilds, groupEventBuilds, this.currentEvent, externalEvent);
 
@@ -58,8 +56,7 @@ class RemoteJoin extends JoinBase {
             pipelineId: externalEvent.pipelineId,
             event: externalEvent,
             nextBuild,
-            nextJobName,
-            nextJobId,
+            nextJob,
             parentBuilds: newParentBuilds,
             parentBuildId,
             joinListNames,

--- a/plugins/builds/triggers/remoteTrigger.js
+++ b/plugins/builds/triggers/remoteTrigger.js
@@ -12,14 +12,13 @@ class RemoteTrigger extends OrBase {
      * Trigger the next jobs of the current job
      * @param {Event} event
      * @param {Number} pipelineId
-     * @param {String} nextJobName
-     * @param {String} nextJobId
+     * @param {Job} nextJob
      * @param {import('./helpers').ParentBuilds} parentBuilds
      * @param {Boolean} isNextJobVirtual
      * @returns {Promise<Build|null>}
      */
-    async execute(event, pipelineId, nextJobName, nextJobId, parentBuilds, isNextJobVirtual) {
-        return this.trigger(event, pipelineId, nextJobName, nextJobId, parentBuilds, isNextJobVirtual);
+    async execute(event, pipelineId, nextJob, parentBuilds, isNextJobVirtual) {
+        return this.trigger(event, pipelineId, nextJob, parentBuilds, isNextJobVirtual);
     }
 }
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1512,7 +1512,14 @@ describe('build plugin test', () => {
                     id: publishJobId,
                     pipelineId,
                     state: 'ENABLED',
-                    parsePRJobName: sinon.stub().returns('publish')
+                    parsePRJobName: sinon.stub().returns('publish'),
+                    permutations: [
+                        {
+                            settings: {
+                                email: 'foo@bar.com'
+                            }
+                        }
+                    ]
                 };
 
                 beforeEach(() => {
@@ -2332,12 +2339,26 @@ describe('build plugin test', () => {
                     id: 2,
                     pipelineId,
                     state: 'ENABLED',
-                    parsePRJobName: sinon.stub().returns('b')
+                    parsePRJobName: sinon.stub().returns('b'),
+                    permutations: [
+                        {
+                            settings: {
+                                email: 'foo@bar.com'
+                            }
+                        }
+                    ]
                 };
                 const jobC = {
                     ...jobB,
                     id: 3,
-                    parsePRJobName: sinon.stub().returns('c')
+                    parsePRJobName: sinon.stub().returns('c'),
+                    permutations: [
+                        {
+                            settings: {
+                                email: 'foo@bar.com'
+                            }
+                        }
+                    ]
                 };
                 let buildMocks;
                 let jobBconfig;
@@ -2787,7 +2808,14 @@ describe('build plugin test', () => {
                     id: 2,
                     pipelineId,
                     state: 'ENABLED',
-                    parsePRJobName: sinon.stub().returns('b')
+                    parsePRJobName: sinon.stub().returns('b'),
+                    permutations: [
+                        {
+                            settings: {
+                                email: 'foo@bar.com'
+                            }
+                        }
+                    ]
                 };
                 const jobC = {
                     ...jobB,
@@ -2803,6 +2831,10 @@ describe('build plugin test', () => {
                         })
                     ),
                     parsePRJobName: sinon.stub().returns('c')
+                };
+                const jobD = {
+                    ...jobB,
+                    id: 4
                 };
                 const externalEventBuilds = [
                     {
@@ -2887,10 +2919,12 @@ describe('build plugin test', () => {
                     eventFactoryMock.get.withArgs(8888).resolves(parentEventMock);
                     jobFactoryMock.get.withArgs(jobB.id).resolves(jobB);
                     jobFactoryMock.get.withArgs(jobC.id).resolves(jobC);
+                    jobFactoryMock.get.withArgs(jobD.id).resolves(jobD);
                     jobFactoryMock.get.withArgs(6).resolves(jobC);
                     jobFactoryMock.get.withArgs(3).resolves(jobC);
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'b' }).resolves(jobB);
                     jobFactoryMock.get.withArgs({ pipelineId, name: 'c' }).resolves(jobC);
+                    jobFactoryMock.get.withArgs({ pipelineId, name: 'd' }).resolves(jobD);
                     jobFactoryMock.list.resolves([{ id: 5555 }]);
                     jobMock.name = 'a';
                     buildMock.eventId = '8888';
@@ -2989,6 +3023,24 @@ describe('build plugin test', () => {
                     });
                 });
                 it('triggers next job as external when user used external syntax for same pipeline', () => {
+                    const pipeline2JobB = {
+                        id: 2,
+                        pipelineId: 123,
+                        name: 'b',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('b'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '123', name: 'b' }).resolves(pipeline2JobB);
+                    jobFactoryMock.get.withArgs(pipeline2JobB.id).resolves(pipeline2JobB);
+
                     const expectedEventArgs = {
                         pipelineId: '123',
                         startFrom: '~sd@123:a',
@@ -3038,6 +3090,24 @@ describe('build plugin test', () => {
                 });
 
                 it('triggers next next job when next job is external', () => {
+                    const pipeline2JobA = {
+                        id: 2,
+                        pipelineId: 2,
+                        name: 'a',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('a'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'a' }).resolves(pipeline2JobA);
+                    jobFactoryMock.get.withArgs(pipeline2JobA.id).resolves(pipeline2JobA);
+
                     const expectedEventArgs = {
                         pipelineId: '2',
                         startFrom: '~sd@123:a',
@@ -3536,6 +3606,24 @@ describe('build plugin test', () => {
                 it('triggers if all jobs in external join are done and updates join job', () => {
                     // re-entry case
                     // join-job exist
+                    const pipeline2JobC = {
+                        id: 3,
+                        pipelineId: 2,
+                        name: 'c',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('c'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'c' }).resolves(pipeline2JobC);
+                    jobFactoryMock.get.withArgs(pipeline2JobC.id).resolves(pipeline2JobC);
+
                     eventMock.workflowGraph = {
                         nodes: [
                             { name: '~pr' },
@@ -3669,6 +3757,24 @@ describe('build plugin test', () => {
                     //  ~sd@2:a -> a -> sd@2:c
                     // If user is at `a`, it should trigger `sd@2:c`
                     // No join-job, so create
+                    const pipeline2JobC = {
+                        id: 6,
+                        pipelineId: 2,
+                        name: 'c',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('c'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'c' }).resolves(pipeline2JobC);
+                    jobFactoryMock.get.withArgs(pipeline2JobC.id).resolves(pipeline2JobC);
+
                     eventMock.workflowGraph = {
                         nodes: [
                             { name: '~pr' },
@@ -3705,7 +3811,7 @@ describe('build plugin test', () => {
                         baseBranch: 'master',
                         configPipelineSha: 'abc123',
                         eventId: 8887,
-                        jobId: 3,
+                        jobId: 6,
                         parentBuildId: [12345],
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345 } },
@@ -3787,6 +3893,24 @@ describe('build plugin test', () => {
                     //  ~sd@2:b ------➚
                     // If user is at `a`, it should trigger `sd@2:c`
                     // ~sd@123:a is or trigger, so create
+                    const pipeline2JobC = {
+                        id: 6,
+                        pipelineId: 2,
+                        name: 'c',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('c'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'c' }).resolves(pipeline2JobC);
+                    jobFactoryMock.get.withArgs(pipeline2JobC.id).resolves(pipeline2JobC);
+
                     eventMock.workflowGraph = {
                         nodes: [
                             { name: '~pr' },
@@ -3819,11 +3943,11 @@ describe('build plugin test', () => {
                         parentBuilds,
                         start: sinon.stub().resolves()
                     });
-                    const jobCConfig = {
+                    const pipeline2JobCConfig = {
                         baseBranch: 'master',
                         configPipelineSha: 'abc123',
                         eventId: 8887,
-                        jobId: 3,
+                        jobId: 6,
                         parentBuildId: 12345,
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345 } },
@@ -3844,7 +3968,7 @@ describe('build plugin test', () => {
                         pr: {},
                         id: 8887,
                         configPipelineSha: 'abc123',
-                        pipelineId: 123,
+                        pipelineId: 2,
                         baseBranch: 'master',
                         builds: [
                             {
@@ -3896,11 +4020,45 @@ describe('build plugin test', () => {
                         assert.notCalled(eventFactoryMock.create);
                         assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
-                        assert.calledWith(buildFactoryMock.create, jobCConfig);
+                        assert.calledWith(buildFactoryMock.create, pipeline2JobCConfig);
                     });
                 });
 
                 it('starts multiple builds with the existing downstream event', () => {
+                    const pipeline2JobC = {
+                        id: 6,
+                        pipelineId: 2,
+                        name: 'c',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('c'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+                    const pipeline2JobD = {
+                        id: 7,
+                        pipelineId: 2,
+                        name: 'd',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('d'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'c' }).resolves(pipeline2JobC);
+                    jobFactoryMock.get.withArgs(pipeline2JobC.id).resolves(pipeline2JobC);
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'd' }).resolves(pipeline2JobD);
+                    jobFactoryMock.get.withArgs(pipeline2JobD.id).resolves(pipeline2JobD);
+
                     eventMock.workflowGraph = {
                         nodes: [
                             { name: '~pr' },
@@ -4081,6 +4239,24 @@ describe('build plugin test', () => {
                 });
 
                 it('creates without starting join job in external join when fork not done', () => {
+                    const pipeline2JobC = {
+                        id: 3,
+                        pipelineId: 2,
+                        name: 'c',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('c'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'c' }).resolves(pipeline2JobC);
+                    jobFactoryMock.get.withArgs(pipeline2JobC.id).resolves(pipeline2JobC);
+
                     eventMock.workflowGraph = {
                         nodes: [
                             { name: '~pr' },
@@ -4703,6 +4879,24 @@ describe('build plugin test', () => {
                     //                  d
                     //
                     // If user restarts `123:a`, it should get `2:c`'s parent event status and trigger `c`
+                    const pipeline2JobC = {
+                        id: 3,
+                        pipelineId: 2,
+                        name: 'c',
+                        state: 'ENABLED',
+                        parsePRJobName: sinon.stub().returns('c'),
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
+                    };
+
+                    jobFactoryMock.get.withArgs({ pipelineId: '2', name: 'c' }).resolves(pipeline2JobC);
+                    jobFactoryMock.get.withArgs(pipeline2JobC.id).resolves(pipeline2JobC);
+
                     eventMock.workflowGraph = {
                         nodes: [
                             { name: '~pr' },

--- a/test/plugins/data/trigger/virtual-jobs-with-freeze-windows.yaml
+++ b/test/plugins/data/trigger/virtual-jobs-with-freeze-windows.yaml
@@ -1,0 +1,57 @@
+shared:
+    image: node:20
+    steps:
+        - test: echo 'test'
+
+jobs:
+    hub:
+        requires: [ ~commit, ~pr ]
+    a:
+        requires: [ ~hub ]
+    b:
+        requires: [ ~hub ]
+    c:
+        requires: [ ~hub ]
+    d1:
+        requires: [ ~a ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+    d2:
+        requires: [ ~a, ~b ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+    d3:
+        requires: [ ~a, b ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+    d4:
+        requires: [ a, ~b ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+    d5:
+        requires: [ a, b ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+    d6:
+        requires: [ a, ~b, c ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+    d7:
+        requires: [ a, b, c ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+
+    target1:
+        requires: [ ~d1 ]
+        freezeWindows: ['* 10-21 ? * *']
+        annotations:
+            screwdriver.cd/virtualJob: true
+    target2:
+        requires: [ ~d1 ]

--- a/test/plugins/trigger.test.helper.js
+++ b/test/plugins/trigger.test.helper.js
@@ -187,11 +187,12 @@ class PipelineFactoryMock {
 
         const { jobs, stages, workflowGraph } = pipeline;
 
-        Object.keys(jobs).forEach(name => {
+        Object.entries(jobs).forEach(([name, jobConfigArr]) => {
             jobs[name] = this.server.app.jobFactory.create({
                 name,
                 pipeline,
-                pipelineId: pipeline.id
+                pipelineId: pipeline.id,
+                permutations: jobConfigArr
             });
         });
 
@@ -755,7 +756,6 @@ class JobFactoryMock {
     create(config) {
         const job = {
             ...config,
-            permutations: [{}],
             id: this.records.length,
             toJson: sinon.stub(),
             getLatestBuild: sinon.stub().resolves([]),

--- a/test/plugins/trigger.test.helper.js
+++ b/test/plugins/trigger.test.helper.js
@@ -255,7 +255,14 @@ class PipelineFactoryMock {
                     jobs[prJobName] = this.server.app.jobFactory.create({
                         name: prJobName,
                         pipeline,
-                        pipelineId: pipeline.id
+                        pipelineId: pipeline.id,
+                        permutations: [
+                            {
+                                settings: {
+                                    email: 'foo@bar.com'
+                                }
+                            }
+                        ]
                     });
                 }
             });


### PR DESCRIPTION
## Context

Changes were made in this PR https://github.com/screwdriver-cd/screwdriver/pull/3131 to skip execution of job with the annotation `screwdriver.cd/virtualJob: true`.

But this change did not take freeze windows in to the consideration. Due to this, the virtual jobs are skipped execution and marked as 'SUCCESS' with in the freeze window.

## Objective
Do not skip the execution of virtual jobs with freeze windows. Instead add it to the execution queue.
Let Queue Service skip the execution when the job is picked up from the queue outside the freeze windows.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3209

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
