### PR TITLE
feat(3304): Relax permission check to allow admins from other SCMs to update pipeline

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -26,9 +26,10 @@ function getPermissionsForOldPipeline({ scmContexts, pipeline, user }) {
         if (pipeline.admins[user.username]) {
             permission.admin = true;
         }
+
         return Promise.resolve(permission);
     }
-    
+
     return user.getPermissions(pipeline.scmUri);
 }
 

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -19,16 +19,16 @@ const ANNOTATION_USE_DEPLOY_KEY = 'screwdriver.cd/useDeployKey';
  */
 function getPermissionsForOldPipeline({ scmContexts, pipeline, user }) {
     // this pipeline's scmContext has been removed, allow current admin to change it
-    if (!scmContexts.includes(pipeline.scmContext)) {
+    // also allow pipeline admins from other scmContexts to change it
+    if (!scmContexts.includes(pipeline.scmContext) || user.scmContext !== pipeline.scmContext) {
         const permission = { admin: false };
 
         if (pipeline.admins[user.username]) {
             permission.admin = true;
         }
-
         return Promise.resolve(permission);
     }
-
+    
     return user.getPermissions(pipeline.scmUri);
 }
 
@@ -40,7 +40,7 @@ module.exports = () => ({
         notes: 'Update a specific pipeline',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token'],
+            strategies: ['token'], // basically this only accepts jwt tokens
             scope: ['user', '!guest', 'pipeline']
         },
 

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -41,7 +41,7 @@ module.exports = () => ({
         notes: 'Update a specific pipeline',
         tags: ['api', 'pipelines'],
         auth: {
-            strategies: ['token'], // basically this only accepts jwt tokens
+            strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -164,8 +164,6 @@ const getStagesMocks = stages => {
 const getUserMock = user => {
     const mock = hoek.clone(user);
 
-    console.log(mock);
-
     mock.getPermissions = sinon.stub();
     mock.getFullDisplayName = sinon.stub().returns('batman');
     mock.update = sinon.stub();


### PR DESCRIPTION
## Context

Screwdriver restricts pipeline updates to admins within the same SCM context as the user’s login.

## Objective

This PR relaxes the permission check, allowing admins from different SCM contexts to update the pipeline.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3304

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
