### PR TITLE
fix: Show error details and change status code in case of webhook error [2]

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -447,23 +447,21 @@ async function startEvents(eventConfigs, eventFactory) {
 
     if (errorCount > 0 && errorCount === eventsCount) {
         // preserve current behavior of returning 500 on error
-        const errorMessages = [];
+        const errorMessages = new Set();
         let statusCode;
 
         errors.forEach(err => {
-            if (err.message !== undefined) {
-                errorMessages.push(err.message);
-            }
+            errorMessages.add(`"${err.message}"`);
             if (err.statusCode !== undefined) {
                 statusCode = err.statusCode;
             }
         });
 
-        const errorMessage = errorMessages.join(',');
+        const errorMessage = [...errorMessages].join(', ');
         const error =
             errorCount === 1
-                ? new Error(`Failed to start a event caused by "${errorMessage}"`)
-                : new Error(`Failed to start some events caused by "${errorMessage}"`);
+                ? new Error(`Failed to start a event caused by ${errorMessage}`)
+                : new Error(`Failed to start some events caused by ${errorMessage}`);
 
         error.statusCode = statusCode;
         throw error;

--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -448,7 +448,7 @@ async function startEvents(eventConfigs, eventFactory) {
     if (errorCount > 0 && errorCount === eventsCount) {
         // preserve current behavior of returning 500 on error
         const errorMessages = new Set();
-        let statusCode;
+        let statusCode = 500;
 
         errors.forEach(err => {
             errorMessages.add(`"${err.message}"`);

--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -433,18 +433,40 @@ async function startEvents(eventConfigs, eventFactory) {
         })
     );
 
+    const errors = [];
+
     results.forEach((result, i) => {
         if (result.status === 'fulfilled') {
             if (result.value) events.push(result.value);
         } else {
             errorCount += 1;
+            errors.push(result.reason);
             logger.error(`pipeline:${eventConfigs[i].pipelineId} error in starting event`, result.reason);
         }
     });
 
-    if (errorCount && errorCount === eventsCount) {
+    if (errorCount > 0 && errorCount === eventsCount) {
         // preserve current behavior of returning 500 on error
-        throw new Error('Failed to start any events');
+        const errorMessages = [];
+        let statusCode;
+
+        errors.forEach(err => {
+            if (err.message !== undefined) {
+                errorMessages.push(err.message);
+            }
+            if (err.statusCode !== undefined) {
+                statusCode = err.statusCode;
+            }
+        });
+
+        const errorMessage = errorMessages.join(',');
+        const error =
+            errorCount === 1
+                ? new Error(`Failed to start a event caused by "${errorMessage}"`)
+                : new Error(`Failed to start some events caused by "${errorMessage}"`);
+
+        error.statusCode = statusCode;
+        throw error;
     }
 
     return events;

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1722,7 +1722,7 @@ describe('startHookEvent test', () => {
                 .then(() => assert.fail())
                 .catch(err => {
                     assert.equal(err.message, 'Failed to start a event caused by "Failed to start"');
-                    assert.equal(err.statusCode, undefined);
+                    assert.equal(err.statusCode, 500);
                 });
         });
 
@@ -2241,7 +2241,7 @@ describe('startHookEvent test', () => {
                     .then(() => assert.fail())
                     .catch(err => {
                         assert.equal(err.message, 'Failed to start a event caused by "Failed to start"');
-                        assert.equal(err.statusCode, undefined);
+                        assert.equal(err.statusCode, 500);
                     });
             });
 
@@ -2939,7 +2939,7 @@ describe('startHookEvent test', () => {
                     .then(() => assert.fail())
                     .catch(err => {
                         assert.equal(err.message, 'Failed to start a event caused by "Failed to create event"');
-                        assert.equal(err.statusCode, undefined);
+                        assert.equal(err.statusCode, 500);
                     });
             });
 

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1714,11 +1714,17 @@ describe('startHookEvent test', () => {
         });
 
         it('throws error when failed', () => {
-            eventFactoryMock.create.rejects(new Error('Failed to start'));
+            const error = new Error('Failed to start');
+
+            error.statusCode = 500;
+            eventFactoryMock.create.rejects(error);
 
             return startHookEvent(request, responseHandler, parsed)
                 .then(() => assert.fail())
-                .catch(err => assert.equal(err.message, 'Failed to start any events'));
+                .catch(err => {
+                    assert.equal(err.message, 'Failed to start a event caused by "Failed to start"');
+                    assert.equal(err.statusCode, 500);
+                });
         });
     });
 
@@ -2117,11 +2123,17 @@ describe('startHookEvent test', () => {
             });
 
             it('throws error when failed', () => {
-                eventFactoryMock.create.rejects(new Error('Failed to start'));
+                const error = new Error('Failed to start');
+
+                error.statusCode = 500;
+                eventFactoryMock.create.rejects(error);
 
                 return startHookEvent(request, responseHandler, parsed)
                     .then(() => assert.fail())
-                    .catch(err => assert.equal(err.message, 'Failed to start any events'));
+                    .catch(err => {
+                        assert.equal(err.message, 'Failed to start a event caused by "Failed to start"');
+                        assert.equal(err.statusCode, 500);
+                    });
             });
 
             it('creates empty event if pr from fork by default', () => {
@@ -2706,11 +2718,17 @@ describe('startHookEvent test', () => {
             });
 
             it('throws error when failed', () => {
-                eventFactoryMock.create.rejects(new Error('Failed to create event'));
+                const error = new Error('Failed to create event');
+
+                error.statusCode = 500;
+                eventFactoryMock.create.rejects(error);
 
                 return startHookEvent(request, responseHandler, parsed)
                     .then(() => assert.fail())
-                    .catch(err => assert.equal(err.message, 'Failed to start any events'));
+                    .catch(err => {
+                        assert.equal(err.message, 'Failed to start a event caused by "Failed to create event"');
+                        assert.equal(err.statusCode, 500);
+                    });
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If a user specifies a non-existent buildcluster for a job, models will return an error, but the API will return 500 because no status code is specified.

Also, even though models returns a detailed error, it does not output the error to the webhook, so the user cannot determine the cause of the error by looking at the webhook response.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Outputs a detailed error log to the webhook response
In addition, the status code set in the event of an error is specified in the webhook response.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Related: https://github.com/screwdriver-cd/models/pull/636

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
