### PR TITLE
fix(1749): Download dir endpoint

### DIFF
--- a/plugins/builds/README.md
+++ b/plugins/builds/README.md
@@ -78,6 +78,10 @@ Arguments:
 
 `GET /builds/{id}/artifacts/{name*}?type=preview`
 
+`GET /builds/{id}/artifacts/this/is/a/directory/path/?type=download`
+
+*Note: To download a directory, there must be a trailing slash (`/`) in the name and `type=download`.*
+
 #### Get build statuses
 `GET /builds/statuses`
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -7314,7 +7314,7 @@ describe('build plugin test', () => {
         });
 
         it('returns 500 for a missing manifest for artifact directory', () => {
-            options.url = `/builds/${id}/artifacts/doesnotexist/?type=preview`;
+            options.url = `/builds/${id}/artifacts/doesnotexist/?type=download`;
 
             nock(logBaseUrl)
                 .defaultReplyHeaders(headersMock)


### PR DESCRIPTION
## Context

Should use `type=download` for directory download.

## Objective

This PR checks for `type` and also saves files in zip relative to current directory.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1749

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
