### PR TITLE
fix: test of remote join acceleration by virtual job [3]

### DIFF
--- a/features/step_definitions/trigger.js
+++ b/features/step_definitions/trigger.js
@@ -326,7 +326,15 @@ Then(
         const parentJob = parentPipeline.jobs.find(j => j.name === parentJobName);
         const parentBuild = parentBuilds.find(b => b.jobId === parentJob.id);
 
-        Assert.oneOf(parentBuild.id, joinBuild.parentBuildId);
+        // Before success, parentBuildId may be incomplete. Therefore, get it here.
+        const succeededJoinBuild = await this.waitForBuild(joinBuild.id).then(resp => {
+            Assert.equal(resp.statusCode, 200);
+            Assert.equal(resp.body.status, 'SUCCESS');
+
+            return resp.body;
+        });
+
+        Assert.oneOf(parentBuild.id, succeededJoinBuild.parentBuildId);
 
         const externalPipeline = this.pipelines[externalBranchName];
         const externalBuilds = await sdapi.findEventBuilds({
@@ -340,7 +348,7 @@ Then(
         const externalJob = externalPipeline.jobs.find(j => j.name === externalJobName);
         const externalBuild = externalBuilds.find(b => b.jobId === externalJob.id);
 
-        Assert.oneOf(externalBuild.id, joinBuild.parentBuildId);
+        Assert.oneOf(externalBuild.id, succeededJoinBuild.parentBuildId);
     }
 );
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Making a remote join job a virtual job could cause the test to fail in functional test.

## Objective
Allow virtual jobs to be used in functional test remote join jobs.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
