### PR TITLE
feat(3181): Skip execution of a virtual job when an event is started from that job

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "screwdriver-executor-queue": "^5.0.0",
     "screwdriver-executor-router": "^4.0.0",
     "screwdriver-logger": "^2.0.0",
-    "screwdriver-models": "^30.2.0",
+    "screwdriver-models": "^31.0.0",
     "screwdriver-notifications-email": "^4.0.0",
     "screwdriver-notifications-slack": "^6.0.0",
     "screwdriver-request": "^2.0.1",

--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -1,0 +1,304 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const hoek = require('@hapi/hoek');
+const merge = require('lodash.mergewith');
+const { getFullStageJobName } = require('../../helper');
+const STAGE_TEARDOWN_PATTERN = /^stage@([\w-]+)(?::teardown)$/;
+const TERMINAL_STATUSES = ['FAILURE', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
+const FINISHED_STATUSES = ['FAILURE', 'SUCCESS', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
+
+/**
+ * @typedef {import('screwdriver-models/lib/build')} Build
+ * @typedef {import('screwdriver-models/lib/event')} Event
+ */
+
+/**
+ * Identify whether this build resulted in a previously failed job to become successful.
+ *
+ * @method isFixedBuild
+ * @param  build         Build Object
+ * @param  jobFactory    Job Factory instance
+ */
+async function isFixedBuild(build, jobFactory) {
+    if (build.status !== 'SUCCESS') {
+        return false;
+    }
+
+    const job = await jobFactory.get(build.jobId);
+    const failureBuild = await job.getLatestBuild({ status: 'FAILURE' });
+    const successBuild = await job.getLatestBuild({ status: 'SUCCESS' });
+
+    if ((failureBuild && !successBuild) || failureBuild.id > successBuild.id) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Stops a frozen build from executing
+ * @method stopFrozenBuild
+ * @param  {Object} build         Build Object
+ * @param  {String} previousStatus    Prevous build status
+ */
+async function stopFrozenBuild(build, previousStatus) {
+    if (previousStatus !== 'FROZEN') {
+        return Promise.resolve();
+    }
+
+    return build.stopFrozen(previousStatus);
+}
+
+/**
+ * Updates execution details for init step
+ * @method stopFrozenBuild
+ * @param  {Object} build       Build Object
+ * @param  {Object} app         Hapi app Object
+ */
+async function updateInitStep(build, app) {
+    const step = await app.stepFactory.get({ buildId: build.id, name: 'sd-setup-init' });
+    // If there is no init step, do nothing
+
+    if (!step) {
+        return null;
+    }
+
+    step.endTime = build.startTime || new Date().toISOString();
+    step.code = 0;
+
+    return step.update();
+}
+
+/**
+ * Set build status to desired status, set build statusMessage
+ * @param {Object} build                Build Model
+ * @param {String} desiredStatus        New Status
+ * @param {String} statusMessage        User passed status message
+ * @param {String} statusMessageType    User passed severity of the status message
+ * @param {String} username             User initiating status build update
+ */
+function updateBuildStatus(build, desiredStatus, statusMessage, statusMessageType, username) {
+    // UNSTABLE -> SUCCESS needs to update meta and endtime.
+    // However, the status itself cannot be updated to SUCCESS
+    const currentStatus = build.status;
+
+    if (currentStatus !== 'UNSTABLE') {
+        if (desiredStatus !== undefined) {
+            build.status = desiredStatus;
+        }
+        if (build.status === 'ABORTED') {
+            if (currentStatus === 'FROZEN') {
+                build.statusMessage = `Frozen build aborted by ${username}`;
+            } else {
+                build.statusMessage = `Aborted by ${username}`;
+            }
+        } else if (build.status === 'FAILURE' || build.status === 'SUCCESS') {
+            if (statusMessage) {
+                build.statusMessage = statusMessage;
+                build.statusMessageType = statusMessageType || null;
+            }
+        } else {
+            build.statusMessage = statusMessage || null;
+            build.statusMessageType = statusMessageType || null;
+        }
+    }
+}
+
+/**
+ * Get stage for current node
+ * @param  {StageFactory}   stageFactory                Stage factory
+ * @param  {Object}         workflowGraph               Workflow graph
+ * @param  {String}         jobName                     Job name
+ * @param  {Number}         pipelineId                  Pipeline ID
+ * @return {Stage}                                      Stage for node
+ */
+async function getStage({ stageFactory, workflowGraph, jobName, pipelineId }) {
+    const currentNode = workflowGraph.nodes.find(node => node.name === jobName);
+    let stage = null;
+
+    if (currentNode && currentNode.stageName) {
+        stage = await stageFactory.get({
+            pipelineId,
+            name: currentNode.stageName
+        });
+    }
+
+    return Promise.resolve(stage);
+}
+
+/**
+ * Checks if all builds in stage are done running
+ * @param  {Object}     stage                     Stage
+ * @param  {Object}     event                     Event
+ * @return {Boolean}              Flag if stage is done
+ */
+async function isStageDone({ stage, event }) {
+    // Get all jobIds for jobs in the stage
+    const stageJobIds = stage.jobIds;
+
+    stageJobIds.push(stage.setup);
+
+    // Get all builds in a stage for this event
+    const stageJobBuilds = await event.getBuilds({ params: { jobId: stageJobIds } });
+    let stageIsDone = false;
+
+    if (stageJobBuilds && stageJobBuilds.length !== 0) {
+        stageIsDone = !stageJobBuilds.some(b => !FINISHED_STATUSES.includes(b.status));
+    }
+
+    return stageIsDone;
+}
+
+/**
+ * Updates the build and trigger its downstream jobs in the workflow
+ *
+ * @method updateBuildAndTriggerDownstreamJobs
+ * @param   {Object}    config
+ * @param   {Build}     build
+ * @param   {Object}    server
+ * @param   {String}    username
+ * @param   {Object}    scmContext
+ * @returns {Promise<Build>} Updated build
+ */
+async function updateBuildAndTriggerDownstreamJobs(config, build, server, username, scmContext) {
+    const { buildFactory, eventFactory, jobFactory, stageFactory, stageBuildFactory } = server.app;
+    const { statusMessage, statusMessageType, stats, status: desiredStatus, meta } = config;
+    const { triggerNextJobs, removeJoinBuilds, createOrUpdateStageTeardownBuild } = server.plugins.builds;
+
+    const currentStatus = build.status;
+
+    const event = await eventFactory.get(build.eventId);
+
+    if (stats) {
+        // need to do this so the field is dirty
+        build.stats = Object.assign(build.stats, stats);
+    }
+
+    // Short circuit for cases that don't need to update status
+    if (!desiredStatus) {
+        build.statusMessage = statusMessage || build.statusMessage;
+        build.statusMessageType = statusMessageType || build.statusMessageType;
+    } else if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(desiredStatus)) {
+        build.meta = meta || {};
+        event.meta = merge({}, event.meta, build.meta);
+        build.endTime = new Date().toISOString();
+    } else if (desiredStatus === 'RUNNING') {
+        build.startTime = new Date().toISOString();
+    } else if (desiredStatus === 'BLOCKED' && !hoek.reach(build, 'stats.blockedStartTime')) {
+        build.stats = Object.assign(build.stats, {
+            blockedStartTime: new Date().toISOString()
+        });
+    } else if (desiredStatus === 'QUEUED' && currentStatus !== 'QUEUED') {
+        throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);
+    } else if (desiredStatus === 'BLOCKED' && currentStatus === 'BLOCKED') {
+        // Queue-Service can call BLOCKED status update multiple times
+        throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);
+    }
+
+    let isFixed = Promise.resolve(false);
+    let stopFrozen = null;
+
+    updateBuildStatus(build, desiredStatus, statusMessage, statusMessageType, username);
+
+    // If status got updated to RUNNING or COLLAPSED, update init endTime and code
+    if (['RUNNING', 'COLLAPSED', 'FROZEN'].includes(desiredStatus)) {
+        await updateInitStep(build, server.app);
+    } else {
+        stopFrozen = stopFrozenBuild(build, currentStatus);
+        isFixed = isFixedBuild(build, jobFactory);
+    }
+
+    const [newBuild, newEvent] = await Promise.all([build.update(), event.update(), stopFrozen]);
+    const job = await newBuild.job;
+    const pipeline = await job.pipeline;
+
+    if (desiredStatus) {
+        await server.events.emit('build_status', {
+            settings: job.permutations[0].settings,
+            status: newBuild.status,
+            event: newEvent.toJson(),
+            pipeline: pipeline.toJson(),
+            jobName: job.name,
+            build: newBuild.toJson(),
+            buildLink: `${buildFactory.uiUri}/pipelines/${pipeline.id}/builds/${build.id}`,
+            isFixed: await isFixed
+        });
+    }
+
+    const skipFurther = /\[(skip further)\]/.test(newEvent.causeMessage);
+
+    // Update stageBuild status if it has changed;
+    // if stageBuild status is currently terminal, do not update
+    const stage = await getStage({
+        stageFactory,
+        workflowGraph: newEvent.workflowGraph,
+        jobName: job.name,
+        pipelineId: pipeline.id
+    });
+    const isStageTeardown = STAGE_TEARDOWN_PATTERN.test(job.name);
+    let stageBuildHasFailure = false;
+
+    if (stage) {
+        const stageBuild = await stageBuildFactory.get({
+            stageId: stage.id,
+            eventId: newEvent.id
+        });
+
+        if (stageBuild.status !== newBuild.status) {
+            if (!TERMINAL_STATUSES.includes(stageBuild.status)) {
+                stageBuild.status = newBuild.status;
+                await stageBuild.update();
+            }
+        }
+
+        stageBuildHasFailure = TERMINAL_STATUSES.includes(stageBuild.status);
+    }
+
+    // Guard against triggering non-successful or unstable builds
+    // Don't further trigger pipeline if intend to skip further jobs
+    if (newBuild.status !== 'SUCCESS' || skipFurther) {
+        // Check for failed jobs and remove any child jobs in created state
+        if (newBuild.status === 'FAILURE') {
+            await removeJoinBuilds({ pipeline, job, build: newBuild, event: newEvent, stage }, server.app);
+
+            if (stage && !isStageTeardown) {
+                await createOrUpdateStageTeardownBuild(
+                    { pipeline, job, build, username, scmContext, event, stage },
+                    server.app
+                );
+            }
+        }
+        // Do not continue downstream is current job is stage teardown and statusBuild has failure
+    } else if (newBuild.status === 'SUCCESS' && isStageTeardown && stageBuildHasFailure) {
+        await removeJoinBuilds({ pipeline, job, build: newBuild, event: newEvent, stage }, server.app);
+    } else {
+        await triggerNextJobs({ pipeline, job, build: newBuild, username, scmContext, event: newEvent }, server.app);
+    }
+
+    // Determine if stage teardown build should start
+    // (if stage teardown build exists, and stageBuild.status is negative,
+    // and there are no active stage builds, and teardown build is not started)
+    if (stage && FINISHED_STATUSES.includes(newBuild.status)) {
+        const stageTeardownName = getFullStageJobName({ stageName: stage.name, jobName: 'teardown' });
+        const stageTeardownJob = await jobFactory.get({ pipelineId: pipeline.id, name: stageTeardownName });
+        const stageTeardownBuild = await buildFactory.get({ eventId: newEvent.id, jobId: stageTeardownJob.id });
+
+        // Start stage teardown build if stage is done
+        if (stageTeardownBuild && stageTeardownBuild.status === 'CREATED') {
+            const stageIsDone = await isStageDone({ stage, event: newEvent });
+
+            if (stageIsDone) {
+                stageTeardownBuild.status = 'QUEUED';
+                await stageTeardownBuild.update();
+                await stageTeardownBuild.start();
+            }
+        }
+    }
+
+    return newBuild;
+}
+
+module.exports = {
+    updateBuildAndTriggerDownstreamJobs
+};

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -1,72 +1,11 @@
 'use strict';
 
 const boom = require('@hapi/boom');
