### PR TITLE
fix(3133): upstream event creation when restarting remote join from downstream build

### DIFF
--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -811,7 +811,7 @@ function mergeParentBuilds(parentBuilds, relatedBuilds, currentEvent, nextEvent)
 
             if (strToInt(pipelineId) !== strToInt(currentEvent.pipelineId)) {
                 if (nextEvent) {
-                    if (strToInt(pipelineId) !== nextEvent.pipelineId) {
+                    if (strToInt(pipelineId) !== strToInt(nextEvent.pipelineId)) {
                         nodeName = `sd@${pipelineId}:${nodeName}`;
                     }
                     workflowGraph = nextEvent.workflowGraph;

--- a/test/plugins/data/trigger/sd@2:b_sd@2:c-downstream.yaml
+++ b/test/plugins/data/trigger/sd@2:b_sd@2:c-downstream.yaml
@@ -1,0 +1,12 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  hub:
+    requires: [ ~sd@1:hub ]
+  b:
+    requires: [ ~hub ]
+  c:
+    requires: [ ~hub ]

--- a/test/plugins/data/trigger/sd@2:b_sd@2:c-upstream.yaml
+++ b/test/plugins/data/trigger/sd@2:b_sd@2:c-upstream.yaml
@@ -1,0 +1,10 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  hub:
+    requires: [ ~commit, ~pr ]
+  target:
+    requires: [ sd@2:b, sd@2:c ]


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

A workflow containing a remote join may not trigger a build of the remote join if it is restarted from downstream.

### Example

Build succeeds downstream and remote join build is triggered upstream.

- upstream:
<img width="271" alt="image" src="https://github.com/user-attachments/assets/9044dc7a-e2fa-4a1f-a0ea-2813cac68572">

- downstream:
<img width="302" alt="image" src="https://github.com/user-attachments/assets/6268ff6d-2deb-4b73-8261-b3ef65105e76">

---

Upstream remote join is not triggered even if build succeeds after restarting from downstream.

- downstream:
<img width="299" alt="image" src="https://github.com/user-attachments/assets/d33e750e-8aa8-40fa-9981-17227676c0a4">

- upstream:
<img width="281" alt="image" src="https://github.com/user-attachments/assets/1b7164de-fb11-43ac-b287-ae307f05124d">

---

This is due to a unique constraint error when creating a subsequent remote join build after a successful build restarted from a downstream, when trying to create in the restart source upstream event.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
In the remote join workflow, when restarted from a downstream, create a new event on the upstream side and create a build on that event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3133

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
