### PR TITLE
fix(3181): virtual job is not triggered by webhook

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -671,20 +671,26 @@ async function pullRequestOpened(options, request, h) {
         const hasBuildEvents = events.filter(e => e.builds !== null);
 
         for (const event of hasBuildEvents) {
-            const virtualJobBuilds = event.builds.filter(b => b.status === 'CREATED');
+            const createdBuilds = event.builds.filter(b => b.status === 'CREATED');
 
-            for (const build of virtualJobBuilds) {
-                await updateBuildAndTriggerDownstreamJobs(
-                    {
-                        status: Status.SUCCESS,
-                        statusMessage: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage,
-                        statusMessageType: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
-                    },
-                    build,
-                    request.server,
-                    username,
-                    scmContext
-                );
+            for (const build of createdBuilds) {
+                const job = await build.job;
+                const { annotations } = job.permutations[0];
+                const isVirtualJob = annotations ? annotations['screwdriver.cd/virtualJob'] === true : false;
+
+                if (isVirtualJob) {
+                    await updateBuildAndTriggerDownstreamJobs(
+                        {
+                            status: Status.SUCCESS,
+                            statusMessage: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage,
+                            statusMessageType: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+                        },
+                        build,
+                        request.server,
+                        username,
+                        scmContext
+                    );
+                }
             }
 
             request.log(['webhook', hookId, event.id], `Event ${event.id} started`);
@@ -771,20 +777,26 @@ async function pullRequestSync(options, request, h) {
         const hasBuildEvents = events.filter(e => e.builds !== null);
 
         for (const event of hasBuildEvents) {
-            const virtualJobBuilds = event.builds.filter(b => b.status === 'CREATED');
+            const createdBuilds = event.builds.filter(b => b.status === 'CREATED');
 
-            for (const build of virtualJobBuilds) {
-                await updateBuildAndTriggerDownstreamJobs(
-                    {
-                        status: Status.SUCCESS,
-                        statusMessage: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage,
-                        statusMessageType: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
-                    },
-                    build,
-                    request.server,
-                    username,
-                    scmContext
-                );
+            for (const build of createdBuilds) {
+                const job = await build.job;
+                const { annotations } = job.permutations[0];
+                const isVirtualJob = annotations ? annotations['screwdriver.cd/virtualJob'] === true : false;
+
+                if (isVirtualJob) {
+                    await updateBuildAndTriggerDownstreamJobs(
+                        {
+                            status: Status.SUCCESS,
+                            statusMessage: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage,
+                            statusMessageType: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+                        },
+                        build,
+                        request.server,
+                        username,
+                        scmContext
+                    );
+                }
             }
 
             request.log(['webhook', hookId, event.id], `Event ${event.id} started`);
@@ -1205,20 +1217,26 @@ async function pushEvent(request, h, parsed, skipMessage, token) {
         }
 
         for (const event of hasBuildEvents) {
-            const virtualJobBuilds = event.builds.filter(b => b.status === 'CREATED');
+            const createdBuilds = event.builds.filter(b => b.status === 'CREATED');
 
-            for (const build of virtualJobBuilds) {
-                await updateBuildAndTriggerDownstreamJobs(
-                    {
-                        status: Status.SUCCESS,
-                        statusMessage: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage,
-                        statusMessageType: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
-                    },
-                    build,
-                    request.server,
-                    username,
-                    scmContext
-                );
+            for (const build of createdBuilds) {
+                const job = await build.job;
+                const { annotations } = job.permutations[0];
+                const isVirtualJob = annotations ? annotations['screwdriver.cd/virtualJob'] === true : false;
+
+                if (isVirtualJob) {
+                    await updateBuildAndTriggerDownstreamJobs(
+                        {
+                            status: Status.SUCCESS,
+                            statusMessage: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage,
+                            statusMessageType: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+                        },
+                        build,
+                        request.server,
+                        username,
+                        scmContext
+                    );
+                }
             }
 
             request.log(['webhook', hookId, event.id], `Event ${event.id} started`);

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -276,6 +276,18 @@ describe('startHookEvent test', () => {
     const prRef = 'pull/1/merge';
     const scmDisplayName = 'github';
     const changedFiles = ['README.md'];
+    const nonVirtualJobMock = {
+        permutations: [{}]
+    };
+    const virtualJobMock = {
+        permutations: [
+            {
+                annotations: {
+                    'screwdriver.cd/virtualJob': true
+                }
+            }
+        ]
+    };
     let jobFactoryMock;
     let buildFactoryMock;
     let pipelineFactoryMock;
@@ -1145,7 +1157,11 @@ describe('startHookEvent test', () => {
             }));
 
         it('returns 201 on success with virtual job', () => {
-            eventMock.builds = [{ status: 'CREATED' }];
+            eventMock.builds = [
+                { status: 'CREATED', job: nonVirtualJobMock },
+                { status: 'CREATED', job: virtualJobMock },
+                { status: 'QUEUED' }
+            ];
 
             return startHookEvent(request, responseHandler, parsed).then(reply => {
                 assert.calledOnce(updateBuildAndTriggerDownstreamJobsMock);
@@ -1956,7 +1972,11 @@ describe('startHookEvent test', () => {
                 }));
 
             it('returns 201 on success with virtual job', () => {
-                eventMock.builds = [{ status: 'CREATED' }];
+                eventMock.builds = [
+                    { status: 'CREATED', job: nonVirtualJobMock },
+                    { status: 'CREATED', job: virtualJobMock },
+                    { status: 'QUEUED' }
+                ];
 
                 return startHookEvent(request, responseHandler, parsed).then(reply => {
                     assert.calledOnce(updateBuildAndTriggerDownstreamJobsMock);
@@ -2614,7 +2634,11 @@ describe('startHookEvent test', () => {
                 }));
 
             it('returns 201 on success with virtual job', () => {
-                eventMock.builds = [{ status: 'CREATED' }];
+                eventMock.builds = [
+                    { status: 'CREATED', job: nonVirtualJobMock },
+                    { status: 'CREATED', job: virtualJobMock },
+                    { status: 'QUEUED' }
+                ];
 
                 return startHookEvent(request, responseHandler, parsed).then(reply => {
                     assert.calledOnce(updateBuildAndTriggerDownstreamJobsMock);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Virtual job builds are not triggered directly by webhook.

```yaml
shared:
  image: node:20

jobs:
  main:
    requires: [ ~commit, ~pr ]
    steps:
      - echo: echo 'test'
    annotations:
      screwdriver.cd/virtualJob: true
  foo:
    requires: [ main ]
    steps:
      - echo: echo 'test'
```

After https://github.com/screwdriver-cd/models/pull/635, the virtual job builds are not triggered in `eventFactory`, so we should trigger them other place.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Trigger the virtual job builds in webhook process.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue
- https://github.com/screwdriver-cd/screwdriver/issues/3181

PR
- https://github.com/screwdriver-cd/models/pull/635
- https://github.com/screwdriver-cd/screwdriver/pull/3252

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