-const hoek = require('@hapi/hoek');
 const schema = require('screwdriver-data-schema');
 const joi = require('joi');
 const idSchema = schema.models.build.base.extract('id');
-const merge = require('lodash.mergewith');
-const { getScmUri, getUserPermissions, getFullStageJobName } = require('../helper');
-const STAGE_TEARDOWN_PATTERN = /^stage@([\w-]+)(?::teardown)$/;
-const TERMINAL_STATUSES = ['FAILURE', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
-const FINISHED_STATUSES = ['FAILURE', 'SUCCESS', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
-
-/**
- * Identify whether this build resulted in a previously failed job to become successful.
- *
- * @method isFixedBuild
- * @param  build         Build Object
- * @param  jobFactory    Job Factory instance
- */
-async function isFixedBuild(build, jobFactory) {
-    if (build.status !== 'SUCCESS') {
-        return false;
-    }
-
-    const job = await jobFactory.get(build.jobId);
-    const failureBuild = await job.getLatestBuild({ status: 'FAILURE' });
-    const successBuild = await job.getLatestBuild({ status: 'SUCCESS' });
-
-    if ((failureBuild && !successBuild) || failureBuild.id > successBuild.id) {
-        return true;
-    }
-
-    return false;
-}
-
-/**
- * Stops a frozen build from executing
- * @method stopFrozenBuild
- * @param  {Object} build         Build Object
- * @param  {String} previousStatus    Prevous build status
- */
-async function stopFrozenBuild(build, previousStatus) {
-    if (previousStatus !== 'FROZEN') {
-        return Promise.resolve();
-    }
-
-    return build.stopFrozen(previousStatus);
-}
-
-/**
- * Updates execution details for init step
- * @method stopFrozenBuild
- * @param  {Object} build       Build Object
- * @param  {Object} app         Hapi app Object
- */
-async function updateInitStep(build, app) {
-    const step = await app.stepFactory.get({ buildId: build.id, name: 'sd-setup-init' });
-    // If there is no init step, do nothing
-
-    if (!step) {
-        return null;
-    }
-
-    step.endTime = build.startTime || new Date().toISOString();
-    step.code = 0;
-
-    return step.update();
-}
+const { getScmUri, getUserPermissions } = require('../helper');
+const { updateBuildAndTriggerDownstreamJobs } = require('./helper/updateBuild');
 
 /**
  * Validate if build status can be updated
@@ -127,86 +66,6 @@ async function validateUserPermission(build, request) {
     await getUserPermissions({ user, scmUri, level: 'push', isAdmin: adminDetails.isAdmin });
 }
 
-/**
- * Set build status to desired status, set build statusMessage
- * @param {Object} build                Build Model
- * @param {String} desiredStatus        New Status
- * @param {String} statusMessage        User passed status message
- * @param {String} statusMessageType    User passed severity of the status message
- * @param {String} username             User initiating status build update
- */
-function updateBuildStatus(build, desiredStatus, statusMessage, statusMessageType, username) {
-    // UNSTABLE -> SUCCESS needs to update meta and endtime.
-    // However, the status itself cannot be updated to SUCCESS
-    const currentStatus = build.status;
-
-    if (currentStatus !== 'UNSTABLE') {
-        if (desiredStatus !== undefined) {
-            build.status = desiredStatus;
-        }
-        if (build.status === 'ABORTED') {
-            if (currentStatus === 'FROZEN') {
-                build.statusMessage = `Frozen build aborted by ${username}`;
-            } else {
-                build.statusMessage = `Aborted by ${username}`;
-            }
-        } else if (build.status === 'FAILURE' || build.status === 'SUCCESS') {
-            if (statusMessage) {
-                build.statusMessage = statusMessage;
-                build.statusMessageType = statusMessageType || null;
-            }
-        } else {
-            build.statusMessage = statusMessage || null;
-            build.statusMessageType = statusMessageType || null;
-        }
-    }
-}
-
-/**
- * Get stage for current node
- * @param  {StageFactory}   stageFactory                Stage factory
- * @param  {Object}         workflowGraph               Workflow graph
- * @param  {String}         jobName                     Job name
- * @param  {Number}         pipelineId                  Pipeline ID
- * @return {Stage}                                      Stage for node
- */
-async function getStage({ stageFactory, workflowGraph, jobName, pipelineId }) {
-    const currentNode = workflowGraph.nodes.find(node => node.name === jobName);
-    let stage = null;
-
-    if (currentNode && currentNode.stageName) {
-        stage = await stageFactory.get({
-            pipelineId,
-            name: currentNode.stageName
-        });
-    }
-
-    return Promise.resolve(stage);
-}
-
-/**
- * Checks if all builds in stage are done running
- * @param  {Object}     stage                     Stage
- * @param  {Object}     event                     Event
- * @return {Boolean}              Flag if stage is done
- */
-async function isStageDone({ stage, event }) {
-    // Get all jobIds for jobs in the stage
-    const stageJobIds = stage.jobIds;
-
-    stageJobIds.push(stage.setup);
-
-    // Get all builds in a stage for this event
-    const stageJobBuilds = await event.getBuilds({ params: { jobId: stageJobIds } });
-    let stageIsDone = false;
-
-    if (stageJobBuilds && stageJobBuilds.length !== 0) {
-        stageIsDone = !stageJobBuilds.some(b => !FINISHED_STATUSES.includes(b.status));
-    }
-
-    return stageIsDone;
-}
-
 module.exports = () => ({
     method: 'PUT',
     path: '/builds/{id}',
@@ -220,13 +79,10 @@ module.exports = () => ({
         },
 
         handler: async (request, h) => {
-            const { buildFactory, eventFactory, jobFactory, stageFactory, stageBuildFactory } = request.server.app;
+            const { buildFactory } = request.server.app;
             const { id } = request.params;
-            const { statusMessage, statusMessageType, stats, status: desiredStatus } = request.payload;
             const { username, scmContext, scope } = request.auth.credentials;
             const isBuild = scope.includes('build') || scope.includes('temporal');
-            const { triggerNextJobs, removeJoinBuilds, createOrUpdateStageTeardownBuild } =
-                request.server.plugins.builds;
 
             // Check token permissions
             if (isBuild && username !== id) {
@@ -234,144 +90,18 @@ module.exports = () => ({
             }
 
             const build = await getBuildToUpdate(id, buildFactory);
-            const currentStatus = build.status;
 
             if (!isBuild) {
                 await validateUserPermission(build, request);
             }
-            const event = await eventFactory.get(build.eventId);
 
-            if (stats) {
-                // need to do this so the field is dirty
-                build.stats = Object.assign(build.stats, stats);
-            }
-
-            // Short circuit for cases that don't need to update status
-            if (!desiredStatus) {
-                build.statusMessage = statusMessage || build.statusMessage;
-                build.statusMessageType = statusMessageType || build.statusMessageType;
-            } else if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(desiredStatus)) {
-                build.meta = request.payload.meta || {};
-                event.meta = merge({}, event.meta, build.meta);
-                build.endTime = new Date().toISOString();
-            } else if (desiredStatus === 'RUNNING') {
-                build.startTime = new Date().toISOString();
-            } else if (desiredStatus === 'BLOCKED' && !hoek.reach(build, 'stats.blockedStartTime')) {
-                build.stats = Object.assign(build.stats, {
-                    blockedStartTime: new Date().toISOString()
-                });
-            } else if (desiredStatus === 'QUEUED' && currentStatus !== 'QUEUED') {
-                throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);
-            } else if (desiredStatus === 'BLOCKED' && currentStatus === 'BLOCKED') {
-                // Queue-Service can call BLOCKED status update multiple times
-                throw boom.badRequest(`Cannot update builds to ${desiredStatus}`);
-            }
-
-            let isFixed = Promise.resolve(false);
-            let stopFrozen = null;
-
-            updateBuildStatus(build, desiredStatus, statusMessage, statusMessageType, username);
-
-            // If status got updated to RUNNING or COLLAPSED, update init endTime and code
-            if (['RUNNING', 'COLLAPSED', 'FROZEN'].includes(desiredStatus)) {
-                await updateInitStep(build, request.server.app);
-            } else {
-                stopFrozen = stopFrozenBuild(build, currentStatus);
-                isFixed = isFixedBuild(build, jobFactory);
-            }
-
-            const [newBuild, newEvent] = await Promise.all([build.update(), event.update(), stopFrozen]);
-            const job = await newBuild.job;
-            const pipeline = await job.pipeline;
-
-            if (desiredStatus) {
-                await request.server.events.emit('build_status', {
-                    settings: job.permutations[0].settings,
-                    status: newBuild.status,
-                    event: newEvent.toJson(),
-                    pipeline: pipeline.toJson(),
-                    jobName: job.name,
-                    build: newBuild.toJson(),
-                    buildLink: `${buildFactory.uiUri}/pipelines/${pipeline.id}/builds/${id}`,
-                    isFixed: await isFixed
-                });
-            }
-
-            const skipFurther = /\[(skip further)\]/.test(newEvent.causeMessage);
-
-            // Update stageBuild status if it has changed;
-            // if stageBuild status is currently terminal, do not update
-            const stage = await getStage({
-                stageFactory,
-                workflowGraph: newEvent.workflowGraph,
-                jobName: job.name,
-                pipelineId: pipeline.id
-            });
-            const isStageTeardown = STAGE_TEARDOWN_PATTERN.test(job.name);
-            let stageBuildHasFailure = false;
-
-            if (stage) {
-                const stageBuild = await stageBuildFactory.get({
-                    stageId: stage.id,
-                    eventId: newEvent.id
-                });
-
-                if (stageBuild.status !== newBuild.status) {
-                    if (!TERMINAL_STATUSES.includes(stageBuild.status)) {
-                        stageBuild.status = newBuild.status;
-                        await stageBuild.update();
-                    }
-                }
-
-                stageBuildHasFailure = TERMINAL_STATUSES.includes(stageBuild.status);
-            }
-
-            // Guard against triggering non-successful or unstable builds
-            // Don't further trigger pipeline if intend to skip further jobs
-            if (newBuild.status !== 'SUCCESS' || skipFurther) {
-                // Check for failed jobs and remove any child jobs in created state
-                if (newBuild.status === 'FAILURE') {
-                    await removeJoinBuilds(
-                        { pipeline, job, build: newBuild, event: newEvent, stage },
-                        request.server.app
-                    );
-
-                    if (stage && !isStageTeardown) {
-                        await createOrUpdateStageTeardownBuild(
-                            { pipeline, job, build, username, scmContext, event, stage },
-                            request.server.app
-                        );
-                    }
-                }
-                // Do not continue downstream is current job is stage teardown and statusBuild has failure
-            } else if (newBuild.status === 'SUCCESS' && isStageTeardown && stageBuildHasFailure) {
-                await removeJoinBuilds({ pipeline, job, build: newBuild, event: newEvent, stage }, request.server.app);
-            } else {
-                await triggerNextJobs(
-                    { pipeline, job, build: newBuild, username, scmContext, event: newEvent },
-                    request.server.app
-                );
-            }
-
-            // Determine if stage teardown build should start
-            // (if stage teardown build exists, and stageBuild.status is negative,
-            // and there are no active stage builds, and teardown build is not started)
-            if (stage && FINISHED_STATUSES.includes(newBuild.status)) {
-                const stageTeardownName = getFullStageJobName({ stageName: stage.name, jobName: 'teardown' });
-                const stageTeardownJob = await jobFactory.get({ pipelineId: pipeline.id, name: stageTeardownName });
-                const stageTeardownBuild = await buildFactory.get({ eventId: newEvent.id, jobId: stageTeardownJob.id });
-
-                // Start stage teardown build if stage is done
-                if (stageTeardownBuild && stageTeardownBuild.status === 'CREATED') {
-                    const stageIsDone = await isStageDone({ stage, event: newEvent });
-
-                    if (stageIsDone) {
-                        stageTeardownBuild.status = 'QUEUED';
-                        await stageTeardownBuild.update();
-                        await stageTeardownBuild.start();
-                    }
-                }
-            }
+            const newBuild = await updateBuildAndTriggerDownstreamJobs(
+                request.payload,
+                build,
+                request.server,
+                username,
+                scmContext
+            );
 
             return h.response(await newBuild.toJsonWithSteps()).code(200);
         },

--- a/test/plugins/data/builds.json
+++ b/test/plugins/data/builds.json
@@ -151,4 +151,41 @@
         }
     ],
     "status": "QUEUED"
+},{
+    "id": 776677,
+    "jobId": 1234,
+    "number": 5,
+    "sha": "58393af682d61de87789fb4961645c42180cec5a",
+    "cause": "Started by user foo",
+    "createTime": "2038-01-19T03:17:08.131Z",
+    "startTime": "2038-01-19T03:18:08.131Z",
+    "endTime": "2038-01-19T03:19:10.131Z",
+    "parameters": {},
+    "steps": [
+        {
+            "name": "sd-setup",
+            "code": 0,
+            "startTime": "2038-01-19T03:15:08.131Z",
+            "endTime": "2038-01-19T03:15:08.532Z"
+        },
+        {
+            "name": "install",
+            "code": 5,
+            "startTime": "2038-01-19T03:15:08.532Z",
+            "endTime": "2038-01-19T03:15:09.114Z"
+        },
+        {
+            "name": "test"
+        },
+        {
+            "name": "publish"
+        },
+        {
+            "name": "sd-cleanup",
+            "code": 0,
+            "startTime": "2038-01-19T03:15:09.115Z",
+            "endTime": "2038-01-19T03:15:10.130Z"
+        }
+    ],
+    "status": "CREATED"
 }]

--- a/test/plugins/data/events.json
+++ b/test/plugins/data/events.json
@@ -19,7 +19,9 @@
         "nodes": [
             { "name": "~pr" },
             { "name": "~commit" },
-            { "name": "main" },
+            { "name": "main",
+                "id": 1234
+            },
             { "name": "publish" },
             { "name": "beta" }
         ],

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -401,7 +401,6 @@ describe('event plugin test', () => {
             };
 
             eventMock = getEventMock(testEvent);
-            // eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
             eventFactoryMock.get.withArgs(eventMock.id).resolves(eventMock);
 
             eventMock.builds = [];


### PR DESCRIPTION
## Context

Per changes made in https://github.com/screwdriver-cd/models/pull/635, virtual job builds at the beginning in the workflow for an event, may not be queued for execution. Status of such build will be set to `CREATED`.

## Objective

Identify such build immediately after creating the event to mark its status as 'SUCCESS' and trigger its downstream jobs.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3181

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
