### PR TITLE
fix(3277): Convert string "true" value to boolean for MySQL on banner list endpoint

### DIFF
--- a/plugins/banners/list.js
+++ b/plugins/banners/list.js
@@ -23,12 +23,16 @@ module.exports = () => ({
         },
         handler: async (request, h) => {
             const { bannerFactory } = request.server.app;
-            const { scope } = request.query;
+            const { scope, isActive } = request.query;
 
             if (scope !== 'GLOBAL') {
                 if (!request.auth.isAuthenticated) {
                     throw boom.unauthorized('Authentication required');
                 }
+            }
+
+            if (isActive !== undefined) {
+                request.query.isActive = ['true', true, '1', 1].includes(isActive);
             }
 
             // list params defaults to empty object in models if undefined

--- a/test/plugins/banner.test.js
+++ b/test/plugins/banner.test.js
@@ -213,6 +213,7 @@ describe('banner plugin test', () => {
             bannerFactoryMock.list.resolves(getBannerMock(testBannersActive));
 
             return server.inject(options).then(reply => {
+                assert.calledWith(bannerFactoryMock.list, { params: { isActive: true, scope: 'GLOBAL' } });
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, testBannersActive);
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

After https://github.com/screwdriver-cd/ui/pull/1326, the `isActive` parameter has been included in the request for `GET /banners` endpoint.
However, we cannot get banner list properly when we use MySQL since the value of `isActive` is string value on API side.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Convert the `isActive` parameter from string to boolean.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3277

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
