### PR TITLE
fix(3310): External trigger couldn't trigger a pipeline stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "screwdriver-config-parser": "^12.0.0",
     "screwdriver-coverage-bookend": "^3.0.0",
     "screwdriver-coverage-sonar": "^5.0.0",
-    "screwdriver-data-schema": "^25.1.0",
+    "screwdriver-data-schema": "^25.1.3",
     "screwdriver-datastore-sequelize": "^10.0.0",
     "screwdriver-executor-base": "^11.0.0",
     "screwdriver-executor-docker": "^8.0.1",

--- a/plugins/builds/triggers/joinBase.js
+++ b/plugins/builds/triggers/joinBase.js
@@ -43,6 +43,7 @@ class JoinBase {
      * @param {import('./helpers').ParentBuilds} parentBuilds
      * @param {String} parentBuildId
      * @param {String[]} joinListNames
+     * @param {Boolean} isNextJobVirtual
      * @param {String} nextJobStageName
      * @returns {Promise<Build[]|null>}
      */
@@ -54,6 +55,7 @@ class JoinBase {
         parentBuilds,
         parentBuildId,
         joinListNames,
+        isNextJobVirtual,
         nextJobStageName
     }) {
         let newBuild;
@@ -102,6 +104,7 @@ class JoinBase {
             newBuild,
             job: nextJob,
             pipelineId,
+            isVirtualJob: isNextJobVirtual,
             stageName: nextJobStageName,
             event,
             currentBuild: this.currentBuild

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const merge = require('lodash.mergewith');
-const { createInternalBuild, Status, BUILD_STATUS_MESSAGES, isVirtualJob, hasFreezeWindows } = require('./helpers');
+const { createInternalBuild, Status, BUILD_STATUS_MESSAGES, hasFreezeWindows } = require('./helpers');
 
 /**
  * @typedef {import('screwdriver-models').BuildFactory} BuildFactory
@@ -39,15 +39,15 @@ class OrBase {
      * @param {Number} pipelineId
      * @param {Job} nextJob
      * @param {import('./helpers').ParentBuilds} parentBuilds
+     * @param {Boolean} isNextJobVirtual
      * @return {Promise<Build|null>}
      */
-    async trigger(event, pipelineId, nextJob, parentBuilds) {
+    async trigger(event, pipelineId, nextJob, parentBuilds, isNextJobVirtual) {
         let nextBuild = await this.buildFactory.get({
             eventId: event.id,
             jobId: nextJob.id
         });
 
-        const isNextJobVirtual = isVirtualJob(nextJob);
         const hasWindows = hasFreezeWindows(nextJob);
         const causeMessage = nextJob.name === event.startFrom ? event.causeMessage : '';
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -5880,7 +5880,7 @@ describe('build plugin test', () => {
                             const { lock, unlock } = lockMock;
 
                             assert.calledOnce(lock);
-                            assert.calledTwice(unlock);
+                            assert.calledOnce(unlock);
                         });
                     });
 
@@ -5892,7 +5892,7 @@ describe('build plugin test', () => {
                             const { lock, unlock } = lockMock;
 
                             assert.calledOnce(lock);
-                            assert.calledTwice(unlock);
+                            assert.calledOnce(unlock);
                         });
                     });
                 });

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -57,8 +57,7 @@ describe('createJoinObject function', () => {
                             { id: 11, name: 'jobA' },
                             { id: 12, name: 'jobB' }
                         ],
-                        isExternal: false,
-                        stageName: null
+                        isExternal: false
                     }
                 }
             }
@@ -123,8 +122,7 @@ describe('createJoinObject function', () => {
                             { id: 22, name: 'sd@2:jobB' },
                             { id: 23, name: 'sd@2:jobC' }
                         ],
-                        isExternal: true,
-                        stageName: null
+                        isExternal: true
                     }
                 }
             }
@@ -160,8 +158,8 @@ describe('createJoinObject function', () => {
         const expected = {
             1: {
                 jobs: {
-                    jobB: { id: 12, join: [], isExternal: false, stageName: null },
-                    jobC: { id: 13, join: [], isExternal: false, stageName: null }
+                    jobB: { id: 12, join: [], isExternal: false },
+                    jobC: { id: 13, join: [], isExternal: false }
                 }
             }
         };
@@ -179,7 +177,7 @@ describe('createJoinObject function', () => {
                         { name: '~commit' },
                         { name: 'jobA', id: 11 },
                         { name: 'jobB', id: 12 },
-                        { name: 'jobC', id: 13, stageName: 'red' }
+                        { name: 'jobC', id: 13, virtual: true, stageName: 'red' }
                     ],
                     edges: [
                         { src: '~commit', dest: 'jobA' },
@@ -203,8 +201,7 @@ describe('createJoinObject function', () => {
                             { id: 11, name: 'jobA' },
                             { id: 12, name: 'jobB' }
                         ],
-                        isExternal: false,
-                        stageName: 'red'
+                        isExternal: false
                     }
                 }
             }
@@ -1305,13 +1302,12 @@ describe('handleNewBuild function', () => {
     });
 
     it('should skip the execution of virtual job and mark the build as successful', async () => {
-        jobMock.permutations[0].annotations = { 'screwdriver.cd/virtualJob': true };
-
         await handleNewBuild({
             done: true,
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
+            isVirtualJob: true,
             event: eventMock,
             currentBuild: currentBuildMock
         });
@@ -1324,7 +1320,6 @@ describe('handleNewBuild function', () => {
     });
 
     it('should skip the execution of virtual job when freeze windows is empty', async () => {
-        jobMock.permutations[0].annotations = { 'screwdriver.cd/virtualJob': true };
         jobMock.permutations[0].freezeWindows = [];
 
         await handleNewBuild({
@@ -1332,6 +1327,7 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
+            isVirtualJob: true,
             event: eventMock,
             currentBuild: currentBuildMock
         });
@@ -1342,7 +1338,6 @@ describe('handleNewBuild function', () => {
     });
 
     it('should add virtual job to the execution queue when the job has freeze windows', async () => {
-        jobMock.permutations[0].annotations = { 'screwdriver.cd/virtualJob': true };
         jobMock.permutations[0].freezeWindows = ['* 10-21 ? * *'];
 
         await handleNewBuild({
@@ -1350,6 +1345,7 @@ describe('handleNewBuild function', () => {
             hasFailure: false,
             newBuild: newBuildMock,
             job: jobMock,
+            isVirtualJob: true,
             event: eventMock,
             currentBuild: currentBuildMock
         });


### PR DESCRIPTION
## Context

Workflow of upstream pipeline event was being used to determine if the external downstream job was virtual or not.

## Objective

Use the event associated with the pipeline the job belongs to.

Also reverts few changes made in https://github.com/screwdriver-cd/screwdriver/pull/3283
Determining whether a job is virtual or not should be based on the event workflow and not on the latest job configuration (annotations). If we rely on latest job annotation, we may skip executing a build which not not marked as virtual when the event (parent event in case of restart) was created.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3310

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
