### PR TITLE
fix: Allow groupEventId filter for list pipeline events

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -111,6 +111,7 @@ Query Params:
 * `type` - *Optional* Get pipeline or pr events (default `pipeline`)
 * `prNum` - *Optional* Return only PR events of specified PR number
 * `sha` - *Optional* Search `sha` and `configPipelineSha` for events
+* `groupEventId` - *Optional* Return only events with a specified groupEventId
 * `id` - *Optional* Fetch specific event ID; alternatively can use greater than(`gt:`) or less than(`lt:`) prefix
 
 `GET /pipelines/{id}/events?page={pageNumber}&count={countNumber}&sort={sort}&type={type}&prNum={prNumber}&sha={sha}`

--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -34,7 +34,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const factory = request.server.app.pipelineFactory;
-            const { page, count, sha, prNum, id, sort, sortBy } = request.query;
+            const { page, count, sha, prNum, id, sort, sortBy, groupEventId } = request.query;
 
             return factory
                 .get(request.params.id)
@@ -71,7 +71,11 @@ module.exports = () => ({
                         };
                     }
 
-                    // Event id filter
+                    if (groupEventId) {
+                        config.params.groupEventId = groupEventId;
+                    }
+
+                    // Event id filter; can use greater than(`gt:`) or less than(`lt:`) prefix
                     if (id) {
                         config.params.id = id;
                     }
@@ -96,6 +100,7 @@ module.exports = () => ({
                     prNum: prNumSchema,
                     sha: shaSchema,
                     id: queryIdSchema,
+                    groupEventId: pipelineIdSchema,
                     search: joi.forbidden(), // we don't support search for Pipeline list events
                     getCount: joi.forbidden() // we don't support getCount for Pipeline list events
                 })

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1568,6 +1568,20 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 for getting events with groupEventId', () => {
+            options.url = `/pipelines/${id}/events?groupEventId=4`;
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.getEvents);
+                assert.calledWith(pipelineMock.getEvents, {
+                    params: { groupEventId: 4, type: 'pipeline' },
+                    sort: 'descending'
+                });
+                assert.deepEqual(reply.result, testEvents);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
         it('returns 200 for getting events with id less than 888', () => {
             options.url = `/pipelines/${id}/events?id=lt:888&count=5&sort=ascending&sortBy=createTime`;
 


### PR DESCRIPTION
## Context

Sometimes we might want to filter by groupEventId for pipeline events.

## Objective

This PR adds a filter to `GET /pipelines/{pipelineId}/events` to return only events with a specified `groupEventId`.

## References
NA

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
