### PR TITLE
fix(2957): trigger next build on the child event if some builds are restarted before complete all buidls

### DIFF
--- a/plugins/builds/triggers/and.js
+++ b/plugins/builds/triggers/and.js
@@ -50,6 +50,11 @@ class AndTrigger extends JoinBase {
         return relatedBuilds;
     }
 
+    /**
+     * Get next build in the latest child evnet
+     * @param {Job} nextJob next job
+     * @returns {Promise<Build|null>}
+     */
     async fetchNextBuildInChildEvents(nextJob) {
         const childEvents = await this.eventFactory.list({
             params: {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -408,6 +408,7 @@ describe('build plugin test', () => {
             buildMock = getBuildMock(testBuild);
             buildMock.update.resolves(buildMock);
             buildFactoryMock.get.resolves(buildMock);
+            buildFactoryMock.list.resolves([]);
             stepMock = getBuildMock({
                 buildId: id,
                 name: initStepName
@@ -462,6 +463,7 @@ describe('build plugin test', () => {
                 startFrom: '~commit'
             };
             eventFactoryMock.get.resolves(eventMock);
+            eventFactoryMock.list.resolves([]);
             eventMock.update.resolves(eventMock);
             jobFactoryMock.get.resolves(jobMock);
             bannerFactoryMock.scm.getDisplayName.withArgs({ scmContext }).returns(scmDisplayName);

--- a/test/plugins/trigger.test.helper.js
+++ b/test/plugins/trigger.test.helper.js
@@ -491,9 +491,15 @@ class EventFactoryMock {
      * @returns {Event[]}
      */
     async list({ params }) {
-        const { parentEventId } = params;
+        const { parentEventId, pipelineId } = params;
 
-        return this.getChildEvents(parentEventId);
+        const childEvents = this.getChildEvents(parentEventId);
+
+        if (pipelineId) {
+            return childEvents.filter(event => event && event.pipelineId === pipelineId);
+        }
+
+        return childEvents;
     }
 
     /**
@@ -615,6 +621,22 @@ class BuildFactoryMock {
         }
 
         return build;
+    }
+
+    /**
+     * Mock method: get builds
+     * @param {Object} config
+     * @returns {Build[]}
+     */
+    async list({ params }) {
+        const { eventId, jobId } = params;
+        let eventIds = eventId;
+
+        if (!Array.isArray(eventId)) {
+            eventIds = [eventId];
+        }
+
+        return this.records.filter(build => build && eventIds.includes(build.eventId) && build.jobId === jobId);
     }
 
     /**

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -956,7 +956,7 @@ describe('trigger tests', () => {
         assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
     });
 
-    it('debug [ a, b, c ] is triggered in latest restarted event once', async () => {
+    it('[ a, b, c ] is triggered in latest restarted event once', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('a_b_c.yaml');
         const event = await eventFactoryMock.create({
             pipelineId: pipeline.id,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

This PR fixes some cases of the https://github.com/screwdriver-cd/screwdriver/issues/2957.

It corrects which event the next build should be triggered on in the following case:

```text
[ a, b, c ] is triggered in restarted event when a fails once and then restarts and succeeds before c succeeds
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Find next build in the latest child event even if it is triggered from current event.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/2957

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
