### PR TITLE
fix: Add ability to filter pipeline events for commit message, author, or creator

### DIFF
--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -117,11 +117,11 @@ Query Params:
 * `creator` - *Optional* Search creator `username` and `name` for events
 * `message` - *Optional* Search commit `message` for events
 
-_Caveats_: Only one search field can be used at one time
+_Caveats_: Only one of the search fields can be used at one time (sha, author, creator, or message).
 
 `GET /pipelines/{id}/events?page={pageNumber}&count={countNumber}&sort={sort}&type={type}&prNum={prNumber}&sha={sha}`
 
-`GET /pipelines/{id}/events?commit={commit}`
+`GET /pipelines/{id}/events?message={message}`
 
 `GET /pipelines/{id}/events?id=gt:{eventId}&count={countNumber}` (greater than eventId)
 

--- a/plugins/pipelines/README.md
+++ b/plugins/pipelines/README.md
@@ -110,11 +110,18 @@ Query Params:
 * `sortBy` - *Optional* Field to sort by
 * `type` - *Optional* Get pipeline or pr events (default `pipeline`)
 * `prNum` - *Optional* Return only PR events of specified PR number
-* `sha` - *Optional* Search `sha` and `configPipelineSha` for events
 * `groupEventId` - *Optional* Return only events with a specified groupEventId
 * `id` - *Optional* Fetch specific event ID; alternatively can use greater than(`gt:`) or less than(`lt:`) prefix
+* `sha` - *Optional* Search `sha` and `configPipelineSha` for events
+* `author` - *Optional* Search commit author `username` and `name` for events
+* `creator` - *Optional* Search creator `username` and `name` for events
+* `message` - *Optional* Search commit `message` for events
+
+_Caveats_: Only one search field can be used at one time
 
 `GET /pipelines/{id}/events?page={pageNumber}&count={countNumber}&sort={sort}&type={type}&prNum={prNumber}&sha={sha}`
+
+`GET /pipelines/{id}/events?commit={commit}`
 
 `GET /pipelines/{id}/events?id=gt:{eventId}&count={countNumber}` (greater than eventId)
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1568,6 +1568,60 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 for getting events with commit author name', () => {
+            options.url = `/pipelines/${id}/events?author=Dao`;
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.getEvents);
+                assert.calledWith(pipelineMock.getEvents, {
+                    params: { type: 'pipeline' },
+                    search: {
+                        field: ['commit'],
+                        keyword: '%name":"Dao%'
+                    },
+                    sort: 'descending'
+                });
+                assert.deepEqual(reply.result, testEvents);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 200 for getting events with commit creator name', () => {
+            options.url = `/pipelines/${id}/events?creator=Dao`;
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.getEvents);
+                assert.calledWith(pipelineMock.getEvents, {
+                    params: { type: 'pipeline' },
+                    search: {
+                        field: ['creator'],
+                        keyword: '%name":"Dao%'
+                    },
+                    sort: 'descending'
+                });
+                assert.deepEqual(reply.result, testEvents);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 200 for getting events with commit message', () => {
+            options.url = `/pipelines/${id}/events?message=Update screwdriver.yaml`;
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.getEvents);
+                assert.calledWith(pipelineMock.getEvents, {
+                    params: { type: 'pipeline' },
+                    search: {
+                        field: ['commit'],
+                        keyword: '%"message":"Update screwdriver.yaml%'
+                    },
+                    sort: 'descending'
+                });
+                assert.deepEqual(reply.result, testEvents);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
         it('returns 200 for getting events with groupEventId', () => {
             options.url = `/pipelines/${id}/events?groupEventId=4`;
 
@@ -1630,6 +1684,15 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 500);
+            });
+        });
+
+        it('returns 400 when trying to search multiple fields at once', () => {
+            options.url = `/pipelines/${id}/events?creator=Dao&sha=33`;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 400);
+                assert.equal(reply.result.message, 'Invalid request query input');
             });
         });
     });


### PR DESCRIPTION
## Context

Would be nice if users could search events based on commit message, author, or creator.

## Objective

This PR adds ability to search events based on the above fields.

## References

Related to #2775 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
