### PR TITLE
fix(3230): fix assigned remote trigger events

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -255,11 +255,10 @@ async function triggerNextJobs(config, app) {
 
             // Restart case
             if (isRestart) {
-                // 'joinedPipeline.event.id' is restart event. not group event.
+                // 'joinedPipeline.event.id' is restart event, not group event.
                 const groupEvent = await eventFactory.get({ id: joinedPipeline.event.id });
 
                 externalEventConfig.groupEventId = groupEvent.groupEventId;
-                // externalEventConfig.groupEventId = joinedPipeline.event.id;
                 externalEventConfig.parentBuilds = buildsToRestart[0].parentBuilds;
             } else {
                 const sameParentEvents = await getSameParentEvents({

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -679,6 +679,24 @@ async function getParallelBuilds({ eventFactory, parentEventId, pipelineId }) {
 }
 
 /**
+ * Get all events with a given event ID and pipeline ID
+ * @param {Object} arg
+ * @param {EventFactory} eventFactory Event factory
+ * @param {Number} parentEventId Parent event ID
+ * @param {Number} pipelineId Pipeline ID
+ * @returns {Promise<Event[]>} Array of events with same parent event ID and same pipeline ID
+ */
+async function getSameParentEvents({ eventFactory, parentEventId, pipelineId }) {
+    const parallelEvents = await eventFactory.list({
+        params: {
+            parentEventId
+        }
+    });
+
+    return parallelEvents.filter(pe => strToInt(pe.pipelineId) === pipelineId);
+}
+
+/**
  * Get subsequent job names which the root is the start from node
  * @param   {Array}   [workflowGraph]         Array of graph vertices
  * @param   {Array}   [workflowGraph.nodes]   Array of graph vertices
@@ -1148,6 +1166,7 @@ module.exports = {
     parseJobInfo,
     createInternalBuild,
     getParallelBuilds,
+    getSameParentEvents,
     mergeParentBuilds,
     updateParentBuilds,
     getParentBuildStatus,

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -3111,6 +3111,7 @@ describe('build plugin test', () => {
                     const externalEventMock = { ...eventMock };
 
                     eventFactoryMock.create.resolves(externalEventMock);
+                    eventFactoryMock.list.resolves([]);
 
                     return newServer.inject(options).then(() => {
                         assert.calledOnce(buildFactoryMock.create);
@@ -4942,6 +4943,7 @@ describe('build plugin test', () => {
                             { src: '~sd@2:a', dest: 'a' }
                         ]
                     };
+                    eventMock.groupEventId = '8887';
                     eventMock.parentEventId = 8887;
                     buildMock.parentBuilds = {
                         2: { eventId: '8887', jobs: { a: 12345 } }
@@ -4974,22 +4976,6 @@ describe('build plugin test', () => {
                         },
                         start: sinon.stub().resolves()
                     });
-                    const eventConfig = {
-                        causeMessage: 'Triggered by sd@123:a',
-                        groupEventId: '8889',
-                        parentBuildId: 12345,
-                        parentBuilds: {
-                            123: { eventId: '8888', jobs: { a: 12344, c: 45678 } }
-                        },
-                        parentEventId: '8888',
-                        pipelineId: '2',
-                        scmContext: 'github:github.com',
-                        sha: 'sha',
-                        startFrom: '~sd@123:a',
-                        skipMessage: 'Skip bulk external builds creation',
-                        type: 'pipeline',
-                        username: 'foo'
-                    };
 
                     buildC.update = sinon.stub().resolves(updatedBuildC);
                     const externalEventMock = {
@@ -5089,8 +5075,7 @@ describe('build plugin test', () => {
                     buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
 
                     return newServer.inject(options).then(() => {
-                        assert.calledOnce(eventFactoryMock.create);
-                        assert.calledWith(eventFactoryMock.create, eventConfig);
+                        assert.notCalled(eventFactoryMock.create);
                         assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
                         assert.calledOnce(buildC.update);

--- a/test/plugins/data/trigger/a_b-downstream.yaml
+++ b/test/plugins/data/trigger/a_b-downstream.yaml
@@ -1,0 +1,14 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  a:
+    requires: [ ~sd@1:a ]
+
+  b:
+    requires: [ ~sd@1:b ]
+
+  target:
+    requires: [ a, b ]

--- a/test/plugins/data/trigger/~sd@1:a-and-~sd@1:b-downstream.yaml
+++ b/test/plugins/data/trigger/~sd@1:a-and-~sd@1:b-downstream.yaml
@@ -1,0 +1,11 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  a:
+    requires: [ ~sd@1:a ]
+
+  target:
+    requires: [ ~sd@1:b ]

--- a/test/plugins/data/trigger/~sd@1:a-and-~sd@1:b-upstream.yaml
+++ b/test/plugins/data/trigger/~sd@1:a-and-~sd@1:b-upstream.yaml
@@ -1,0 +1,14 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  hub:
+    requires: [ ~commit, ~pr ]
+
+  a:
+    requires: [ ~hub ]
+
+  b:
+    requires: [ ~sd@2:a ]

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -659,6 +659,40 @@ describe('getParallelBuilds function', () => {
     });
 });
 
+describe('getSameParentEvents function', () => {
+    let eventFactoryMock;
+
+    const getSameParentEvents = RewiredTriggerHelper.__get__('getSameParentEvents');
+
+    beforeEach(() => {
+        eventFactoryMock = {
+            list: sinon.stub()
+        };
+    });
+
+    it('should get same parent events correctly', async () => {
+        const parentEventId = 101;
+        const pipelineId = 1;
+
+        const sameParentEvent1 = {
+            pipelineId: 1,
+            parentEventId: 101
+        };
+        const sameParentEvent2 = {
+            pipelineId: 2,
+            parentEventId: 101
+        };
+
+        eventFactoryMock.list.resolves([sameParentEvent1, sameParentEvent2]);
+
+        const result = await getSameParentEvents({ eventFactory: eventFactoryMock, parentEventId, pipelineId });
+
+        const expected = [{ pipelineId: 1, parentEventId: 101 }];
+
+        assert.deepEqual(result, expected);
+    });
+});
+
 describe('mergeParentBuilds function', () => {
     let loggerWarnStub;
 


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
https://github.com/screwdriver-cd/screwdriver/issues/3230

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix external events triggered by the same event to be combined into one event.
In addition, fix the behavior on restart as follows.
- External events created when restarted with an upstream event belong to the same groupEvent as the external event created by the event before the restart.
- A remote trigger from a downstream event to an upstream event belongs to the same groupEvent as the upstream event that created the restarted downstream event.

Start event(Upstream), Downstream event
<img width="200" alt="after-upstream" src="https://github.com/user-attachments/assets/dff206f4-2f61-4e5e-b0d6-a7b0e064f899"><img width="200" alt="after-upstream-restart" src="https://github.com/user-attachments/assets/81c6835d-5db8-4b77-905e-0327bde7b0fc">

Restart event(Upstream), Downstream event
<img width="200" alt="after-downstream" src="https://github.com/user-attachments/assets/768ba91e-a95a-4676-8f5c-f2101419a4d2"><img width="200" alt="after-downstream-restart" src="https://github.com/user-attachments/assets/fe7e7269-fb78-4172-83e6-6ce2bc759773">

Relatedly, A Issues has been resolved too.
https://github.com/screwdriver-cd/screwdriver/issues/3177


## References
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3230
https://github.com/screwdriver-cd/screwdriver/issues/3177

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
