### PR TITLE
fix(3287): Inherit the metadata of the job immediately before virtual job

### DIFF
--- a/features/metadata.feature
+++ b/features/metadata.feature
@@ -95,3 +95,22 @@ Feature: Metadata
         And the build succeeded
         And the "BAR" job is started
         Then in the build, the value of "foo" is either "foobar" or "barbaz" from metadata
+
+    Scenario: Inherit metadata by or triggered virtual job based on priority
+        Given an existing pipeline on branch "virtual-job-or"
+        And start the "hub" job
+        Then the "virtual" job is started for virtual job test
+        And the build succeeded
+        And { "foo": "success" } metadata in build
+        Then the "target" job is started for virtual job test
+        And the build succeeded
+
+    Scenario: Inherit metadata by and triggered virtual job based on priority
+        Given an existing pipeline on branch "virtual-job-and"
+        And start the "hub" job
+        Then the "virtual" job is started for virtual job test
+        And the build succeeded
+        And { "foo": { "bar": "success" } } metadata in build
+        And { "foo": { "baz": "success" } } metadata in build
+        Then the "target" job is started for virtual job test
+        And the build succeeded

--- a/plugins/builds/triggers/joinBase.js
+++ b/plugins/builds/triggers/joinBase.js
@@ -103,7 +103,8 @@ class JoinBase {
             job: nextJob,
             pipelineId,
             stageName: nextJobStageName,
-            event
+            event,
+            currentBuild: this.currentBuild
         });
     }
 }

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const merge = require('lodash.mergewith');
 const { createInternalBuild, Status, BUILD_STATUS_MESSAGES, isVirtualJob, hasFreezeWindows } = require('./helpers');
 
 /**
@@ -60,6 +61,7 @@ class OrBase {
                 nextBuild.status = Status.SUCCESS;
                 nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
                 nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
+                nextBuild.meta = merge({}, nextBuild.meta, this.currentBuild.meta);
 
                 return nextBuild.update();
             }
@@ -91,6 +93,7 @@ class OrBase {
             nextBuild.status = Status.SUCCESS;
             nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
             nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
+            nextBuild.meta = merge({}, nextBuild.meta, this.currentBuild.meta);
 
             await nextBuild.update();
         }

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -1177,6 +1177,7 @@ describe('handleNewBuild function', () => {
     const handleNewBuild = RewiredTriggerHelper.__get__('handleNewBuild');
 
     let newBuildMock;
+    let currentBuildMock;
     let jobMock;
     let eventMock;
 
@@ -1184,6 +1185,15 @@ describe('handleNewBuild function', () => {
         newBuildMock = {
             id: 123,
             status: Status.CREATED,
+            eventId: 456,
+            update: sinon.stub().resolves(),
+            start: sinon.stub().resolvesThis(),
+            remove: sinon.stub().resolves()
+        };
+
+        currentBuildMock = {
+            id: 234,
+            status: Status.SUCCESS,
             eventId: 456,
             update: sinon.stub().resolves(),
             start: sinon.stub().resolvesThis(),
@@ -1211,7 +1221,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.isNull(result);
@@ -1228,7 +1239,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.strictEqual(result.status, Status.QUEUED);
@@ -1245,7 +1257,8 @@ describe('handleNewBuild function', () => {
             job: jobMock,
             pipelineId: 1,
             stage: { name: 'deploy' },
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.isNull(result);
@@ -1265,7 +1278,8 @@ describe('handleNewBuild function', () => {
             job: jobMock,
             pipelineId: 1,
             stageName: 'deploy',
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.isNull(result);
@@ -1281,7 +1295,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.strictEqual(result.status, Status.QUEUED);
@@ -1297,7 +1312,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.SUCCESS);
@@ -1316,7 +1332,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.SUCCESS);
@@ -1333,7 +1350,8 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
-            event: eventMock
+            event: eventMock,
+            currentBuild: currentBuildMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.QUEUED);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

fix https://github.com/screwdriver-cd/screwdriver/issues/3287

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Enable the metadata of the job immediately before the virtual job to take precedence over the event metadata.

The following PRs need to be merged first because functest is being added.
- https://github.com/screwdriver-cd-test/functional-metadata/pull/6
- https://github.com/screwdriver-cd-test/functional-metadata/pull/7

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3287
https://github.com/screwdriver-cd/screwdriver/issues/3235
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
