### PR TITLE
feat(3248): add logging in builds PUT to capture failure

### DIFF
--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -95,6 +95,13 @@ module.exports = () => ({
                 await validateUserPermission(build, request);
             }
 
+            if (request.payload.status && request.payload.status === 'FAILURE') {
+                request.log(
+                    ['PUT', 'builds', id],
+                    `Build failed. Received payload: ${JSON.stringify(request.payload)}`
+                );
+            }
+
             const newBuild = await updateBuildAndTriggerDownstreamJobs(
                 request.payload,
                 build,


### PR DESCRIPTION
## Context

It is not possible to access the request payload for investigating the [builds/update API endpoint](https://github.com/screwdriver-cd/screwdriver/blob/36d3365e5ba59b5a6a905177c2f2b0389527c905/plugins/builds/update.js)

## Objective

To assist with troubleshooting, it would be helpful to log the payload using a logger. Additionally, having detailed logs would enable implementing log-based alerting.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3248

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.