### PR TITLE
fix(3235): Fetch parentEvent meta when create Event

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -220,15 +220,24 @@ module.exports = () => ({
 
             payload.sha = sha;
 
-            // If there is parentEvent, pass workflowGraph and sha to payload
+            // If there is parentEvent, pass workflowGraph, meta and sha to payload
             // Skip PR, for PR builds, we should always start from latest commit
             if (payload.parentEventId) {
                 const parentEvent = await eventFactory.get(parentEventId);
+                let mergedParameters = {};
 
                 payload.baseBranch = parentEvent.baseBranch || null;
 
                 if (!payload.meta.parameters && parentEvent.meta && parentEvent.meta.parameters) {
-                    payload.meta.parameters = parentEvent.meta.parameters;
+                    mergedParameters = parentEvent.meta.parameters;
+                }
+
+                if (Object.keys(payload.meta).length === 0) {
+                    payload.meta = { ...parentEvent.meta };
+                }
+
+                if (Object.keys(mergedParameters).length > 0) {
+                    payload.meta.parameters = mergedParameters;
                 }
 
                 if (!prNum) {

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -224,14 +224,17 @@ module.exports = () => ({
             // Skip PR, for PR builds, we should always start from latest commit
             if (payload.parentEventId) {
                 const parentEvent = await eventFactory.get(parentEventId);
-                let mergedParameters = {};
+                let mergedParameters = payload.meta.parameters || {};
 
                 payload.baseBranch = parentEvent.baseBranch || null;
 
+                // Merge parameters if they exist in the parent event and not in the payload
                 if (!payload.meta.parameters && parentEvent.meta && parentEvent.meta.parameters) {
                     mergedParameters = parentEvent.meta.parameters;
                 }
+                delete payload.meta.parameters;
 
+                // Copy meta from parent event if payload.meta is empty except for the parameters
                 if (Object.keys(payload.meta).length === 0) {
                     payload.meta = { ...parentEvent.meta };
                 }

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -907,14 +907,18 @@ describe('event plugin test', () => {
                 one: 1
             };
             eventConfig.configPipelineSha = 'configPipelineSha';
-            eventConfig.meta.parameters = {
-                user: { value: 'klu' },
+            eventConfig.meta = {
+                parameters: {
+                    user: { value: 'klu' }
+                },
                 foo: 'bar',
                 one: 1
             };
             options.payload.parentEventId = parentEventId;
-            options.payload.meta.parameters = {
-                user: { value: 'klu' }
+            options.payload.meta = {
+                parameters: {
+                    user: { value: 'klu' }
+                }
             };
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When restart build was failed in `sd-setup-init` step and restart build from that build, meta is missing at that time.
So we fix this behavior by fetching parent event meta when creating event.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fetch parent event meta when creating event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#3225 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
