### PR TITLE
feat(3292): New endpoint to update buildcluster of a pipeline

### DIFF
--- a/design/sd-build-cluster-selection.md
+++ b/design/sd-build-cluster-selection.md
@@ -74,8 +74,9 @@ graph TD
   click C "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/buildFactory.js#L221-L226"
   click D "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/buildFactory.js#L213"
   click E "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/buildFactory.js#L214"
+  click F "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/buildFactory.js#L215-L219"
   click H "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L245-L248"
-  click I "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L235-L237"
+  click J "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L235-L237"
   click L "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L239-L241"
   click M "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L259-L265"
 ```

--- a/design/sd-build-cluster-selection.md
+++ b/design/sd-build-cluster-selection.md
@@ -1,0 +1,43 @@
+### Build Cluster Selection
+
+```mermaid
+graph TD
+
+  A(Start) -->|Create| B[Pipeline Create]
+  B -->|Sync| C[Pipeline Sync]
+  C -->|Fetch Config| D[Get Config]
+
+  subgraph GH
+    E1@{ shape: lean-r, label: "SD YAML" }
+  end
+  E1 --> D
+
+  D --> E{Pipeline-level build cluster annotation?}
+  E -->|Yes| F[Store annotation]
+  E -->|No| F1[Get pipeline annotation]
+
+  subgraph Database
+    F1
+    F
+  end
+
+  F1 --> H{Pipeline has build cluster annotation?}
+  H -->|Yes| I[Use annotation] --> F
+  H -->|No| J[Derive build cluster] --> F
+  F --> Z@{ shape: stadium, label: "End" }
+
+  subgraph buildCluster Table in DB
+    K@{ shape: lean-r, label: "group" }
+    L@{ shape: lean-r, label: "weight" }
+  end
+
+  K --> J
+  L --> J
+
+  click B "https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/pipelines/create.js"
+  click C "https://github.com/screwdriver-cd/screwdriver/blob/5a74c24e232a95a12d28e0ae7c4c3a5b25e6f872/plugins/pipelines/create.js#L104"
+  click D "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/pipeline.js#L1009-L1021"
+  click I "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/pipeline.js#L1018-L1020"
+  click J "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L229-L293"
+
+```

--- a/design/sd-build-cluster-selection.md
+++ b/design/sd-build-cluster-selection.md
@@ -1,5 +1,7 @@
 ### Build Cluster Selection
 
+##### On pipeline creation
+
 ```mermaid
 graph TD
 
@@ -40,4 +42,40 @@ graph TD
   click I "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/pipeline.js#L1018-L1020"
   click J "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L229-L293"
 
