### PR TITLE
fix(3242): Unable to force start a frozen job that is part of a pipeline stage

### DIFF
--- a/plugins/builds/triggers/joinBase.js
+++ b/plugins/builds/triggers/joinBase.js
@@ -105,7 +105,8 @@ class JoinBase {
             job: nextJob,
             pipelineId,
             isVirtualJob: isNextJobVirtual,
-            stageName: nextJobStageName
+            stageName: nextJobStageName,
+            event
         });
     }
 }

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -50,6 +50,8 @@ class OrBase {
         const hasFreezeWindows =
             nextJob.permutations[0].freezeWindows && nextJob.permutations[0].freezeWindows.length > 0;
 
+        const causeMessage = nextJob.name === event.startFrom ? event.causeMessage : '';
+
         if (nextBuild !== null) {
             if (Status.isStarted(nextBuild.status)) {
                 return nextBuild;
@@ -67,7 +69,7 @@ class OrBase {
             nextBuild.status = Status.QUEUED;
             await nextBuild.update();
 
-            return nextBuild.start();
+            return nextBuild.start({ causeMessage });
         }
 
         nextBuild = await createInternalBuild({
@@ -82,7 +84,8 @@ class OrBase {
             baseBranch: event.baseBranch || null,
             parentBuilds,
             parentBuildId: this.currentBuild.id,
-            start: hasFreezeWindows || !isNextJobVirtual
+            start: hasFreezeWindows || !isNextJobVirtual,
+            causeMessage
         });
 
         // Bypass execution of the build if the job is virtual

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -923,7 +923,8 @@ describe('createInternalBuild function', () => {
             prSource: '',
             prInfo: '',
             start: true,
-            baseBranch: 'master'
+            baseBranch: 'master',
+            causeMessage: undefined
         });
     });
 
@@ -1023,7 +1024,8 @@ describe('createInternalBuild function', () => {
                 prBranchName: 'feature-branch'
             },
             start: true,
-            baseBranch: 'master'
+            baseBranch: 'master',
+            causeMessage: undefined
         });
     });
 });
@@ -1224,6 +1226,7 @@ describe('handleNewBuild function', () => {
 
     let newBuildMock;
     let jobMock;
+    let eventMock;
 
     beforeEach(() => {
         newBuildMock = {
@@ -1241,6 +1244,8 @@ describe('handleNewBuild function', () => {
             permutations: [{}]
         };
 
+        eventMock = {};
+
         sinon.stub(logger, 'info');
     });
 
@@ -1253,7 +1258,8 @@ describe('handleNewBuild function', () => {
             done: false,
             hasFailure: false,
             newBuild: newBuildMock,
-            job: jobMock
+            job: jobMock,
+            event: eventMock
         });
 
         assert.isNull(result);
@@ -1269,7 +1275,8 @@ describe('handleNewBuild function', () => {
             done: true,
             hasFailure: false,
             newBuild: newBuildMock,
-            job: jobMock
+            job: jobMock,
+            event: eventMock
         });
 
         assert.strictEqual(result.status, Status.QUEUED);
@@ -1285,7 +1292,8 @@ describe('handleNewBuild function', () => {
             newBuild: newBuildMock,
             job: jobMock,
             pipelineId: 1,
-            stage: { name: 'deploy' }
+            stage: { name: 'deploy' },
+            event: eventMock
         });
 
         assert.isNull(result);
@@ -1304,7 +1312,8 @@ describe('handleNewBuild function', () => {
             newBuild: newBuildMock,
             job: jobMock,
             pipelineId: 1,
-            stageName: 'deploy'
+            stageName: 'deploy',
+            event: eventMock
         });
 
         assert.isNull(result);
@@ -1319,7 +1328,8 @@ describe('handleNewBuild function', () => {
             done: true,
             hasFailure: false,
             newBuild: newBuildMock,
-            job: jobMock
+            job: jobMock,
+            event: eventMock
         });
 
         assert.strictEqual(result.status, Status.QUEUED);
@@ -1333,7 +1343,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            isVirtualJob: true
+            isVirtualJob: true,
+            event: eventMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.SUCCESS);
@@ -1351,7 +1362,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            isVirtualJob: true
+            isVirtualJob: true,
+            event: eventMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.SUCCESS);
@@ -1367,7 +1379,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            isVirtualJob: true
+            isVirtualJob: true,
+            event: eventMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.QUEUED);


### PR DESCRIPTION
## Context

When an event is started from a frozen stage job, it again gets into frozen state.

This is because, when an event is started from a stage job, the stage `setup` is executed prior to executing the event origin job.

## Objective

Pass the event `causeMessage` to the stage job build so that the executor can force start the build for the frozen stage job.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3242

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
