### PR TITLE
feat(3248): log request payload for steps update endpoint

### DIFF
--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -21,7 +21,11 @@ module.exports = () => ({
             const stepName = request.params.name;
             const buildIdCred = request.auth.credentials.username;
 
-            request.log(['builds', buildId, 'steps', stepName], `Received payload: ${JSON.stringify(request.payload)}`);
+            if (request.payload && request.payload.code !== undefined) {
+                if (request.payload.code !== 0) {
+                    request.log(['builds', buildId, 'steps', stepName], `Step failed. Received payload: ${JSON.stringify(request.payload)}`);
+                }
+            } 
 
             if (buildId !== buildIdCred) {
                 return boom.forbidden(`Credential only valid for ${buildIdCred}`);

--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -21,6 +21,8 @@ module.exports = () => ({
             const stepName = request.params.name;
             const buildIdCred = request.auth.credentials.username;
 
+            request.log(['builds', buildId, 'steps', stepName], `Received payload: ${JSON.stringify(request.payload)}`);
+
             if (buildId !== buildIdCred) {
                 return boom.forbidden(`Credential only valid for ${buildIdCred}`);
             }

--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -23,9 +23,12 @@ module.exports = () => ({
 
             if (request.payload && request.payload.code !== undefined) {
                 if (request.payload.code !== 0) {
-                    request.log(['builds', buildId, 'steps', stepName], `Step failed. Received payload: ${JSON.stringify(request.payload)}`);
+                    request.log(
+                        ['builds', buildId, 'steps', stepName],
+                        `Step failed. Received payload: ${JSON.stringify(request.payload)}`
+                    );
                 }
-            } 
+            }
 
             if (buildId !== buildIdCred) {
                 return boom.forbidden(`Credential only valid for ${buildIdCred}`);


### PR DESCRIPTION
## Context

It is not possible to access the request payload for investigating the [steps/update API endpoint](https://github.com/screwdriver-cd/screwdriver/blob/9beed12ecae4cb08be5baeff895bf7b9efe6c186/plugins/builds/steps/update.js) 

## Objective

To assist with troubleshooting, it would be helpful to log the payload using a logger. Additionally, having detailed logs would enable implementing log-based alerting.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3248

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
