### PR TITLE
fix(3287): Set parentBuildId just before execution

### DIFF
--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -98,7 +98,6 @@ class AndTrigger extends JoinBase {
             nextBuild,
             nextJob,
             parentBuilds: newParentBuilds,
-            parentBuildId: this.currentBuild.id,
             joinListNames,
             isNextJobVirtual,
             nextJobStageName

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -545,10 +545,9 @@ async function getBuildsForGroupEvent(groupEventId, buildFactory) {
  * @param {Object} arg
  * @param {ParentBuilds} arg.joinParentBuilds Parent builds object for join job
  * @param {Build} arg.nextBuild Next build
- * @param {Build} arg.build Build for current completed job
  * @returns {Promise<Build>} Updated next build
  */
-async function updateParentBuilds({ joinParentBuilds, nextBuild, build }) {
+async function updateParentBuilds({ joinParentBuilds, nextBuild }) {
     // Override old parentBuilds info
     const newParentBuilds = merge({}, joinParentBuilds, nextBuild.parentBuilds, (objVal, srcVal) =>
         // passthrough objects, else mergeWith mutates source
@@ -556,59 +555,69 @@ async function updateParentBuilds({ joinParentBuilds, nextBuild, build }) {
     );
 
     nextBuild.parentBuilds = newParentBuilds;
-    // nextBuild.parentBuildId may be int or Array, so it needs to be flattened
-    nextBuild.parentBuildId = Array.from(new Set([build.id, nextBuild.parentBuildId || []].flat()));
 
     return nextBuild.update();
 }
 
 /**
- * Check if all parent builds of the new build are done
- * @param {Object} arg
- * @param {Build} arg.newBuild Updated build
+ * Get builds in join list from parent builds
+ * @param {newBuild} arg.newBuild Updated build
  * @param {String[]} arg.joinListNames Join list names
  * @param {Number} arg.pipelineId Pipeline ID
  * @param {BuildFactory} arg.buildFactory Build factory
- * @returns {Promise<{hasFailure: Boolean, done: Boolean}>} Object with done and hasFailure statuses
+ * @returns {Promise<Map<String, Build>>} Join builds
  */
-async function getParentBuildStatus({ newBuild, joinListNames, pipelineId, buildFactory }) {
+async function getJoinBuilds({ newBuild, joinListNames, pipelineId, buildFactory }) {
     const upstream = newBuild.parentBuilds || {};
+    const joinBuilds = {};
 
-    // Get buildId
-    const joinBuildIds = joinListNames.map(name => {
+    for (const jobName of joinListNames) {
         let upstreamPipelineId = pipelineId;
-        let upstreamJobName = name;
+        let upstreamJobName = jobName;
 
-        if (isExternalTrigger(name)) {
-            const { externalPipelineId, externalJobName } = getExternalPipelineAndJob(name);
+        if (isExternalTrigger(upstreamJobName)) {
+            const { externalJobName, externalPipelineId } = getExternalPipelineAndJob(jobName);
 
             upstreamPipelineId = externalPipelineId;
             upstreamJobName = externalJobName;
         }
 
         if (upstream[upstreamPipelineId] && upstream[upstreamPipelineId].jobs[upstreamJobName]) {
-            return upstream[upstreamPipelineId].jobs[upstreamJobName];
+            const buildId = upstream[upstreamPipelineId].jobs[upstreamJobName];
+
+            const build = await buildFactory.get(buildId);
+
+            if (typeof build.endTime === 'string') {
+                build.endTime = new Date(build.endTime);
+            }
+
+            joinBuilds[jobName] = build;
         }
+    }
 
-        return undefined;
-    });
+    return joinBuilds;
+}
 
+/**
+ * Check if all parent builds of the new build are done
+ * @param {Object} arg
+ * @param {String[]} arg.joinListNames Join list names
+ * @param {String[]} arg.joinBuilds Join builds
+ * @returns {Promise<{hasFailure: Boolean, done: Boolean}>} Object with done and hasFailure statuses
+ */
+async function getParentBuildStatus({ joinListNames, joinBuilds }) {
     // If buildId is empty, the job hasn't executed yet and the join is not done
-    const isExecuted = !joinBuildIds.includes(undefined);
+    const isExecuted = joinListNames.every(name => joinBuilds[name] !== undefined);
+    const parentBuilds = Object.values(joinBuilds);
 
-    // Get the status of the builds
-    const buildIds = joinBuildIds.filter(buildId => buildId !== undefined);
-    const promisesToAwait = buildIds.map(buildId => buildFactory.get(buildId));
-    const joinedBuilds = await Promise.all(promisesToAwait);
-
-    const hasFailure = joinedBuilds
+    const hasFailure = parentBuilds
         .map(build => {
             // Do not need to run the next build; terminal status
             return [Status.FAILURE, Status.ABORTED, Status.COLLAPSED, Status.UNSTABLE].includes(build.status);
         })
         .includes(true);
 
-    const isDoneStatus = joinedBuilds.every(build => {
+    const isDoneStatus = parentBuilds.every(build => {
         // All builds are done
         return [Status.FAILURE, Status.SUCCESS, Status.ABORTED, Status.UNSTABLE, Status.COLLAPSED].includes(
             build.status
@@ -627,29 +636,30 @@ async function getParentBuildStatus({ newBuild, joinListNames, pipelineId, build
  *          if no failure, start new build
  * Otherwise, do nothing
  * @param {Object} arg If the build is done or not
- * @param {Boolean} arg.done If the build is done or not
- * @param {Boolean} arg.hasFailure If the build has a failure or not
+ * @param {String[]} arg.joinListNames Join list names
  * @param {Build} arg.newBuild Next build
  * @param {Job} arg.job Next job
  * @param {String|undefined} arg.pipelineId Pipeline ID
  * @param {String|undefined} arg.stageName Stage name
  * @param {Event} arg.event Event
- * @param {Build} arg.currentBuild Current build
+ * @param {BuildFactory} arg.buildFactory Build factory
  * @returns {Promise<Build|null>} The newly updated/created build
  */
-async function handleNewBuild({ done, hasFailure, newBuild, job, pipelineId, stageName, event, currentBuild }) {
+async function handleNewBuild({ joinListNames, newBuild, job, pipelineId, stageName, event, buildFactory }) {
+    const joinBuilds = await getJoinBuilds({
+        newBuild,
+        joinListNames,
+        pipelineId,
+        buildFactory
+    });
+
+    /* CHECK IF ALL PARENT BUILDS OF NEW BUILD ARE DONE */
+    const { hasFailure, done } = await getParentBuildStatus({
+        joinBuilds,
+        joinListNames
+    });
+
     if (!done || Status.isStarted(newBuild.status)) {
-        // The virtual job does not inherit metadata because the Launcher is not executed.
-        // Therefore, it is necessary to take over the metadata from the previous build.
-
-        // TODO There is a bug when virtual job requires [a, b] and if "a" and "b" are completed simultaneously.
-        // https://github.com/screwdriver-cd/screwdriver/issues/3287
-        if (isVirtualJob(job) && !hasFreezeWindows(job)) {
-            newBuild.meta = merge({}, newBuild.meta, currentBuild.meta);
-
-            await newBuild.update();
-        }
-
         return null;
     }
 
@@ -668,14 +678,26 @@ async function handleNewBuild({ done, hasFailure, newBuild, job, pipelineId, sta
         return null;
     }
 
+    /* Prepare to execute the build */
+    const parentBuilds = Object.values(joinBuilds);
+
+    parentBuilds.sort((l, r) => {
+        if (l.endTime && r.endTime) {
+            return l.endTime.getTime() - r.endTime.getTime();
+        }
+
+        // Move to tail if endTime is not set
+        return (l.endTime ? 0 : 1) - (r.endTime ? 0 : 1);
+    });
+    newBuild.parentBuildId = parentBuilds.map(build => build.id);
+
     // Bypass execution of the build if the job is virtual
     if (isVirtualJob(job) && !hasFreezeWindows(job)) {
         newBuild.status = Status.SUCCESS;
         newBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
         newBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
-        // The virtual job does not inherit metadata because the Launcher is not executed.
-        // Therefore, it is necessary to take over the metadata from the previous build.
-        newBuild.meta = merge({}, newBuild.meta, currentBuild.meta);
+
+        newBuild.meta = parentBuilds.reduce((acc, build) => merge(acc, build.meta), {});
 
         return newBuild.update();
     }
@@ -1003,7 +1025,7 @@ async function ensureStageTeardownBuildExists({
             username,
             scmContext,
             parentBuilds,
-            parentBuildId: current.build.id,
+            parentBuildId: [current.build.id],
             event: current.event, // this is the parentBuild for the next build
             baseBranch: current.event.baseBranch || null,
             start: false
@@ -1015,38 +1037,6 @@ async function ensureStageTeardownBuildExists({
             build: current.build
         });
     }
-}
-
-/**
- * Get parentBuildId from parentBuilds object
- * @param {Object} arg
- * @param {ParentBuilds} arg.parentBuilds Builds that triggered this build
- * @param {String[]} arg.joinListNames Array of join job name
- * @param {Number} arg.pipelineId Pipeline ID
- * @returns {String[]} Array of parentBuildId
- */
-function getParentBuildIds({ currentBuildId, parentBuilds, joinListNames, pipelineId }) {
-    const parentBuildIds = joinListNames
-        .map(name => {
-            let parentBuildPipelineId = pipelineId;
-            let parentBuildJobName = name;
-
-            if (isExternalTrigger(name)) {
-                const { externalPipelineId, externalJobName } = getExternalPipelineAndJob(name);
-
-                parentBuildPipelineId = externalPipelineId;
-                parentBuildJobName = externalJobName;
-            }
-
-            if (parentBuilds[parentBuildPipelineId] && parentBuilds[parentBuildPipelineId].jobs[parentBuildJobName]) {
-                return parentBuilds[parentBuildPipelineId].jobs[parentBuildJobName];
-            }
-
-            return null;
-        })
-        .filter(Boolean); // Remove undefined or null values
-
-    return Array.from(new Set([currentBuildId, ...parentBuildIds]));
 }
 
 /**
@@ -1208,13 +1198,13 @@ module.exports = {
     getSameParentEvents,
     mergeParentBuilds,
     updateParentBuilds,
+    getJoinBuilds,
     getParentBuildStatus,
     handleNewBuild,
     ensureStageTeardownBuildExists,
     getBuildsForGroupEvent,
     createJoinObject,
     createExternalEvent,
-    getParentBuildIds,
     strToInt,
     createEvent,
     deleteBuild,

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -949,7 +949,7 @@ async function createJoinObject(nextJobNames, current, eventFactory) {
         let isExternal = false;
 
         if (isExternalTrigger(jobName)) {
-            const { externalPipelineId, externalJobName } = getExternalPipelineAndJob(jobName);
+            const { externalJobName, externalPipelineId } = getExternalPipelineAndJob(jobName);
 
             nextJobPipelineId = externalPipelineId;
             nextJobName = externalJobName;
@@ -1025,7 +1025,7 @@ async function ensureStageTeardownBuildExists({
             username,
             scmContext,
             parentBuilds,
-            parentBuildId: [current.build.id],
+            parentBuildId: current.build.id,
             event: current.event, // this is the parentBuild for the next build
             baseBranch: current.event.baseBranch || null,
             start: false

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -439,7 +439,7 @@ function createParentBuildsObj(config) {
         let parentBuildJobName = name;
 
         if (isExternalTrigger(name)) {
-            const { externalJobName, externalPipelineId } = getExternalPipelineAndJob(name);
+            const { externalPipelineId, externalJobName } = getExternalPipelineAndJob(name);
 
             parentBuildPipelineId = externalPipelineId;
             parentBuildJobName = externalJobName;

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -439,7 +439,7 @@ function createParentBuildsObj(config) {
         let parentBuildJobName = name;
 
         if (isExternalTrigger(name)) {
-            const { externalPipelineId, externalJobName } = getExternalPipelineAndJob(name);
+            const { externalJobName, externalPipelineId } = getExternalPipelineAndJob(name);
 
             parentBuildPipelineId = externalPipelineId;
             parentBuildJobName = externalJobName;
@@ -576,7 +576,7 @@ async function getJoinBuilds({ newBuild, joinListNames, pipelineId, buildFactory
         let upstreamJobName = jobName;
 
         if (isExternalTrigger(upstreamJobName)) {
-            const { externalJobName, externalPipelineId } = getExternalPipelineAndJob(jobName);
+            const { externalPipelineId, externalJobName } = getExternalPipelineAndJob(jobName);
 
             upstreamPipelineId = externalPipelineId;
             upstreamJobName = externalJobName;
@@ -949,7 +949,7 @@ async function createJoinObject(nextJobNames, current, eventFactory) {
         let isExternal = false;
 
         if (isExternalTrigger(jobName)) {
-            const { externalJobName, externalPipelineId } = getExternalPipelineAndJob(jobName);
+            const { externalPipelineId, externalJobName } = getExternalPipelineAndJob(jobName);
 
             nextJobPipelineId = externalPipelineId;
             nextJobName = externalJobName;

--- a/plugins/builds/triggers/joinBase.js
+++ b/plugins/builds/triggers/joinBase.js
@@ -61,7 +61,7 @@ class JoinBase {
                 event, // this is the parentBuild for the next build
                 baseBranch: event.baseBranch || null,
                 parentBuilds,
-                parentBuildId: [this.currentBuild.id],
+                parentBuildId: this.currentBuild.id,
                 start: false
             });
         } else {

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -61,7 +61,10 @@ class OrBase {
                 nextBuild.status = Status.SUCCESS;
                 nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
                 nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
-                nextBuild.meta = merge({}, nextBuild.meta, this.currentBuild.meta);
+
+                // Overwrite metadata by current build's
+                nextBuild.parentBuildId = [this.currentBuild.id];
+                nextBuild.meta = merge({}, this.currentBuild.meta);
 
                 return nextBuild.update();
             }
@@ -83,7 +86,7 @@ class OrBase {
             event,
             baseBranch: event.baseBranch || null,
             parentBuilds,
-            parentBuildId: this.currentBuild.id,
+            parentBuildId: [this.currentBuild.id],
             start: hasWindows || !isNextJobVirtual,
             causeMessage
         });
@@ -93,7 +96,9 @@ class OrBase {
             nextBuild.status = Status.SUCCESS;
             nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
             nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
-            nextBuild.meta = merge({}, nextBuild.meta, this.currentBuild.meta);
+
+            // Overwrite metadata by current build's
+            nextBuild.meta = merge({}, this.currentBuild.meta);
 
             await nextBuild.update();
         }

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -86,7 +86,7 @@ class OrBase {
             event,
             baseBranch: event.baseBranch || null,
             parentBuilds,
-            parentBuildId: [this.currentBuild.id],
+            parentBuildId: this.currentBuild.id,
             start: hasWindows || !isNextJobVirtual,
             causeMessage
         });

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -56,6 +56,8 @@ class OrBase {
                 return nextBuild;
             }
 
+            nextBuild.parentBuildId = [this.currentBuild.id];
+
             // Bypass execution of the build if the job is virtual
             if (isNextJobVirtual && !hasWindows) {
                 nextBuild.status = Status.SUCCESS;
@@ -63,7 +65,6 @@ class OrBase {
                 nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
 
                 // Overwrite metadata by current build's
-                nextBuild.parentBuildId = [this.currentBuild.id];
                 nextBuild.meta = merge({}, this.currentBuild.meta);
 
                 return nextBuild.update();

--- a/plugins/builds/triggers/remoteJoin.js
+++ b/plugins/builds/triggers/remoteJoin.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { mergeParentBuilds, getParentBuildIds } = require('./helpers');
+const { mergeParentBuilds } = require('./helpers');
 const { JoinBase } = require('./joinBase');
 
 /**
@@ -45,20 +45,12 @@ class RemoteJoin extends JoinBase {
 
         const newParentBuilds = mergeParentBuilds(parentBuilds, groupEventBuilds, this.currentEvent, externalEvent);
 
-        const parentBuildId = getParentBuildIds({
-            currentBuildId: this.currentBuild.id,
-            parentBuilds: newParentBuilds,
-            joinListNames,
-            pipelineId: externalEvent.pipelineId
-        });
-
         return this.processNextBuild({
             pipelineId: externalEvent.pipelineId,
             event: externalEvent,
             nextBuild,
             nextJob,
             parentBuilds: newParentBuilds,
-            parentBuildId,
             joinListNames,
             isNextJobVirtual,
             nextJobStageName

--- a/plugins/jobs/buildCluster/update.js
+++ b/plugins/jobs/buildCluster/update.js
@@ -74,7 +74,7 @@ module.exports = () => ({
 
             permutation.annotations = permutation.annotations || {};
 
-            const annotations = permutation.annotations;
+            const { annotations } = permutation;
 
             if (annotations[adminAnnotation]) {
                 logger.info(

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1629,7 +1629,7 @@ describe('build plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId: publishJobId,
                             sha: testBuild.sha,
-                            parentBuildId: id,
+                            parentBuildId: [id],
                             parentBuilds: { 123: { eventId: '8888', jobs: { 'PR-15:main': 12345 } } },
                             username,
                             scmContext,
@@ -2580,7 +2580,7 @@ describe('build plugin test', () => {
                     jobBconfig = {
                         jobId: 2,
                         sha: '58393af682d61de87789fb4961645c42180cec5a',
-                        parentBuildId: 12345,
+                        parentBuildId: [12345],
                         parentBuilds: { 123: { eventId: '8888', jobs: { a: 12345 } } },
                         start: true,
                         eventId: '8888',
@@ -2630,6 +2630,196 @@ describe('build plugin test', () => {
                     return server.inject(options).then(() => {
                         assert.calledWith(buildFactoryMock.create.firstCall, jobBconfig);
                         assert.calledWith(buildFactoryMock.create.secondCall, jobCconfig);
+                    });
+                });
+
+                it('triggers virtual job and its downstream jobs with metadata', () => {
+                    eventMock.workflowGraph = {
+                        nodes: [
+                            { name: '~pr' },
+                            { name: '~commit' },
+                            { name: 'a', id: 1 },
+                            { name: 'b', id: 2 },
+                            { name: 'c', id: 3 },
+                            { name: 'd', id: 4 },
+                            { name: 'e', id: 5 },
+                            { name: 'f', id: 6 }
+                        ],
+                        edges: [
+                            { src: '~pr', dest: 'a' },
+                            { src: '~commit', dest: 'a' },
+                            { src: '~pr', dest: 'b' },
+                            { src: '~commit', dest: 'b' },
+                            { src: '~pr', dest: 'c' },
+                            { src: '~commit', dest: 'c' },
+                            { src: 'a', dest: 'd', join: true },
+                            { src: 'b', dest: 'd', join: true },
+                            { src: 'c', dest: 'd', join: true },
+                            { src: 'd', dest: 'e' },
+                            { src: 'd', dest: 'f' }
+                        ]
+                    };
+                    eventMock.groupEventId = 9999;
+
+                    options.payload.meta = {
+                        sameKey: 'job-a',
+                        jobA: 'test'
+                    };
+
+                    const jobD = {
+                        ...jobB,
+                        id: 4,
+                        permutations: [
+                            {
+                                ...jobB.permutations[0],
+                                annotations: { 'screwdriver.cd/virtualJob': true }
+                            }
+                        ],
+                        name: 'd'
+                    };
+
+                    const jobE = {
+                        ...jobB,
+                        id: 5,
+                        name: 'e'
+                    };
+                    const jobF = {
+                        ...jobD,
+                        id: 6,
+                        name: 'f'
+                    };
+
+                    const buildA = {
+                        // Complete this build
+                        ...buildMock,
+                        id: 12345,
+                        jobId: 1,
+                        eventId: '8888',
+                        status: 'RUNNING',
+                        update: sinon.stub()
+                    };
+                    const buildB = {
+                        id: 2,
+                        jobId: jobB.id,
+                        eventId: '8888',
+                        status: 'SUCCESS',
+                        meta: { sameKey: 'job-b', jobB: 'test' }
+                    };
+                    const buildC = {
+                        id: 3,
+                        jobId: jobC.id,
+                        eventId: '8888',
+                        status: 'SUCCESS',
+                        endTime: '2020-03-17T04:47:03.207Z',
+                        meta: { sameKey: 'job-c', jobC: 'test' }
+                    };
+                    const buildD = {
+                        // Trigger this virtual build with metadata
+                        id: 4,
+                        jobId: jobD.id,
+                        eventId: '8888',
+                        status: 'CREATED',
+                        endTime: '',
+                        meta: {},
+                        update: sinon.stub()
+                    };
+                    const buildE = {
+                        // Trigger this build from buildD
+                        id: 5,
+                        jobId: jobE.id,
+                        eventId: '8888',
+                        status: 'CREATED',
+                        endTime: '',
+                        meta: {},
+                        update: sinon.stub()
+                    };
+                    const buildF = {
+                        // Trigger this build from buildD
+                        id: 6,
+                        jobId: jobF.id,
+                        eventId: '8888',
+                        status: 'CREATED',
+                        endTime: '',
+                        parentBuildId: [buildD.id],
+                        meta: {},
+                        update: sinon.stub()
+                    };
+
+                    const jobEConfig = {
+                        ...jobBconfig,
+                        start: true,
+                        parentBuildId: [buildD.id],
+                        parentBuilds: {
+                            123: {
+                                eventId: '8888',
+                                jobs: { a: buildMock.id, b: buildB.id, c: buildC.id, d: buildD.id }
+                            }
+                        },
+                        jobId: jobE.id,
+                        causeMessage: ''
+                    };
+                    const jobFConfig = {
+                        ...jobBconfig,
+                        start: false,
+                        parentBuildId: [buildD.id],
+                        parentBuilds: {
+                            123: {
+                                eventId: '8888',
+                                jobs: { a: buildMock.id, b: buildB.id, c: buildC.id, d: buildD.id }
+                            }
+                        },
+                        jobId: jobF.id,
+                        causeMessage: ''
+                    };
+
+                    buildA.update.resolves(buildA);
+                    buildD.update.resolves(buildD);
+
+                    jobFactoryMock.get.withArgs({ name: 'd', pipelineId: pipelineMock.id }).resolves(jobD);
+                    jobFactoryMock.get.withArgs({ name: 'e', pipelineId: pipelineMock.id }).resolves(jobE);
+                    jobFactoryMock.get.withArgs({ name: 'f', pipelineId: pipelineMock.id }).resolves(jobF);
+                    jobFactoryMock.get.withArgs(jobE.id).resolves(jobE);
+                    jobFactoryMock.get.withArgs(jobF.id).resolves(jobF);
+                    buildFactoryMock.getLatestBuilds
+                        .withArgs({ groupEventId: eventMock.groupEventId, readOnly: false })
+                        .resolves([buildA, buildB, buildC, buildD]);
+                    buildFactoryMock.get.withArgs(buildA.id).resolves(buildA);
+                    buildFactoryMock.get.withArgs(buildB.id).resolves(buildB);
+                    buildFactoryMock.get.withArgs(buildC.id).resolves(buildC);
+                    buildFactoryMock.get.withArgs({ eventId: eventMock.id, jobId: jobD.id }).resolves(null);
+                    buildFactoryMock.get.withArgs({ eventId: eventMock.id, jobId: jobE.id }).resolves(null);
+                    buildFactoryMock.get.withArgs({ eventId: eventMock.id, jobId: jobF.id }).resolves(null);
+                    buildFactoryMock.create.withArgs(jobEConfig).resolves(buildE);
+                    buildFactoryMock.create.withArgs(jobFConfig).resolves(buildF);
+
+                    return server.inject(options).then(() => {
+                        // Virtual job was triggered with merged metadata
+                        assert.equal(buildD.status, 'SUCCESS');
+                        assert.equal(buildD.statusMessage, 'Skipped execution of the virtual job');
+                        assert.equal(buildD.statusMessageType, 'INFO');
+                        assert.deepEqual(buildD.parentBuildId, [buildC.id, buildA.id, buildB.id]);
+                        assert.deepEqual(buildD.meta, {
+                            jobA: 'test',
+                            jobB: 'test',
+                            jobC: 'test',
+                            sameKey: 'job-b'
+                        });
+
+                        // Virtual job triggers its downstream jobs
+                        assert.calledWith(buildFactoryMock.create.firstCall, jobEConfig);
+
+                        // Virtual job is triggered from the virtual job
+                        assert.calledWith(buildFactoryMock.create.secondCall, jobFConfig);
+                        assert.equal(buildF.status, 'SUCCESS');
+                        assert.equal(buildF.statusMessage, 'Skipped execution of the virtual job');
+                        assert.equal(buildF.statusMessageType, 'INFO');
+                        assert.deepEqual(buildF.parentBuildId, [buildD.id]);
+                        assert.deepEqual(buildF.meta, {
+                            jobA: 'test',
+                            jobB: 'test',
+                            jobC: 'test',
+                            sameKey: 'job-b'
+                        });
                     });
                 });
 
@@ -2860,6 +3050,17 @@ describe('build plugin test', () => {
                 });
 
                 it('update parent build IDs', () => {
+                    const endTimeA = new Date();
+                    const endTimeB = new Date();
+
+                    testBuild.endTime = endTimeA;
+                    endTimeB.setTime(endTimeA.getTime() + 10);
+
+                    const buildB = {
+                        id: 222,
+                        status: 'SUCCESS',
+                        endTime: endTimeB
+                    };
                     const buildC = {
                         id: 333,
                         jobId: 3, // build is already created
@@ -2886,6 +3087,7 @@ describe('build plugin test', () => {
                         },
                         buildC
                     ]);
+                    buildFactoryMock.get.withArgs(222).resolves(buildB);
                     buildFactoryMock.get.withArgs(333).resolves(buildC);
 
                     return server.inject(options).then(() => {
@@ -3093,7 +3295,7 @@ describe('build plugin test', () => {
                     jobBconfig = {
                         jobId: 2,
                         sha: '58393af682d61de87789fb4961645c42180cec5a',
-                        parentBuildId: 12345,
+                        parentBuildId: [12345],
                         start: true,
                         eventId: '8888',
                         username: 12345,
@@ -3293,7 +3495,7 @@ describe('build plugin test', () => {
                     };
                     const expectedBuildArgs = {
                         jobId: 2,
-                        parentBuildId: 12345,
+                        parentBuildId: [12345],
                         parentBuilds: {
                             123: {
                                 eventId: '8888',
@@ -3690,7 +3892,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
+                    buildFactoryMock.get.withArgs(5555).resolves({ endTime: new Date(), status: 'SUCCESS' }); // d is done
                     buildFactoryMock.get.withArgs(3).resolves(buildC);
 
                     return newServer.inject(options).then(() => {
@@ -4115,7 +4317,7 @@ describe('build plugin test', () => {
                         configPipelineSha: 'abc123',
                         eventId: 8887,
                         jobId: 6,
-                        parentBuildId: 12345,
+                        parentBuildId: [12345],
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345 } },
                             2: { eventId: '8887', jobs: { a: 12345, b: null } }
@@ -4566,17 +4768,11 @@ describe('build plugin test', () => {
                                 eventId: '8888',
                                 jobs: { 'PR-15:a': null, 'PR-15:d': 5555 }
                             }
-                        }
-                    };
-
-                    const updatedBuildC = Object.assign(buildC, {
-                        parentBuilds: {
-                            123: { eventId: '8888', jobs: { 'PR-15:a': 12345, 'PR-15:d': 5555 } }
                         },
                         start: sinon.stub().resolves()
-                    });
+                    };
 
-                    buildC.update = sinon.stub().resolves(updatedBuildC);
+                    buildC.update = sinon.stub().resolves(buildC);
 
                     buildFactoryMock.getLatestBuilds.resolves([
                         {
@@ -4617,12 +4813,12 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
+                    buildFactoryMock.get.withArgs(5555).resolves({ endTime: new Date(), status: 'SUCCESS' }); // d is done
                     buildFactoryMock.get.withArgs(3).resolves(buildC); // d is done
 
                     return newServer.inject(options).then(() => {
                         assert.calledWith(buildFactoryMock.create, jobBconfig);
-                        assert.calledOnce(updatedBuildC.start);
+                        assert.calledOnce(buildC.start);
                     });
                 });
 
@@ -4698,10 +4894,6 @@ describe('build plugin test', () => {
                         },
                         start: sinon.stub().resolves()
                     };
-                    const updatedBuildC = Object.assign(buildC, {
-                        parentBuilds,
-                        start: sinon.stub().resolves()
-                    });
                     const externalEventMock = {
                         id: 2,
                         pipelineId: 123,
@@ -4781,25 +4973,24 @@ describe('build plugin test', () => {
                             eventId: '8888',
                             status: 'SUCCESS',
                             parentBuilds: JSON.stringify({})
-                        }
+                        },
+                        buildC
                     ]);
 
                     jobCconfig.start = false;
                     jobCconfig.parentBuilds = parentBuilds;
                     jobCconfig.causeMessage = undefined;
-                    buildC.update = sinon.stub().resolves(updatedBuildC);
-                    buildFactoryMock.create.onCall(1).resolves(buildC);
-                    buildFactoryMock.get.withArgs(4).resolves({ status: 'SUCCESS' });
+                    buildC.update = sinon.stub().resolves(buildC);
+                    buildFactoryMock.get.withArgs(4).resolves({ endTime: new Date(), status: 'SUCCESS' });
 
                     return newServer.inject(options).then(() => {
-                        assert.calledTwice(buildFactoryMock.create);
+                        assert.calledOnce(buildFactoryMock.create);
                         assert.calledWith(buildFactoryMock.create.firstCall, jobBconfig);
-                        assert.calledWith(buildFactoryMock.create.secondCall, jobCconfig);
                         assert.calledOnce(buildC.start);
                     });
                 });
 
-                it('triggers if all jobs in internal join are done with parent event', () => {
+                it('triggers if all jobs in internal join are done with parent event (restart)', () => {
                     // (Internal join restart case)
                     // For a pipeline like this:
                     //   -> b
@@ -5102,23 +5293,10 @@ describe('build plugin test', () => {
                                 jobs: { a: 12345 }
                             }
                         },
-                        start: sinon.stub().resolves()
+                        start: sinon.stub().resolves(),
+                        update: sinon.stub().resolves()
                     };
-                    const updatedBuildC = Object.assign(buildC, {
-                        parentBuilds: {
-                            123: {
-                                eventId: '8888',
-                                jobs: { a: 12345 }
-                            },
-                            2: {
-                                eventId: '8889',
-                                jobs: { a: 12345 }
-                            }
-                        },
-                        start: sinon.stub().resolves()
-                    });
 
-                    buildC.update = sinon.stub().resolves(updatedBuildC);
                     const externalEventMock = {
                         id: 2,
                         pipelineId: 2,
@@ -5219,8 +5397,7 @@ describe('build plugin test', () => {
                         assert.notCalled(eventFactoryMock.create);
                         assert.calledOnce(buildFactoryMock.getLatestBuilds);
                         assert.calledOnce(buildFactoryMock.create);
-                        assert.calledOnce(buildC.update);
-                        assert.calledOnce(updatedBuildC.start);
+                        assert.calledOnce(buildC.start);
                     });
                 });
 
@@ -5623,7 +5800,7 @@ describe('build plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId: 55,
                             sha: '58393af682d61de87789fb4961645c42180cec5a',
-                            parentBuildId: 12345,
+                            parentBuildId: [12345],
                             parentBuilds: {
                                 123: {
                                     eventId: '8888',
@@ -5727,7 +5904,7 @@ describe('build plugin test', () => {
                         eventId: '8888',
                         id: 7004,
                         status: 'CREATED',
-                        parentBuildId: 7003,
+                        parentBuildId: [7003],
                         parentBuilds: {
                             123: {
                                 eventId: '8888',
@@ -5774,7 +5951,7 @@ describe('build plugin test', () => {
 
                         assert.notCalled(buildFactoryMock.create);
                         assert.calledTwice(buildGammaTeardown.update);
-                        assert.deepEqual(buildGammaTeardown.parentBuildId, [12345, 7003]);
+                        assert.deepEqual(buildGammaTeardown.parentBuildId, [7001, 7002, 7003, 12345]);
                         assert.deepEqual(buildGammaTeardown.parentBuilds, {
                             123: {
                                 eventId: '8888',

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1629,7 +1629,7 @@ describe('build plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId: publishJobId,
                             sha: testBuild.sha,
-                            parentBuildId: [id],
+                            parentBuildId: id,
                             parentBuilds: { 123: { eventId: '8888', jobs: { 'PR-15:main': 12345 } } },
                             username,
                             scmContext,
@@ -2580,7 +2580,7 @@ describe('build plugin test', () => {
                     jobBconfig = {
                         jobId: 2,
                         sha: '58393af682d61de87789fb4961645c42180cec5a',
-                        parentBuildId: [12345],
+                        parentBuildId: 12345,
                         parentBuilds: { 123: { eventId: '8888', jobs: { a: 12345 } } },
                         start: true,
                         eventId: '8888',
@@ -2741,7 +2741,7 @@ describe('build plugin test', () => {
                         eventId: '8888',
                         status: 'CREATED',
                         endTime: '',
-                        parentBuildId: [buildD.id],
+                        parentBuildId: buildD.id,
                         meta: {},
                         update: sinon.stub()
                     };
@@ -2749,7 +2749,7 @@ describe('build plugin test', () => {
                     const jobEConfig = {
                         ...jobBconfig,
                         start: true,
-                        parentBuildId: [buildD.id],
+                        parentBuildId: buildD.id,
                         parentBuilds: {
                             123: {
                                 eventId: '8888',
@@ -2762,7 +2762,7 @@ describe('build plugin test', () => {
                     const jobFConfig = {
                         ...jobBconfig,
                         start: false,
-                        parentBuildId: [buildD.id],
+                        parentBuildId: buildD.id,
                         parentBuilds: {
                             123: {
                                 eventId: '8888',
@@ -2815,7 +2815,7 @@ describe('build plugin test', () => {
                         assert.equal(buildF.status, 'SUCCESS');
                         assert.equal(buildF.statusMessage, 'Skipped execution of the virtual job');
                         assert.equal(buildF.statusMessageType, 'INFO');
-                        assert.deepEqual(buildF.parentBuildId, [buildD.id]);
+                        assert.deepEqual(buildF.parentBuildId, buildD.id);
                         assert.deepEqual(buildF.meta, {
                             jobA: 'test',
                             jobB: 'test',
@@ -3298,7 +3298,7 @@ describe('build plugin test', () => {
                     jobBconfig = {
                         jobId: 2,
                         sha: '58393af682d61de87789fb4961645c42180cec5a',
-                        parentBuildId: [12345],
+                        parentBuildId: 12345,
                         start: true,
                         eventId: '8888',
                         username: 12345,
@@ -3498,7 +3498,7 @@ describe('build plugin test', () => {
                     };
                     const expectedBuildArgs = {
                         jobId: 2,
-                        parentBuildId: [12345],
+                        parentBuildId: 12345,
                         parentBuilds: {
                             123: {
                                 eventId: '8888',
@@ -3895,7 +3895,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.get.withArgs(5555).resolves({ endTime: new Date(), status: 'SUCCESS' }); // d is done
+                    buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
                     buildFactoryMock.get.withArgs(3).resolves(buildC);
 
                     return newServer.inject(options).then(() => {
@@ -4183,7 +4183,7 @@ describe('build plugin test', () => {
                         configPipelineSha: 'abc123',
                         eventId: 8887,
                         jobId: 6,
-                        parentBuildId: [12345],
+                        parentBuildId: 12345,
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345 } },
                             2: { eventId: '8887', jobs: { a: 12345 } }
@@ -4320,7 +4320,7 @@ describe('build plugin test', () => {
                         configPipelineSha: 'abc123',
                         eventId: 8887,
                         jobId: 6,
-                        parentBuildId: [12345],
+                        parentBuildId: 12345,
                         parentBuilds: {
                             123: { eventId: '8888', jobs: { a: 12345 } },
                             2: { eventId: '8887', jobs: { a: 12345, b: null } }
@@ -4816,7 +4816,7 @@ describe('build plugin test', () => {
                         }
                     };
 
-                    buildFactoryMock.get.withArgs(5555).resolves({ endTime: new Date(), status: 'SUCCESS' }); // d is done
+                    buildFactoryMock.get.withArgs(5555).resolves({ status: 'SUCCESS' }); // d is done
                     buildFactoryMock.get.withArgs(3).resolves(buildC); // d is done
 
                     return newServer.inject(options).then(() => {
@@ -4984,7 +4984,7 @@ describe('build plugin test', () => {
                     jobCconfig.parentBuilds = parentBuilds;
                     jobCconfig.causeMessage = undefined;
                     buildC.update = sinon.stub().resolves(buildC);
-                    buildFactoryMock.get.withArgs(4).resolves({ endTime: new Date(), status: 'SUCCESS' });
+                    buildFactoryMock.get.withArgs(4).resolves({ status: 'SUCCESS' });
 
                     return newServer.inject(options).then(() => {
                         assert.calledOnce(buildFactoryMock.create);
@@ -5803,7 +5803,7 @@ describe('build plugin test', () => {
                         assert.calledWith(buildFactoryMock.create, {
                             jobId: 55,
                             sha: '58393af682d61de87789fb4961645c42180cec5a',
-                            parentBuildId: [12345],
+                            parentBuildId: 12345,
                             parentBuilds: {
                                 123: {
                                     eventId: '8888',
@@ -5907,7 +5907,7 @@ describe('build plugin test', () => {
                         eventId: '8888',
                         id: 7004,
                         status: 'CREATED',
-                        parentBuildId: [7003],
+                        parentBuildId: 7003,
                         parentBuilds: {
                             123: {
                                 eventId: '8888',

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2662,7 +2662,8 @@ describe('build plugin test', () => {
                     eventMock.groupEventId = 9999;
 
                     options.payload.meta = {
-                        sameKey: 'job-a',
+                        allKey: 'job-a',
+                        acKey: 'job-a',
                         jobA: 'test'
                     };
 
@@ -2703,7 +2704,7 @@ describe('build plugin test', () => {
                         jobId: jobB.id,
                         eventId: '8888',
                         status: 'SUCCESS',
-                        meta: { sameKey: 'job-b', jobB: 'test' }
+                        meta: { allKey: 'job-b', jobB: 'test' }
                     };
                     const buildC = {
                         id: 3,
@@ -2711,7 +2712,7 @@ describe('build plugin test', () => {
                         eventId: '8888',
                         status: 'SUCCESS',
                         endTime: '2020-03-17T04:47:03.207Z',
-                        meta: { sameKey: 'job-c', jobC: 'test' }
+                        meta: { allKey: 'job-c', acKey: 'job-c', jobC: 'test' }
                     };
                     const buildD = {
                         // Trigger this virtual build with metadata
@@ -2802,7 +2803,8 @@ describe('build plugin test', () => {
                             jobA: 'test',
                             jobB: 'test',
                             jobC: 'test',
-                            sameKey: 'job-b'
+                            acKey: 'job-a',
+                            allKey: 'job-b'
                         });
 
                         // Virtual job triggers its downstream jobs
@@ -2818,7 +2820,8 @@ describe('build plugin test', () => {
                             jobA: 'test',
                             jobB: 'test',
                             jobC: 'test',
-                            sameKey: 'job-b'
+                            acKey: 'job-a',
+                            allKey: 'job-b'
                         });
                     });
                 });

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -1037,12 +1037,9 @@ describe('updateParentBuilds function', () => {
             }
         };
 
-        const expectedParentBuildId = [3001, 2001];
-
         const result = await updateParentBuilds({ joinParentBuilds, nextBuild, build });
 
         assert.deepEqual(result.parentBuilds, expectedParentBuilds);
-        assert.deepEqual(result.parentBuildId, expectedParentBuildId);
         sinon.assert.calledOnce(nextBuildMock.update);
     });
 });
@@ -1050,123 +1047,75 @@ describe('updateParentBuilds function', () => {
 describe('getParentBuildStatus function', () => {
     const getParentBuildStatus = RewiredTriggerHelper.__get__('getParentBuildStatus');
 
-    let buildFactoryMock;
-
-    beforeEach(() => {
-        buildFactoryMock = {
-            get: sinon.stub()
-        };
-    });
-
-    afterEach(() => {
-        sinon.restore();
-    });
-
     it('should return done and no failure when all parent builds are successful', async () => {
-        const newBuild = {
-            parentBuilds: {
-                1: { jobs: { jobA: 1001, jobB: 1002 } }
-            }
-        };
         const joinListNames = ['jobA', 'jobB'];
-        const pipelineId = 1;
-
-        buildFactoryMock.get.withArgs(1001).resolves({ status: Status.SUCCESS });
-        buildFactoryMock.get.withArgs(1002).resolves({ status: Status.SUCCESS });
+        const joinBuilds = {
+            jobA: { status: Status.SUCCESS },
+            jobB: { status: Status.SUCCESS }
+        };
 
         const result = await getParentBuildStatus({
-            newBuild,
             joinListNames,
-            pipelineId,
-            buildFactory: buildFactoryMock
+            joinBuilds
         });
 
         assert.deepEqual(result, { hasFailure: false, done: true });
     });
 
     it('should return not done and no failure when some parent builds are not executed', async () => {
-        const newBuild = {
-            parentBuilds: {
-                1: { jobs: { jobA: 1001 } }
-            }
-        };
         const joinListNames = ['jobA', 'jobB'];
-        const pipelineId = 1;
-
-        buildFactoryMock.get.withArgs(1001).resolves({ status: Status.SUCCESS });
+        const joinBuilds = {
+            jobA: { status: Status.SUCCESS }
+        };
 
         const result = await getParentBuildStatus({
-            newBuild,
             joinListNames,
-            pipelineId,
-            buildFactory: buildFactoryMock
+            joinBuilds
         });
 
         assert.deepEqual(result, { hasFailure: false, done: false });
     });
 
     it('should return done and has failure when any parent build has failed', async () => {
-        const newBuild = {
-            parentBuilds: {
-                1: { jobs: { jobA: 1001, jobB: 1002 } }
-            }
-        };
         const joinListNames = ['jobA', 'jobB'];
-        const pipelineId = 1;
-
-        buildFactoryMock.get.withArgs(1001).resolves({ status: Status.SUCCESS });
-        buildFactoryMock.get.withArgs(1002).resolves({ status: Status.FAILURE });
+        const joinBuilds = {
+            jobA: { status: Status.SUCCESS },
+            jobB: { status: Status.FAILURE }
+        };
 
         const result = await getParentBuildStatus({
-            newBuild,
             joinListNames,
-            pipelineId,
-            buildFactory: buildFactoryMock
+            joinBuilds
         });
 
         assert.deepEqual(result, { hasFailure: true, done: true });
     });
 
     it('should handle external triggers correctly', async () => {
-        const newBuild = {
-            parentBuilds: {
-                1: { jobs: { jobA: 1001 } },
-                2: { jobs: { jobB: 1002 } }
-            }
-        };
         const joinListNames = ['jobA', 'sd@2:jobB'];
-        const pipelineId = 1;
-
-        buildFactoryMock.get.withArgs(1001).resolves({ status: Status.SUCCESS });
-        buildFactoryMock.get.withArgs(1002).resolves({ status: Status.SUCCESS });
+        const joinBuilds = {
+            jobA: { status: Status.SUCCESS },
+            'sd@2:jobB': { status: Status.SUCCESS }
+        };
 
         const result = await getParentBuildStatus({
-            newBuild,
             joinListNames,
-            pipelineId,
-            buildFactory: buildFactoryMock
+            joinBuilds
         });
 
         assert.deepEqual(result, { hasFailure: false, done: true });
     });
 
     it('should return not done and no failure when some parent builds are in progress', async () => {
-        const newBuild = {
-            parentBuilds: {
-                1: { jobs: { jobA: 1001, jobB: 1002 } }
-            }
-        };
         const joinListNames = ['jobA', 'jobB'];
-        const pipelineId = 1;
-
-        buildFactoryMock.get.withArgs(1001).resolves({ status: Status.SUCCESS });
-        buildFactoryMock.get.withArgs(1002).resolves({ status: Status.IN_PROGRESS });
+        const joinBuilds = {
+            jobA: { status: Status.SUCCESS },
+            jobB: { status: Status.IN_PROGRESS }
+        };
 
         const result = await getParentBuildStatus({
-            newBuild,
             joinListNames,
-            pipelineId,
-            buildFactory: buildFactoryMock
+            joinBuilds
         });
 
         assert.deepEqual(result, { hasFailure: false, done: false });
@@ -1175,26 +1124,19 @@ describe('getParentBuildStatus function', () => {
 
 describe('handleNewBuild function', () => {
     const handleNewBuild = RewiredTriggerHelper.__get__('handleNewBuild');
+    const joinListNames = ['a'];
 
     let newBuildMock;
-    let currentBuildMock;
     let jobMock;
     let eventMock;
+    let buildFactoryMock;
 
     beforeEach(() => {
         newBuildMock = {
             id: 123,
             status: Status.CREATED,
             eventId: 456,
-            update: sinon.stub().resolves(),
-            start: sinon.stub().resolvesThis(),
-            remove: sinon.stub().resolves()
-        };
-
-        currentBuildMock = {
-            id: 234,
-            status: Status.SUCCESS,
-            eventId: 456,
+            parentBuilds: { 123: { jobs: { a: 1 } } },
             update: sinon.stub().resolves(),
             start: sinon.stub().resolvesThis(),
             remove: sinon.stub().resolves()
@@ -1208,6 +1150,10 @@ describe('handleNewBuild function', () => {
 
         eventMock = {};
 
+        buildFactoryMock = {
+            get: sinon.stub().resolves({ status: Status.SUCCESS })
+        };
+
         sinon.stub(logger, 'info');
     });
 
@@ -1216,13 +1162,15 @@ describe('handleNewBuild function', () => {
     });
 
     it('should return null if not done', async () => {
+        buildFactoryMock.get.resolves({ status: Status.RUNNING });
+
         const result = await handleNewBuild({
-            done: false,
-            hasFailure: false,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
+            pipelineId: 123,
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
         assert.isNull(result);
@@ -1232,33 +1180,35 @@ describe('handleNewBuild function', () => {
     });
 
     it('should return null if new build is already started', async () => {
-        newBuildMock.status = Status.STARTED;
+        newBuildMock.status = Status.RUNNING;
 
         const result = await handleNewBuild({
-            done: true,
-            hasFailure: false,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
+            pipelineId: 123,
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
-        assert.strictEqual(result.status, Status.QUEUED);
-        sinon.assert.calledOnce(newBuildMock.update);
-        sinon.assert.calledOnce(newBuildMock.start);
+        assert.isNull(result);
+        assert.strictEqual(newBuildMock.status, Status.RUNNING);
+        sinon.assert.notCalled(newBuildMock.update);
+        sinon.assert.notCalled(newBuildMock.start);
         sinon.assert.notCalled(newBuildMock.remove);
     });
 
     it('should remove new build if there is a failure and it is not a stage teardown job', async () => {
+        buildFactoryMock.get.resolves({ status: Status.FAILURE });
+
         const result = await handleNewBuild({
-            done: true,
-            hasFailure: true,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
-            pipelineId: 1,
+            pipelineId: 123,
             stage: { name: 'deploy' },
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
         assert.isNull(result);
@@ -1270,16 +1220,16 @@ describe('handleNewBuild function', () => {
 
     it('should not remove new build if there is a failure and it is a stage teardown job', async () => {
         jobMock.name = 'stage@deploy:teardown';
+        buildFactoryMock.get.resolves({ status: Status.FAILURE });
 
         const result = await handleNewBuild({
-            done: true,
-            hasFailure: true,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
-            pipelineId: 1,
+            pipelineId: 123,
             stageName: 'deploy',
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
         assert.isNull(result);
@@ -1291,12 +1241,12 @@ describe('handleNewBuild function', () => {
 
     it('should start new build if all join builds finished successfully', async () => {
         const result = await handleNewBuild({
-            done: true,
-            hasFailure: false,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
+            pipelineId: 123,
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
         assert.strictEqual(result.status, Status.QUEUED);
@@ -1308,12 +1258,12 @@ describe('handleNewBuild function', () => {
         jobMock.permutations[0].annotations = { 'screwdriver.cd/virtualJob': true };
 
         await handleNewBuild({
-            done: true,
-            hasFailure: false,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
+            pipelineId: 123,
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.SUCCESS);
@@ -1328,12 +1278,12 @@ describe('handleNewBuild function', () => {
         jobMock.permutations[0].freezeWindows = [];
 
         await handleNewBuild({
-            done: true,
-            hasFailure: false,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
+            pipelineId: 123,
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.SUCCESS);
@@ -1346,12 +1296,12 @@ describe('handleNewBuild function', () => {
         jobMock.permutations[0].freezeWindows = ['* 10-21 ? * *'];
 
         await handleNewBuild({
-            done: true,
-            hasFailure: false,
+            joinListNames,
             newBuild: newBuildMock,
             job: jobMock,
+            pipelineId: 123,
             event: eventMock,
-            currentBuild: currentBuildMock
+            buildFactory: buildFactoryMock
         });
 
         assert.strictEqual(newBuildMock.status, Status.QUEUED);
@@ -1853,73 +1803,56 @@ describe('createExternalEvent function', () => {
     });
 });
 
-describe('getParentBuildIds function', () => {
-    const getParentBuildIds = RewiredTriggerHelper.__get__('getParentBuildIds');
-    const currentBuildId = '1001';
-    const pipelineId = 1;
+describe('getJoinBuilds', () => {
+    const getJoinBuilds = RewiredTriggerHelper.__get__('getJoinBuilds');
 
-    it('should return parent build IDs including current build ID', () => {
-        const parentBuilds = {
-            1: {
-                jobs: {
-                    jobA: '2001',
-                    jobB: '2002'
-                }
-            }
+    let buildFactoryMock;
+
+    beforeEach(() => {
+        buildFactoryMock = {
+            get: sinon.stub(),
+            remove: sinon.stub().resolves()
         };
-        const joinListNames = ['jobA', 'jobB'];
-
-        const result = getParentBuildIds({ currentBuildId, parentBuilds, joinListNames, pipelineId });
-
-        assert.deepEqual(result, ['1001', '2001', '2002']);
     });
 
-    it('should handle external triggers correctly', () => {
-        const parentBuilds = {
-            1: {
-                jobs: {
-                    jobA: '2001'
-                }
-            },
-            2: {
-                jobs: {
-                    jobB: '3001'
-                }
-            }
-        };
-        const joinListNames = ['jobA', 'sd@2:jobB'];
-
-        const result = getParentBuildIds({ currentBuildId, parentBuilds, joinListNames, pipelineId });
-
-        assert.deepEqual(result, ['1001', '2001', '3001']);
+    afterEach(() => {
+        sinon.restore();
     });
 
-    it('should filter out null values', () => {
-        const parentBuilds = {
-            1: {
-                jobs: {
-                    jobA: '2001'
+    it('should get existing builds in join lisnt', async () => {
+        const build = {
+            parentBuilds: {
+                123: {
+                    jobs: {
+                        a: 1,
+                        b: 2,
+                        d: 4
+                    }
+                },
+                456: {
+                    jobs: {
+                        e: 5
+                    }
                 }
             }
         };
-        const joinListNames = ['jobA', 'jobB']; // jobB does not exist in parentBuilds
 
-        const result = getParentBuildIds({ currentBuildId, parentBuilds, joinListNames, pipelineId });
+        buildFactoryMock.get.withArgs(1).resolves({ id: 1, endTime: '2025-03-17T04:47:03.207Z' });
+        buildFactoryMock.get.withArgs(2).resolves({ id: 2, endTime: '2025-03-18T04:47:03.207Z' });
+        buildFactoryMock.get.withArgs(5).resolves({ id: 5, endTime: '2025-03-19T04:47:03.207Z' });
 
-        assert.deepEqual(result, ['1001', '2001']);
-    });
+        const result = await getJoinBuilds({
+            newBuild: build,
+            joinListNames: ['a', 'b', 'c', 'sd@456:e'],
+            pipelineId: 123,
+            buildFactory: buildFactoryMock
+        });
 
-    it('should handle joinListNames with no matching parent builds', () => {
-        const parentBuilds = {
-            1: {
-                jobs: {}
-            }
-        };
-        const joinListNames = ['jobA', 'jobB']; // Neither jobA nor jobB exist in parentBuilds
-
-        const result = getParentBuildIds({ currentBuildId, parentBuilds, joinListNames, pipelineId });
-
-        assert.deepEqual(result, ['1001']);
+        assert.deepEqual(result, {
+            a: { id: 1, endTime: new Date('2025-03-17T04:47:03.207Z') },
+            b: { id: 2, endTime: new Date('2025-03-18T04:47:03.207Z') },
+            'sd@456:e': { id: 5, endTime: new Date('2025-03-19T04:47:03.207Z') }
+        });
     });
 });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Sometime, `parentBuildId` is not correct when parent builds are finished in same time.
For this reason, the build miss some metadata from the parent builds in launcher.

Likewise, virtual job cannot get some metadata from the parent builds.
https://github.com/screwdriver-cd/screwdriver/issues/3287#issuecomment-2674046847

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Update `parentBuildId` just before build execution
- Merge `metadata` from all of the parent builds into the virtual job just before build execution

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3287#issuecomment-2674046847

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
