### PR TITLE
fix: handle virtual job properly in remote triggers

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -129,7 +129,7 @@ async function triggerNextJobs(config, app) {
                 nextBuild = await andTrigger.execute(nextJob, parentBuilds, joinListNames, nextJobStageName);
             }
 
-            if (isVirtualJob(nextJob) && nextBuild !== null && nextBuild.status === Status.SUCCESS) {
+            if (isVirtualJob(nextJob) && nextBuild && nextBuild.status === Status.SUCCESS) {
                 downstreamOfNextJobsToBeProcessed.push({
                     build: nextBuild,
                     event: currentEvent,
@@ -315,7 +315,7 @@ async function triggerNextJobs(config, app) {
                         );
                     }
 
-                    if (isVirtualJob(nextJob) && nextBuild !== null && nextBuild.status === Status.SUCCESS) {
+                    if (isVirtualJob(nextJob) && nextBuild && nextBuild.status === Status.SUCCESS) {
                         downstreamOfNextJobsToBeProcessed.push({
                             build: nextBuild,
                             event: currentEvent,

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -129,7 +129,7 @@ async function triggerNextJobs(config, app) {
                 nextBuild = await andTrigger.execute(nextJob, parentBuilds, joinListNames, nextJobStageName);
             }
 
-            if (isVirtualJob(nextJob) && nextBuild.status === Status.SUCCESS) {
+            if (isVirtualJob(nextJob) && nextBuild !== null && nextBuild.status === Status.SUCCESS) {
                 downstreamOfNextJobsToBeProcessed.push({
                     build: nextBuild,
                     event: currentEvent,
@@ -315,7 +315,7 @@ async function triggerNextJobs(config, app) {
                         );
                     }
 
-                    if (isVirtualJob(nextJob) && nextBuild.status === Status.SUCCESS) {
+                    if (isVirtualJob(nextJob) && nextBuild !== null && nextBuild.status === Status.SUCCESS) {
                         downstreamOfNextJobsToBeProcessed.push({
                             build: nextBuild,
                             event: currentEvent,

--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -39,7 +39,8 @@ const {
     getParallelBuilds,
     isStartFromMiddleOfCurrentStage,
     Status,
-    getSameParentEvents
+    getSameParentEvents,
+    isVirtualJob
 } = require('./triggers/helpers');
 const { getFullStageJobName } = require('../helper');
 
@@ -97,7 +98,7 @@ async function triggerNextJobs(config, app) {
 
     for (const [nextJobName, nextJobInfo] of Object.entries(currentPipelineNextJobs)) {
         const nextJob = await getJob(nextJobName, currentPipeline.id, jobFactory);
-        const { isVirtual: isNextJobVirtual, stageName: nextJobStageName } = nextJobInfo;
+        const { stageName: nextJobStageName } = nextJobInfo;
         const resource = `pipeline:${currentPipeline.id}:groupEvent:${currentEvent.groupEventId}`;
         let lock;
         let nextBuild;
@@ -123,24 +124,12 @@ async function triggerNextJobs(config, app) {
                 isOrTrigger(currentEvent.workflowGraph, originalCurrentJobName, trimJobName(nextJobName)) ||
                 isStartFromMiddleOfCurrentStage(currentJob.name, currentEvent.startFrom, currentEvent.workflowGraph)
             ) {
-                nextBuild = await orTrigger.execute(
-                    currentEvent,
-                    currentPipeline.id,
-                    nextJob,
-                    parentBuilds,
-                    isNextJobVirtual
-                );
+                nextBuild = await orTrigger.execute(currentEvent, currentPipeline.id, nextJob, parentBuilds);
             } else {
-                nextBuild = await andTrigger.execute(
-                    nextJob,
-                    parentBuilds,
-                    joinListNames,
-                    isNextJobVirtual,
-                    nextJobStageName
-                );
+                nextBuild = await andTrigger.execute(nextJob, parentBuilds, joinListNames, nextJobStageName);
             }
 
-            if (isNextJobVirtual && nextBuild.status === Status.SUCCESS) {
+            if (isVirtualJob(nextJob) && nextBuild.status === Status.SUCCESS) {
                 downstreamOfNextJobsToBeProcessed.push({
                     build: nextBuild,
                     event: currentEvent,
@@ -285,7 +274,7 @@ async function triggerNextJobs(config, app) {
         if (externalEvent) {
             for (const [nextJobName, nextJobInfo] of Object.entries(joinedPipeline.jobs)) {
                 const nextJob = await getJob(nextJobName, joinedPipelineId, jobFactory);
-                const { isVirtual: isNextJobVirtual, stageName: nextJobStageName } = nextJobInfo;
+                const { stageName: nextJobStageName } = nextJobInfo;
 
                 const { parentBuilds } = parseJobInfo({
                     joinObj: joinedPipeline.jobs,
@@ -306,8 +295,7 @@ async function triggerNextJobs(config, app) {
                             externalEvent,
                             externalEvent.pipelineId,
                             nextJob,
-                            parentBuilds,
-                            isNextJobVirtual
+                            parentBuilds
                         );
                     } else {
                         // Re get join list when first time remote trigger since external event was empty and cannot get workflow graph then
@@ -323,12 +311,11 @@ async function triggerNextJobs(config, app) {
                             parentBuilds,
                             groupEventBuilds,
                             joinListNames,
-                            isNextJobVirtual,
                             nextJobStageName
                         );
                     }
 
-                    if (isNextJobVirtual && nextBuild.status === Status.SUCCESS) {
+                    if (isVirtualJob(nextJob) && nextBuild.status === Status.SUCCESS) {
                         downstreamOfNextJobsToBeProcessed.push({
                             build: nextBuild,
                             event: currentEvent,

--- a/plugins/builds/triggers/joinBase.js
+++ b/plugins/builds/triggers/joinBase.js
@@ -43,7 +43,6 @@ class JoinBase {
      * @param {import('./helpers').ParentBuilds} parentBuilds
      * @param {String} parentBuildId
      * @param {String[]} joinListNames
-     * @param {Boolean} isNextJobVirtual
      * @param {String} nextJobStageName
      * @returns {Promise<Build[]|null>}
      */
@@ -55,7 +54,6 @@ class JoinBase {
         parentBuilds,
         parentBuildId,
         joinListNames,
-        isNextJobVirtual,
         nextJobStageName
     }) {
         let newBuild;
@@ -104,7 +102,6 @@ class JoinBase {
             newBuild,
             job: nextJob,
             pipelineId,
-            isVirtualJob: isNextJobVirtual,
             stageName: nextJobStageName,
             event
         });

--- a/test/plugins/data/trigger/virtual-jobs-downstream.yaml
+++ b/test/plugins/data/trigger/virtual-jobs-downstream.yaml
@@ -1,0 +1,14 @@
+shared:
+    image: node:20
+    steps:
+        - test: echo 'test'
+
+jobs:
+    b:
+        requires: [ ~sd@1:a ]
+        annotations:
+            screwdriver.cd/virtualJob: true
+    c:
+        requires: [ sd@1:a ]
+        annotations:
+            screwdriver.cd/virtualJob: true

--- a/test/plugins/data/trigger/virtual-jobs-upstream.yaml
+++ b/test/plugins/data/trigger/virtual-jobs-upstream.yaml
@@ -1,0 +1,18 @@
+shared:
+    image: node:20
+    steps:
+        - test: echo 'test'
+
+jobs:
+    hub:
+        requires: [ ~commit, ~pr ]
+    a:
+        requires: [ hub ]
+    d:
+        requires: [ ~sd@2:b ]
+        annotations:
+            screwdriver.cd/virtualJob: true
+    e:
+        requires: [ sd@2:b, sd@2:c ]
+        annotations:
+            screwdriver.cd/virtualJob: true

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -58,7 +58,6 @@ describe('createJoinObject function', () => {
                             { id: 12, name: 'jobB' }
                         ],
                         isExternal: false,
-                        isVirtual: false,
                         stageName: null
                     }
                 }
@@ -125,7 +124,6 @@ describe('createJoinObject function', () => {
                             { id: 23, name: 'sd@2:jobC' }
                         ],
                         isExternal: true,
-                        isVirtual: false,
                         stageName: null
                     }
                 }
@@ -162,53 +160,8 @@ describe('createJoinObject function', () => {
         const expected = {
             1: {
                 jobs: {
-                    jobB: { id: 12, join: [], isExternal: false, isVirtual: false, stageName: null },
-                    jobC: { id: 13, join: [], isExternal: false, isVirtual: false, stageName: null }
-                }
-            }
-        };
-
-        assert.deepEqual(result, expected);
-    });
-
-    it('should create join object for virtual jobs', async () => {
-        const nextJobNames = ['jobC'];
-        const current = {
-            build: { id: 1 },
-            event: {
-                workflowGraph: {
-                    nodes: [
-                        { name: '~commit' },
-                        { name: 'jobA', id: 11 },
-                        { name: 'jobB', id: 12 },
-                        { name: 'jobC', id: 13, virtual: true }
-                    ],
-                    edges: [
-                        { src: '~commit', dest: 'jobA' },
-                        { src: '~commit', dest: 'jobB' },
-                        { src: 'jobA', dest: 'jobC', join: true },
-                        { src: 'jobB', dest: 'jobC', join: true }
-                    ]
-                }
-            },
-            pipeline: { id: 1 }
-        };
-
-        const result = await createJoinObject(nextJobNames, current, eventFactoryMock);
-
-        const expected = {
-            1: {
-                jobs: {
-                    jobC: {
-                        id: 13,
-                        join: [
-                            { id: 11, name: 'jobA' },
-                            { id: 12, name: 'jobB' }
-                        ],
-                        isExternal: false,
-                        isVirtual: true,
-                        stageName: null
-                    }
+                    jobB: { id: 12, join: [], isExternal: false, stageName: null },
+                    jobC: { id: 13, join: [], isExternal: false, stageName: null }
                 }
             }
         };
@@ -226,7 +179,7 @@ describe('createJoinObject function', () => {
                         { name: '~commit' },
                         { name: 'jobA', id: 11 },
                         { name: 'jobB', id: 12 },
-                        { name: 'jobC', id: 13, virtual: true, stageName: 'red' }
+                        { name: 'jobC', id: 13, stageName: 'red' }
                     ],
                     edges: [
                         { src: '~commit', dest: 'jobA' },
@@ -251,7 +204,6 @@ describe('createJoinObject function', () => {
                             { id: 12, name: 'jobB' }
                         ],
                         isExternal: false,
-                        isVirtual: true,
                         stageName: 'red'
                     }
                 }
@@ -1338,12 +1290,13 @@ describe('handleNewBuild function', () => {
     });
 
     it('should skip the execution of virtual job and mark the build as successful', async () => {
+        jobMock.permutations[0].annotations = { 'screwdriver.cd/virtualJob': true };
+
         await handleNewBuild({
             done: true,
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            isVirtualJob: true,
             event: eventMock
         });
 
@@ -1355,6 +1308,7 @@ describe('handleNewBuild function', () => {
     });
 
     it('should skip the execution of virtual job when freeze windows is empty', async () => {
+        jobMock.permutations[0].annotations = { 'screwdriver.cd/virtualJob': true };
         jobMock.permutations[0].freezeWindows = [];
 
         await handleNewBuild({
@@ -1362,7 +1316,6 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            isVirtualJob: true,
             event: eventMock
         });
 
@@ -1372,6 +1325,7 @@ describe('handleNewBuild function', () => {
     });
 
     it('should add virtual job to the execution queue when the job has freeze windows', async () => {
+        jobMock.permutations[0].annotations = { 'screwdriver.cd/virtualJob': true };
         jobMock.permutations[0].freezeWindows = ['* 10-21 ? * *'];
 
         await handleNewBuild({
@@ -1379,7 +1333,6 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            isVirtualJob: true,
             event: eventMock
         });
 

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -35,8 +35,8 @@ describe('trigger tests', () => {
 
     const loggerMock = {
         info: sinon.stub(),
-        error: sinon.stub(),
-        warn: sinon.stub()
+        warn: sinon.stub(),
+        error: (msg, err) => console.error(msg, err)
     };
 
     beforeEach(async () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Handling for virtual jobs was added by https://github.com/screwdriver-cd/screwdriver/pull/3131 .
However, the virtual jobs are executed in remote triggers.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

In remote trigger/join, [`isVirtual`](https://github.com/screwdriver-cd/screwdriver/blob/5a74c24e232a95a12d28e0ae7c4c3a5b25e6f872/plugins/builds/triggers/helpers.js#L905) is always `false` since the nodes of remote trigger does not have `virtual` property (ref. [here](https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/pipeline.js#L1147-L1151)).

This PR gets the virtual info directly from the `job.annotations`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
