### PR TITLE
fix(3181): Virtual builds not completed when triggered by webhook

### DIFF
--- a/plugins/events/helper/createEvent.js
+++ b/plugins/events/helper/createEvent.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { updateBuildAndTriggerDownstreamJobs } = require('../../builds/helper/updateBuild');
+const { Status, BUILD_STATUS_MESSAGES } = require('../../builds/triggers/helpers');
+
+/**
+ * @typedef {import('screwdriver-models/lib/event')} Event
+ */
+
+/**
+ * Create a new event.
+ * Updates the status of all the virtual builds at the beginning of the event workflow to "SUCCESS"
+ * and trigger their downstream jobs.
+ *
+ * @method createEvent
+ * @param   {Object}    config
+ * @param   {String}    config.username
+ * @param   {Object}    config.scmContext
+ * @param   {Object}    server
+ * @returns {Promise<Event>} Newly created event
+ */
+async function createEvent(config, server) {
+    const { eventFactory } = server.app;
+    const { username, scmContext } = config;
+    const event = await eventFactory.create(config);
+
+    if (event.builds) {
+        const virtualJobBuilds = event.builds.filter(b => b.status === 'CREATED');
+
+        for (const build of virtualJobBuilds) {
+            await updateBuildAndTriggerDownstreamJobs(
+                {
+                    status: Status.SUCCESS,
+                    statusMessage: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage,
+                    statusMessageType: BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType
+                },
+                build,
+                server,
+                username,
+                scmContext
+            );
+        }
+    }
+
+    return event;
+}
+
+module.exports = {
+    createEvent
+};

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2955,7 +2955,8 @@ describe('pipeline plugin test', () => {
             pipelineFactoryMock.list.resolves(getPipelineMocks(testPipelines));
         });
 
-        it('returns 201 for starting all child pipelines', () =>
+        it('returns 201 for starting all child pipelines', () => {
+            eventFactoryMock.create.resolves({});
             server.inject(options).then(reply => {
                 assert.calledWith(pipelineFactoryMock.list, {
                     params: {
@@ -2966,7 +2967,8 @@ describe('pipeline plugin test', () => {
                 assert.calledThrice(pipelineFactoryMock.scm.getCommitSha);
                 assert.calledThrice(eventFactoryMock.create);
                 assert.equal(reply.statusCode, 201);
-            }));
+            });
+        });
 
         it('returns 403 when user does not have admin permission', () => {
             const error = {


### PR DESCRIPTION
## Context

Changes made in the PR https://github.com/screwdriver-cd/screwdriver/pull/3252 introduced a regression. Virtual job builds at the beginning of the event workflow never got marked as completed (remain in `CREATED` state) when the event is created by SCM webhook. 

## Objective

Mark virtual job builds at the beginning of the event workflow for all the scenarios.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3181

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
