### PR TITLE
fix: Prevent webhook pipeline has no admins

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -1008,6 +1008,9 @@ async function createEvents(server, userFactory, pipelineFactory, pipelines, par
                     ref,
                     isReleaseOrTagFiltering
                 );
+
+                await updateAdmins(userFactory, username, scmContext, pTuple.pipeline, pipelineFactory);
+
                 const token = await pTuple.pipeline.token;
                 const scmConfig = {
                     scmUri: pTuple.pipeline.scmUri,
@@ -1082,8 +1085,6 @@ async function createEvents(server, userFactory, pipelineFactory, pipelines, par
                 if (skipMessage) {
                     eventConfig.skipMessage = skipMessage;
                 }
-
-                await updateAdmins(userFactory, username, scmContext, pTuple.pipeline, pipelineFactory);
 
                 return eventConfig;
             } catch (err) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If the pipeline admins is empty or if the admins account is suspended, then `Pipeline has no admin` error occurs when trying to create an event and get pipeline token in webhook process.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add the webhook executor to admins before get pipeline token if webhook executor can be admin, so that the pipeline token does not generate errors in the above cases.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
