### PR TITLE
fix(3176): Stage teardown should not run when other stage jobs are not finished

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -98,9 +98,7 @@ async function getBuildToUpdate(id, buildFactory) {
 async function validateUserPermission(build, request) {
     const { jobFactory, userFactory, bannerFactory, pipelineFactory } = request.server.app;
     const { username, scmContext, scmUserId } = request.auth.credentials;
-
     const { status: desiredStatus } = request.payload;
-
     const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
     // Check if Screwdriver admin
     const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(username, scmDisplayName, scmUserId);
@@ -117,7 +115,6 @@ async function validateUserPermission(build, request) {
     // Check permission against the pipeline
     // Fetch the job and user models
     const [job, user] = await Promise.all([jobFactory.get(build.jobId), userFactory.get({ username, scmContext })]);
-
     const pipeline = await job.pipeline;
 
     // Use parent's scmUri if pipeline is child pipeline and using read-only SCM
@@ -197,7 +194,8 @@ async function isStageDone({ stage, event }) {
     const stageJobBuilds = await event.getBuilds({ params: { jobId: stageJobIds } });
     let stageIsDone = false;
 
-    if (stageJobBuilds && stageJobBuilds.length !== 0) {
+    // Make sure all builds in stage have run
+    if (stageJobBuilds && stageJobBuilds.length === stageJobIds.length) {
         stageIsDone = !stageJobBuilds.some(b => !FINISHED_STATUSES.includes(b.status));
     }
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -679,6 +679,8 @@ describe('build plugin test', () => {
 
         describe('user token', () => {
             it('returns 200 for updating a build that exists', () => {
+                screwdriverAdminDetailsMock.returns({ isAdmin: false });
+
                 const userMock = {
                     username: id,
                     getPermissions: sinon.stub().resolves({ push: true })
@@ -714,6 +716,7 @@ describe('build plugin test', () => {
             });
 
             it('does not update completed builds', () => {
+                screwdriverAdminDetailsMock.returns({ isAdmin: false });
                 buildMock.status = 'SUCCESS';
                 const options = {
                     method: 'PUT',
@@ -736,6 +739,8 @@ describe('build plugin test', () => {
             });
 
             it('does not allow users other than abort', () => {
+                screwdriverAdminDetailsMock.returns({ isAdmin: false });
+
                 const options = {
                     method: 'PUT',
                     url: `/builds/${id}`,
@@ -744,7 +749,8 @@ describe('build plugin test', () => {
                     },
                     auth: {
                         credentials: {
-                            scope: ['user']
+                            scope: ['user'],
+                            username: 'test-user'
                         },
                         strategy: ['token']
                     }
@@ -2071,13 +2077,25 @@ describe('build plugin test', () => {
                         {
                             id: 1,
                             eventId: '8888',
-                            jobId: 1,
+                            jobId: 11,
                             status: 'FAILURE'
                         },
                         {
                             id: 7777,
                             eventId: '8888',
-                            jobId: 4,
+                            jobId: 44,
+                            status: 'SUCCESS'
+                        },
+                        {
+                            id: 12,
+                            eventId: '8888',
+                            jobId: 22,
+                            status: 'SUCCESS'
+                        },
+                        {
+                            id: 777,
+                            eventId: '8888',
+                            jobId: 33,
                             status: 'SUCCESS'
                         }
                     ]);
@@ -5456,7 +5474,13 @@ describe('build plugin test', () => {
                             eventId: '8888',
                             status: 'SUCCESS'
                         },
-                        buildAlphaTest
+                        buildAlphaTest,
+                        {
+                            jobId: 44,
+                            id: 1003,
+                            eventId: '8888',
+                            status: 'SUCCESS'
+                        }
                     ]);
 
                     return newServer.inject(localOptions).then(() => {
@@ -5609,12 +5633,17 @@ describe('build plugin test', () => {
                             eventId: '8888',
                             status: 'FAILURE'
                         },
-                        buildGammaTestFunctional
+                        buildGammaTestFunctional,
+                        {
+                            jobId: 775,
+                            id: 7004,
+                            eventId: '8888',
+                            status: 'SUCCESS'
+                        }
                     ]);
 
                     return newServer.inject(localOptions).then(() => {
                         assert.notCalled(stageBuildMock.update);
-
                         assert.notCalled(buildFactoryMock.create);
                         assert.calledTwice(buildGammaTeardown.update);
                         assert.deepEqual(buildGammaTeardown.parentBuildId, [12345, 7003]);


### PR DESCRIPTION
## Context

Stage teardown sometimes runs prematurely when a job has completed successfully even if a parallel job has not completed running.
 
## Objective

This PR checks that all builds in the stage are done running before running the stage teardown job.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3176

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
