### PR TITLE
feat(3284): add scmUri param for search pipelines [1]

### DIFF
--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -634,6 +634,39 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 and all pipelines with matched scmUri', () => {
+            options.url = '/pipelines?scmUri=github.com:123:main';
+            pipelineFactoryMock.list
+                .withArgs({
+                    params: {
+                        scmContext: 'github:github.com'
+                    },
+                    sort: 'descending',
+                    search: {
+                        field: 'scmUri',
+                        keyword: 'github.com:123:%'
+                    }
+                })
+                .resolves(getPipelineMocks(testPipelines));
+            pipelineFactoryMock.list
+                .withArgs({
+                    params: {
+                        scmContext: 'gitlab:mygitlab'
+                    },
+                    sort: 'descending',
+                    search: {
+                        field: 'scmUri',
+                        keyword: 'github.com:123:%'
+                    }
+                })
+                .resolves([]);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(reply.result, testPipelines);
+            });
+        });
+
         it('returns 200 and all pipelines with matched configPipelineId', () => {
             options.url = '/pipelines?page=1&count=3&configPipelineId=123';
             pipelineFactoryMock.list


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We are using `name` search to get sibling pipelines.
But it is not better.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Add the query `scmUri` for search pipelines to get sibling pipelines.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue: https://github.com/screwdriver-cd/screwdriver/issues/3284

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
