### PR TITLE
feat(3304): Relax permission check to allow admins from other SCMs to update pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "screwdriver-config-parser": "^12.0.0",
     "screwdriver-coverage-bookend": "^3.0.0",
     "screwdriver-coverage-sonar": "^5.0.0",
-    "screwdriver-data-schema": "^25.1.3",
+    "screwdriver-data-schema": "^25.2.0",
     "screwdriver-datastore-sequelize": "^10.0.0",
     "screwdriver-executor-base": "^11.0.0",
     "screwdriver-executor-docker": "^8.0.1",

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -19,15 +19,15 @@ const ANNOTATION_USE_DEPLOY_KEY = 'screwdriver.cd/useDeployKey';
  */
 function getPermissionsForOldPipeline({ scmContexts, pipeline, user }) {
     const isPipelineSCMContextObsolete = !scmContexts.includes(pipeline.scmContext);
+    const isUserFromAnotherSCMContext = user.scmContext !== pipeline.scmContext;
 
     // this pipeline's scmContext has been removed, allow current admin to change it
     // also allow pipeline admins from other scmContexts to change it
-    if (isPipelineSCMContextObsolete || user.scmContext !== pipeline.scmContext) {
-        let isAdmin = pipeline.adminUserIds.includes(user.id) || !!pipeline.admins[user.username];
+    if (isPipelineSCMContextObsolete || isUserFromAnotherSCMContext) {
+        const isUserIdInAdminList = pipeline.adminUserIds.includes(user.id);
+        const isSCMUsernameInAdminsObject = !!pipeline.admins[user.username];
 
-        if (!isAdmin && isPipelineSCMContextObsolete && pipeline.admins[user.username]) {
-            isAdmin = true;
-        }
+        const isAdmin = isUserIdInAdminList || (isPipelineSCMContextObsolete && isSCMUsernameInAdminsObject);
 
         return Promise.resolve({ admin: isAdmin });
     }

--- a/test/plugins/data/collection.response.json
+++ b/test/plugins/data/collection.response.json
@@ -13,6 +13,7 @@
             "admins": {
                 "stjohn": true
             },
+            "adminUserIds": [11],
             "lastEventId": 456,
             "state": "ACTIVE"
         },
@@ -24,6 +25,7 @@
             "admins": {
                 "tkyi": true
             },
+            "adminUserIds": [22],
             "lastEventId": 789,
             "state": "ACTIVE"
         },
@@ -35,6 +37,7 @@
             "admins": {
                 "d2lam": true
             },
+            "adminUserIds": [33],
             "state": "ACTIVE"
         }
     ]

--- a/test/plugins/data/pipeline.json
+++ b/test/plugins/data/pipeline.json
@@ -6,5 +6,6 @@
   "admins": {
     "stjohn": true
   },
+  "adminUserIds": [],
   "state": "ACTIVE"
 }

--- a/test/plugins/data/pipelines.json
+++ b/test/plugins/data/pipelines.json
@@ -7,6 +7,7 @@
         "admins": {
             "stjohn": true
         },
+        "adminUserIds": [11],
         "lastEventId": 456,
         "state": "ACTIVE"
     },
@@ -18,6 +19,7 @@
         "admins": {
             "tkyi": true
         },
+        "adminUserIds": [22],
         "lastEventId": 789,
         "state": "ACTIVE"
     },
@@ -29,6 +31,7 @@
         "admins": {
             "d2lam": true
         },
+        "adminUserIds": [33],
         "state": "ACTIVE"
     }
 ]

--- a/test/plugins/data/pipelinesFromGitlab.json
+++ b/test/plugins/data/pipelinesFromGitlab.json
@@ -7,6 +7,7 @@
         "admins": {
             "stjohn": true
         },
+        "adminUserIds": [11],
         "lastEventId": 222,
         "state": "ACTIVE"
     }

--- a/test/plugins/data/privatePipelines.json
+++ b/test/plugins/data/privatePipelines.json
@@ -13,6 +13,7 @@
         "admins": {
             "stjohn": true
         },
+        "adminUserIds": [11],
         "lastEventId": 456,
         "state": "ACTIVE"
     },
@@ -30,6 +31,7 @@
         "admins": {
             "tkyi": true
         },
+        "adminUserIds": [22],
         "settings": {
             "public": true
         },
@@ -44,6 +46,7 @@
         "admins": {
             "d2lam": true
         },
+        "adminUserIds": [33],
         "state": "ACTIVE"
     },
     {
@@ -60,6 +63,7 @@
         "admins": {
             "foo": true
         },
+        "adminUserIds": [44],
         "lastEventId": 789,
         "state": "ACTIVE"
     }


### PR DESCRIPTION
## Context

Screwdriver restricts pipeline updates to admins within the same SCM context as the user’s login.

## Objective

This PR relaxes the permission check, allowing admins from different SCM contexts to update the pipeline.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3304

Related PRs:
https://github.com/screwdriver-cd/data-schema/pull/595

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
