### PR TITLE
feat(3274): add not equal filter for pipeline events creator

### DIFF
--- a/plugins/pipelines/listEvents.js
+++ b/plugins/pipelines/listEvents.js
@@ -73,7 +73,19 @@ module.exports = () => ({
                         config.search = { field: ['commit'], keyword: `%name":"${author}%` };
                     } else if (creator) {
                         // searches name and username
-                        config.search = { field: ['creator'], keyword: `%name":"${creator}%` };
+                        let inverse = false;
+                        let creatorName = creator;
+
+                        if (creator.startsWith('ne:')) {
+                            inverse = true;
+                            creatorName = creator.substring(3); // Remove 'ne:' prefix
+                        }
+
+                        config.search = {
+                            field: ['creator'],
+                            keyword: `%name":"${creatorName}%`,
+                            inverse
+                        };
                     }
 
                     if (groupEventId) {
@@ -107,7 +119,12 @@ module.exports = () => ({
                         sha: shaSchema,
                         message: joi.string().label('Commit message').example('fix: Typo'),
                         author: joi.string().label('Author Name').example('Dao Lam'),
-                        creator: joi.string().label('Creator Name').example('Dao Lam'),
+                        creator: joi
+                            .string()
+                            .label('Creator Name')
+                            .description('Creator Name; optionally use "ne:" prefix to exclude creator')
+                            .example('Dao Lam')
+                            .example('ne:Dao Lam'),
                         id: queryIdSchema,
                         groupEventId: pipelineIdSchema,
                         search: joi.forbidden(), // we don't support search for Pipeline list events

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1595,7 +1595,27 @@ describe('pipeline plugin test', () => {
                     params: { type: 'pipeline' },
                     search: {
                         field: ['creator'],
-                        keyword: '%name":"Dao%'
+                        keyword: '%name":"Dao%',
+                        inverse: false
+                    },
+                    sort: 'descending'
+                });
+                assert.deepEqual(reply.result, testEvents);
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
+        it('returns 200 for getting events with commit creator not sd:scheduler', () => {
+            options.url = `/pipelines/${id}/events?creator=ne:sd:scheduler`;
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.getEvents);
+                assert.calledWith(pipelineMock.getEvents, {
+                    params: { type: 'pipeline' },
+                    search: {
+                        field: ['creator'],
+                        keyword: '%name":"sd:scheduler%',
+                        inverse: true
                     },
                     sort: 'descending'
                 });


### PR DESCRIPTION
## Context

The pipeline [events list API currently supports filtering to include events created by a specific user](https://github.com/screwdriver-cd/screwdriver/blob/90e55040f62c52a31947ad6214b3d6deb05bae0f/plugins/pipelines/listEvents.js#L74-L77), but it does not provide an option to exclude events created by a user.

## Objective

This change introduces the "ne:${username}" syntax, allowing the exclusion of events created by a specific user.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3274

## License

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