+```
+
+##### On build creation
+
+```mermaid
+graph TD
+
+  A(Start) --> B[Build Create]
+  B --> C[Get build cluster]
+  subgraph input
+  D@{ shape: lean-r, label: "Job permutations" }
+  E@{ shape: lean-r, label: "Pipeline annotations" }
+  F@{ shape: lean-r, label: "Job provider" }
+  end
+  D --> C
+  E --> C
+  F --> C
+  C --> G{Is provider present?}
+  G -->|Yes| H[Derive build cluster based on provider]
+  H --> Z@{ shape: stadium, label: "Done" }
+  G -->|No| I{Is job annotation present?}
+  I --> |Yes| J[Use the build cluster from job annotation]
+  J --> Z
+  I --> |No| K{Is pipeline annotation present?}
+  K --> |Yes| L[Use the build cluster from pipeline annotation]
+  K --> |No| M[Derive randomly]
+  L --> Z
+  M --> Z
+
+  click C "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/buildFactory.js#L221-L226"
+  click D "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/buildFactory.js#L213"
+  click E "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/buildFactory.js#L214"
+  click H "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L245-L248"
+  click I "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L235-L237"
+  click L "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L239-L241"
+  click M "https://github.com/screwdriver-cd/models/blob/7eac5d79e11620793ab8936cf6e06971a2c04eea/lib/helper.js#L259-L265"
 ```

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -43,6 +43,7 @@ const removeTemplateRoute = require('./templates/remove');
 const removeTemplateTagRoute = require('./templates/removeTag');
 const removeTemplateVersionRoute = require('./templates/removeVersion');
 const updateTrustedRoute = require('./templates/updateTrusted');
+const updateBuildCluster = require('./updateBuildCluster');
 
 /**
  * Pipeline API Plugin
@@ -276,7 +277,8 @@ const pipelinesPlugin = {
             removeTemplateRoute(),
             removeTemplateTagRoute(),
             removeTemplateVersionRoute(),
-            updateTrustedRoute()
+            updateTrustedRoute(),
+            updateBuildCluster()
         ]);
     }
 };

--- a/plugins/pipelines/updateBuildCluster.js
+++ b/plugins/pipelines/updateBuildCluster.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
+const idSchema = schema.models.pipeline.base.extract('id');
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/pipelines/{id}/buildCluster',
+    options: {
+        description: 'Update the buildCluster of a pipeline',
+        notes: 'Update the buildCluster of a specific pipeline',
+        tags: ['api', 'pipelines'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        handler: async (request, h) => {
+            const buildClusterAnnotation = 'screwdriver.cd/buildCluster';
+            const payload = request.payload;
+
+            console.log("payload: ", payload);
+
+            const { id } = request.params;
+
+            console.log("id: ", id);
+
+            const { pipelineFactory, bannerFactory } = request.server.app;
+            const { scmContext, username, scmUserId } = request.auth.credentials;
+
+            // only SD cluster admins can update the buildCluster
+            const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
+            if (!adminDetails.isAdmin) {
+                throw boom.forbidden(
+                    `User ${adminDetails.userDisplayName} does not have Screwdriver administrative privileges to update the buildCluster`
+                );
+            }   
+
+            const pipeline = await pipelineFactory.get({ id });
+            // check if pipeline is null
+            if (!pipeline) {                
+                throw boom.notFound(`Pipeline ${id} does not exist`);
+            }
+
+            console.log("pipeline: ", pipeline);
+            const pipelineConfig = await pipeline.getConfiguration({});
+
+            // check if pipeline has buildCluster annotation
+            if (pipelineConfig.annotations?.[buildClusterAnnotation]) {
+                const scmUrl = pipeline.scmRepo.url;
+                throw boom.conflict(`Pipeline ${id} already has a buildCluster annotation set in the YAML configuration: check ${scmUrl}`);
+            }
+
+            // need to make sure that the buildCluster is a valid cluster
+
+            // update pipeline with buildCluster annotation
+            pipeline.annotations[buildClusterAnnotation] = payload[buildClusterAnnotation];
+            logger.info(
+                `[Audit] user ${username} updates ${buildClusterAnnotation} for pipelineID:${id} to ${payload[buildClusterAnnotation]}.`
+            );
+            const result = await pipeline.update();
+
+            // update pipeline
+            // const updatedPipeline = await oldPipeline.update();
+
+            // await updatedPipeline.addWebhooks(`${request.server.info.uri}/v4/webhooks`);
+
+            // const result = await updatedPipeline.sync();
+
+            return h.response(result.toJson()).code(200);
+        },
+        validate: {
+            params: joi.object({
+                id: idSchema
+            })
+        }
+    }
+});

--- a/test/plugins/data/buildClusterInactive.json
+++ b/test/plugins/data/buildClusterInactive.json
@@ -1,0 +1,12 @@
+{
+    "id": 12345,
+    "name": "iOS",
+    "scmOrganizations": ["screwdriver-cd"],
+    "scmContext": "github:github.com",
+    "managedByScrewdriver": false,
+    "maintainer": "foo@bar.com",
+    "isActive": false,
+    "description": "Build cluster for iOS team",
+    "weightage": 100,
+    "group": "on-prem"
+}

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -86,7 +86,7 @@ const decoratePipelineMock = pipeline => {
     mock.sync = sinon.stub();
     mock.addWebhooks = sinon.stub();
     mock.syncPRs = sinon.stub();
-    mock.update = sinon.stub().returns();
+    mock.update = sinon.stub();
     mock.toJson = sinon.stub().returns(pipeline);
     mock.jobs = sinon.stub();
     mock.getJobs = sinon.stub();


### PR DESCRIPTION
## Context

As of now, if there is a need to make a change to build cluster, a manual db change for each pipeline has to be performed and this is not always possible since the DB might be protected with some limited access. 

## Objective

This PR is to add a new endpoint to update a build cluster of a pipeline. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3292

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
