### PR TITLE
feat(3211): Set build status message while skipping execution of virtual job

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "screwdriver-config-parser": "^11.0.0",
     "screwdriver-coverage-bookend": "^2.0.0",
     "screwdriver-coverage-sonar": "^4.1.1",
-    "screwdriver-data-schema": "^24.0.0",
+    "screwdriver-data-schema": "^24.1.0",
     "screwdriver-datastore-sequelize": "^9.0.0",
     "screwdriver-executor-base": "^10.0.0",
     "screwdriver-executor-docker": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "screwdriver-executor-queue": "^5.0.0",
     "screwdriver-executor-router": "^4.0.0",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-models": "^30.0.0",
+    "screwdriver-models": "^30.2.0",
     "screwdriver-notifications-email": "^4.0.0",
     "screwdriver-notifications-slack": "^6.0.0",
     "screwdriver-request": "^2.0.1",

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -6,6 +6,12 @@ const merge = require('lodash.mergewith');
 const schema = require('screwdriver-data-schema');
 const { EXTERNAL_TRIGGER_ALL, STAGE_SETUP_PATTERN } = schema.config.regex;
 const { getFullStageJobName } = require('../../helper');
+const BUILD_STATUS_MESSAGES = {
+    SKIP_VIRTUAL_JOB: {
+        statusMessage: 'Skipped execution of the virtual job',
+        statusMessageType: 'INFO'
+    }
+};
 
 /**
  * @typedef {import('screwdriver-models').JobFactory} JobFactory
@@ -630,6 +636,8 @@ async function handleNewBuild({ done, hasFailure, newBuild, job, pipelineId, sta
 
     if (isVirtualJob && !hasFreezeWindows) {
         newBuild.status = Status.SUCCESS;
+        newBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
+        newBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
 
         return newBuild.update();
     }
@@ -1158,5 +1166,6 @@ module.exports = {
     extractExternalJoinData,
     buildsToRestartFilter,
     trimJobName,
-    isStartFromMiddleOfCurrentStage
+    isStartFromMiddleOfCurrentStage,
+    BUILD_STATUS_MESSAGES
 };

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { createInternalBuild, Status } = require('./helpers');
+const { createInternalBuild, Status, BUILD_STATUS_MESSAGES } = require('./helpers');
 
 /**
  * @typedef {import('screwdriver-models').BuildFactory} BuildFactory
@@ -58,6 +58,8 @@ class OrBase {
             // Bypass execution of the build if the job is virtual
             if (isNextJobVirtual && !hasFreezeWindows) {
                 nextBuild.status = Status.SUCCESS;
+                nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
+                nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
 
                 return nextBuild.update();
             }
@@ -86,6 +88,8 @@ class OrBase {
         // Bypass execution of the build if the job is virtual
         if (isNextJobVirtual && !hasFreezeWindows) {
             nextBuild.status = Status.SUCCESS;
+            nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
+            nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
 
             nextBuild = nextBuild.update();
         }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -977,6 +977,36 @@ describe('build plugin test', () => {
                 });
             });
 
+            it('allows updating statusMessageType', () => {
+                const statusMessage = 'hello';
+                const statusMessageType = 'INFO';
+                const options = {
+                    method: 'PUT',
+                    url: `/builds/${id}`,
+                    auth: {
+                        credentials: {
+                            username: id,
+                            scope: ['temporal']
+                        },
+                        strategy: ['token']
+                    },
+                    payload: {
+                        statusMessage,
+                        statusMessageType
+                    }
+                };
+
+                return server.inject(options).then(reply => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.calledWith(buildFactoryMock.get, id);
+                    assert.calledOnce(buildMock.update);
+                    assert.strictEqual(buildMock.statusMessage, statusMessage);
+                    assert.strictEqual(buildMock.statusMessageType, statusMessageType);
+                    assert.isUndefined(buildMock.meta);
+                    assert.isUndefined(buildMock.endTime);
+                });
+            });
+
             it('allows to update when statusMessage is undefined', () => {
                 const expected = hoek.applyToDefaults(testBuildWithSteps, { status: 'FAILURE' });
                 const options = {

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -5,7 +5,7 @@ const { assert } = chai;
 const sinon = require('sinon');
 const rewire = require('rewire');
 const logger = require('screwdriver-logger');
-const { Status } = require('../../plugins/builds/triggers/helpers');
+const { Status, BUILD_STATUS_MESSAGES } = require('../../plugins/builds/triggers/helpers');
 
 const RewiredTriggerHelper = rewire('../../plugins/builds/triggers/helpers.js');
 
@@ -1303,6 +1303,8 @@ describe('handleNewBuild function', () => {
         });
 
         assert.strictEqual(newBuildMock.status, Status.SUCCESS);
+        assert.strictEqual(newBuildMock.statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.strictEqual(newBuildMock.statusMessageType, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType);
         sinon.assert.calledOnce(newBuildMock.update);
         sinon.assert.notCalled(newBuildMock.start);
     });

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -14,6 +14,7 @@ const {
     JobFactoryMock,
     LockMock
 } = require('./trigger.test.helper');
+const { BUILD_STATUS_MESSAGES } = require('../../plugins/builds/triggers/helpers');
 
 describe('trigger tests', () => {
     let server = new hapi.Server();
@@ -2981,6 +2982,15 @@ describe('trigger tests', () => {
             await event.getBuildOf('a').complete('SUCCESS');
 
             assert.equal(event.getBuildOf('stage@red:setup').status, 'SUCCESS');
+            assert.equal(
+                event.getBuildOf('stage@red:setup').statusMessage,
+                BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage
+            );
+            assert.equal(
+                event.getBuildOf('stage@red:setup').statusMessageType,
+                BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+            );
+
             assert.equal(event.getBuildOf('target1').status, 'RUNNING');
             assert.equal(event.getBuildOf('target2').status, 'RUNNING');
         });
@@ -3071,6 +3081,15 @@ describe('trigger tests', () => {
             await event.getBuildOf('target3').complete('SUCCESS');
 
             assert.equal(event.getBuildOf('stage@red:teardown').status, 'SUCCESS');
+            assert.equal(
+                event.getBuildOf('stage@red:teardown').statusMessage,
+                BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage
+            );
+            assert.equal(
+                event.getBuildOf('stage@red:teardown').statusMessageType,
+                BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+            );
+
             assert.equal(event.getBuildOf('z').status, 'RUNNING');
         });
 
@@ -3177,22 +3196,62 @@ describe('trigger tests', () => {
 
         await event.getBuildOf('a').complete('SUCCESS');
         assert.equal(event.getBuildOf('d1').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('d1').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('d1').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
         assert.equal(event.getBuildOf('d2').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('d2').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('d2').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
         assert.equal(event.getBuildOf('d3').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('d3').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('d3').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
         assert.equal(event.getBuildOf('d4').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('d4').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('d4').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
         assert.equal(event.getBuildOf('d5').status, 'CREATED');
         assert.equal(event.getBuildOf('d6').status, 'CREATED');
         assert.equal(event.getBuildOf('d7').status, 'CREATED');
         assert.equal(event.getBuildOf('target1').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('target1').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('target1').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
         assert.equal(event.getBuildOf('target2').status, 'RUNNING');
 
         await event.getBuildOf('b').complete('SUCCESS');
         assert.equal(event.getBuildOf('d5').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('d5').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('d5').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
         assert.equal(event.getBuildOf('d6').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('d6').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('d6').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
         assert.equal(event.getBuildOf('d7').status, 'CREATED');
 
         await event.getBuildOf('c').complete('SUCCESS');
         assert.equal(event.getBuildOf('d7').status, 'SUCCESS');
+        assert.equal(event.getBuildOf('d7').statusMessage, BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage);
+        assert.equal(
+            event.getBuildOf('d7').statusMessageType,
+            BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+        );
     });
 
     it('should add virtual jobs to execution queue when they have freeze windows', async () => {


### PR DESCRIPTION
## Context

Execution of virtual jobs are skipped and the build status is being set to "SUCCESS".
In the UI, we need to convey the same in the build details page.

## Objective

Set `statusMessage` and `statusMessageType` on the build when the execution is skipped for the virtual job.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3211

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
