### PR TITLE
fix(3259): Add a function to prevent duplicate builds.

### DIFF
--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1433,6 +1433,32 @@ describe('build plugin test', () => {
                 });
             });
 
+            it('does not allow update status "RUNNING" to "RUNNING"', () => {
+                const status = 'RUNNING';
+                const options = {
+                    method: 'PUT',
+                    url: `/builds/${id}`,
+                    auth: {
+                        credentials: {
+                            username: `${id}a`,
+                            scope: ['build']
+                        },
+                        strategy: ['token']
+                    },
+                    payload: {
+                        status
+                    }
+                };
+
+                buildMock.status = 'RUNNING';
+
+                return server.inject(options).then(reply => {
+                    assert.equal(reply.statusCode, 403);
+                    assert.notCalled(buildFactoryMock.get);
+                    assert.notCalled(buildMock.update);
+                });
+            });
+
             it('update status for non-UNSTABLE builds', () => {
                 testBuild.status = 'BLOCKED';
                 testBuild.statusMessage = 'blocked';


### PR DESCRIPTION
## Context
A build pod with the same build ID may be launched twice.
See [this issue](https://github.com/screwdriver-cd/screwdriver/issues/3259) for detail.

## Objective
Do not allow updating the build status to RUNNING if a build with the same ID is already running.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3259

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
