### PR TITLE
fix: skip event creation when there are changed files that name matches source directory

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -229,7 +229,7 @@ function hasChangesUnderRootDir(pipeline, changedFiles) {
 
     // Only check if rootDir is set
     if (rootDir) {
-        return changes.some(file => file.startsWith(rootDir));
+        return changes.some(file => file.startsWith(`${rootDir}/`));
     }
 
     return true;

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -1382,6 +1382,16 @@ describe('startHookEvent test', () => {
             });
         });
 
+        it('returns 204 no event creation on success for pipelines with rootDir', () => {
+            pipelineMock.scmUri = `${pipelineMock.scmUri}:lib`;
+            pipelineFactoryMock.scm.getChangedFiles.resolves(['library']);
+
+            return startHookEvent(request, responseHandler, parsed).then(reply => {
+                assert.equal(reply.statusCode, 204);
+                assert.notCalled(eventFactoryMock.create);
+            });
+        });
+
         it('returns 201 on success for pipelines when mixed forward matching branch', () => {
             const pMock = getPipelineMocks({
                 id: 'pipelineHash1',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Empty events are created when the following case.

- Using source directory (e.g. `foo`)
- Commit/PR has a changed file that name matches the source directory (e.g. `foobar`, NOT `foo/bar`)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR will correct checking that changed files includes the files under source directory.

Ref:
- [checking before builds creation](https://github.com/screwdriver-cd/models/blob/3c515d63a2d7e52a25684e2ae93b552e204c90c2/lib/eventFactory.js#L224-L226)
- [source directory does not have trailing slashes](https://github.com/screwdriver-cd/screwdriver/blob/22967afca4701ea57064fcb5656b7c0eb65cde14/plugins/pipelines/helper.js#L30-L38)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
