### PR TITLE
feat(#11529): Add apis to create and delete buildCluster annotation

### DIFF
--- a/plugins/jobs/buildCluster/remove.js
+++ b/plugins/jobs/buildCluster/remove.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
+const idSchema = schema.models.job.base.extract('id');
+
+module.exports = () => ({
+    method: 'DELETE',
+    path: '/jobs/{id}/buildCluster',
+    options: {
+        description: 'Delete the buildCluster override of a job',
+        notes: 'Returns null if successful',
+        tags: ['api', 'jobs'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+
+        handler: async (request, h) => {
+            const { jobFactory, bannerFactory } = request.server.app;
+            const { userFactory, pipelineFactory } = request.server.app;
+            const { username, scmContext, scmUserId } = request.auth.credentials;
+            const { id } = request.params;
+            const adminAnnotation = 'screwdriver.cd/sdAdminBuildClusterOverride';
+            const job = await jobFactory.get(id);
+
+            if (!job) {
+                throw boom.notFound(`Job ${id} does not exist`);
+            }
+
+            const [pipeline, user] = await Promise.all([
+                pipelineFactory.get(job.pipelineId),
+                userFactory.get({ username, scmContext })
+            ]);
+
+            if (!pipeline) {
+                throw boom.notFound('Pipeline does not exist');
+            }
+
+            if (!user) {
+                throw boom.notFound(`User ${username} does not exist`);
+            }
+
+            const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
+
+            if (!adminDetails.isAdmin) {
+                throw boom.forbidden(
+                    `User ${username} does not have Screwdriver administrative privileges to update the buildCluster`
+                );
+            }
+
+            // remove buildClusterOverride annotation from job
+            const [permutation] = job.permutations;
+            const buildClusterOverride =
+                permutation && permutation.annotations && permutation.annotations[adminAnnotation];
+
+            if (!buildClusterOverride) {
+                logger.info(`[Audit] ${adminAnnotation} does not exists for jobId:${id}.`);
+
+                return h.response().code(204);
+            }
+
+            logger.info(`[Audit] ${adminAnnotation} for jobId:${id} set to ${buildClusterOverride}, deleting.`);
+
+            delete permutation.annotations[adminAnnotation];
+
+            job.stateChanger = username;
+            job.stateChangeTime = new Date().toISOString();
+
+            try {
+                const result = await job.update();
+
+                logger.info(`[Audit] user ${username} deleted ${adminAnnotation} for jobId:${id}.`);
+
+                return h.response(result.toJson()).code(200);
+            } catch (err) {
+                logger.error(`Failed to remove ${adminAnnotation} for job ${id}: ${err.message}`);
+                throw boom.internal(`Failed to remove ${adminAnnotation} for job ${id}`);
+            }
+        },
+        validate: {
+            params: joi.object({
+                id: idSchema
+            })
+        }
+    }
+});

--- a/plugins/jobs/buildCluster/update.js
+++ b/plugins/jobs/buildCluster/update.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
+const idSchema = schema.models.job.base.extract('id');
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/jobs/{id}/buildCluster',
+    options: {
+        description: 'Update the buildCluster of a job',
+        notes: 'Update the buildCluster of a specific job',
+        tags: ['api', 'jobs'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        handler: async (request, h) => {
+            const adminAnnotation = 'screwdriver.cd/sdAdminBuildClusterOverride';
+            const { payload } = request;
+            const { id } = request.params;
+
+            if (!payload[adminAnnotation]) {
+                throw boom.badRequest(`Payload must contain ${adminAnnotation}`);
+            }
+
+            const { jobFactory, bannerFactory, buildClusterFactory, pipelineFactory, userFactory } = request.server.app;
+            const { scmContext, username, scmUserId } = request.auth.credentials;
+
+            const job = await jobFactory.get(id);
+
+            if (!job) {
+                throw boom.notFound(`Job ${id} does not exist`);
+            }
+
+            const [pipeline, user] = await Promise.all([
+                pipelineFactory.get(job.pipelineId),
+                userFactory.get({ username, scmContext })
+            ]);
+
+            if (!pipeline) {
+                throw boom.notFound('Pipeline does not exist');
+            }
+            if (!user) {
+                throw boom.notFound(`User ${username} does not exist`);
+            }
+
+            const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
+
+            if (!adminDetails.isAdmin) {
+                throw boom.forbidden(
+                    `User ${username} does not have Screwdriver administrative privileges to update the buildCluster`
+                );
+            }
+
+            // ensure that the buildCluster is a valid cluster
+            const buildClusterName = payload[adminAnnotation];
+            const buildCluster = await buildClusterFactory.get({ name: buildClusterName, scmContext });
+
+            if (!buildCluster || !buildCluster.isActive) {
+                throw boom.badRequest(`Build cluster ${buildClusterName} does not exist or is not active`);
+            }
+
+            // update job with buildClusterOverride annotation
+            const [permutation] = job.permutations;
+
+            permutation.annotations = permutation.annotations || {};
+
+            const annotations = permutation.annotations;
+
+            if (annotations[adminAnnotation]) {
+                logger.info(
+                    `[Audit] ${adminAnnotation} for jobId:${id} already set to ${annotations[adminAnnotation]}, updating.`
+                );
+            }
+            permutation.annotations[adminAnnotation] = buildClusterName;
+            job.stateChanger = username;
+            job.stateChangeTime = new Date().toISOString();
+
+            try {
+                const result = await job.update();
+
+                logger.info(
+                    `[Audit] user ${username} updates ${adminAnnotation} for jobId:${id} to ${buildClusterName}.`
+                );
+
+                return h.response(result.toJson()).code(200);
+            } catch (err) {
+                logger.error(`Failed to update ${adminAnnotation} for job ${id}: ${err.message}`);
+                throw boom.internal(`Failed to update ${adminAnnotation} for job ${id}`);
+            }
+        },
+        validate: {
+            params: joi.object({
+                id: idSchema
+            })
+        }
+    }
+});

--- a/plugins/jobs/index.js
+++ b/plugins/jobs/index.js
@@ -7,6 +7,8 @@ const lastSuccessfulMeta = require('./lastSuccessfulMeta');
 const latestBuild = require('./latestBuild');
 const metrics = require('./metrics');
 const notify = require('./notify');
+const addBuildCluster = require('./buildCluster/update');
+const removeBuildCluster = require('./buildCluster/remove');
 
 /**
  * Job API Plugin
@@ -23,7 +25,9 @@ const jobsPlugin = {
             lastSuccessfulMeta(),
             metrics(),
             latestBuild(),
-            notify()
+            notify(),
+            addBuildCluster(),
+            removeBuildCluster()
         ]);
     }
 };


### PR DESCRIPTION
## Context

Build Cluster annotation on a job is currently only derived from pipeline or from screwdriver config.
Screwdriver Admin should have a way to override the behavior to move jobs to specific cluster

## Objective

This PR adds 2 new apis to add build cluster annotation and remove build cluster annotation, allowing only Screwdriver admin to use this feature. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
