### PR TITLE
fix: update pipeline template version to latest [5]

### DIFF
--- a/features/pipeline-templates.feature
+++ b/features/pipeline-templates.feature
@@ -96,26 +96,26 @@ Feature: Pipeline Templates
             | test-distrusted-pipeline-template | distrusted | publish-distrusted |
 
     Scenario: Use pipeline template
-        Given a "third" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
+        Given a "third" pipeline using a "test-pipeline-template" @ "latest" pipeline template
         When user starts the job that uses pipeline template
         And the pipeline executes what is specified in the pipeline template
 
     Scenario: Pipeline shared config takes precedence over template config
-        Given a "fourth" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
+        Given a "fourth" pipeline using a "test-pipeline-template" @ "latest" pipeline template
         And user defined shared settings
         And the pipeline template has overwritten shared settings
         When user starts the job that uses pipeline template
         Then job settings are the template command
 
     Scenario: Pipeline exists job config takes precedence over template config
-        Given a "fifth" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
+        Given a "fifth" pipeline using a "test-pipeline-template" @ "latest" pipeline template
         And user defined exists jobs settings
         And the pipeline template has overwritten jobs settings
         When user starts the job that uses pipeline template
         Then job settings are the user command
 
     Scenario: Pipeline user defined job config takes precedence over template config
-        Given a "sixth" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
+        Given a "sixth" pipeline using a "test-pipeline-template" @ "latest" pipeline template
         And user defined additional jobs settings
         And the pipeline template has additional jobs settings
         When user starts the additional job that uses pipeline template

--- a/features/pipeline-templates.feature
+++ b/features/pipeline-templates.feature
@@ -96,26 +96,26 @@ Feature: Pipeline Templates
             | test-distrusted-pipeline-template | distrusted | publish-distrusted |
 
     Scenario: Use pipeline template
-        Given a "third" pipeline using a "test-pipeline-template" @ "1.0.0" pipeline template
+        Given a "third" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
         When user starts the job that uses pipeline template
         And the pipeline executes what is specified in the pipeline template
 
     Scenario: Pipeline shared config takes precedence over template config
-        Given a "fourth" pipeline using a "test-pipeline-template" @ "1.0.0" pipeline template
+        Given a "fourth" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
         And user defined shared settings
         And the pipeline template has overwritten shared settings
         When user starts the job that uses pipeline template
         Then job settings are the template command
 
     Scenario: Pipeline exists job config takes precedence over template config
-        Given a "fifth" pipeline using a "test-pipeline-template" @ "1.0.0" pipeline template
+        Given a "fifth" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
         And user defined exists jobs settings
         And the pipeline template has overwritten jobs settings
         When user starts the job that uses pipeline template
         Then job settings are the user command
 
     Scenario: Pipeline user defined job config takes precedence over template config
-        Given a "sixth" pipeline using a "test-pipeline-template" @ "1.0.0" pipeline template
+        Given a "sixth" pipeline using a "test-pipeline-template" @ "1.0.1" pipeline template
         And user defined additional jobs settings
         And the pipeline template has additional jobs settings
         When user starts the additional job that uses pipeline template


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix #3265 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Update the pipeline template version to latest because the 1.0.0 template is corrupted.
Specifically, environment variables and images are empty on the DB.

Also, the versions of prod and beta do not match, so I have set it to “latest”.

https://cd.screwdriver.cd/templates/pipeline/screwdriver-cd-test/test-pipeline-template/1.0.1
https://beta.cd.screwdriver.cd/templates/pipeline/screwdriver-cd-test/test-pipeline-template/1.0.2

The following PRs must be merged first
- https://github.com/screwdriver-cd-test/functional-pipeline-template/pull/5
- https://github.com/screwdriver-cd-test/functional-pipeline-template/pull/6
- https://github.com/screwdriver-cd-test/functional-pipeline-template/pull/7
- https://github.com/screwdriver-cd-test/functional-pipeline-template/pull/8
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
