### PR TITLE
feat: log request payload when available

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -14,7 +14,6 @@ process.on('unhandledRejection', (reason, p) => {
  * @param  {Hapi.h}     h   Hapi Response Toolkit
  */
 function handlePreResponseLogs(request, h) {
-
     const { response } = request;
     const { release } = request.server.app;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,47 +9,6 @@ process.on('unhandledRejection', (reason, p) => {
 });
 
 /**
- * If we're throwing errors, let's have them say a little more than just 500
- * @method prettyPrintErrors
- * @param  {Hapi.Request}    request Hapi Request object
- * @param  {Hapi.h}     h   Hapi Response Toolkit
- */
-function prettyPrintErrors(request, h) {
-    const { response } = request;
-    const { release } = request.server.app;
-
-    if (release && release.cookieName && request.state && !request.state[release.cookieName]) {
-        h.state(release.cookieName, release.cookieValue);
-    }
-
-    if (!response.isBoom) {
-        return h.continue;
-    }
-
-    const err = response;
-    const errName = err.output.payload.error;
-    const errMessage = err.message;
-    const { statusCode } = err.output.payload;
-    const stack = err.stack || errMessage;
-
-    if (statusCode === 500) {
-        request.log(['server', 'error'], stack);
-    }
-
-    const res = {
-        statusCode,
-        error: errName,
-        message: errMessage
-    };
-
-    if (err.data) {
-        res.data = err.data;
-    }
-
-    return h.response(res).code(statusCode);
-}
-
-/**
  * Configures & starts up a HapiJS server
  * @method
  * @param  {Object}      config
@@ -164,8 +123,52 @@ module.exports = async config => {
             });
         }
 
-        // Write prettier errors
-        server.ext('onPreResponse', prettyPrintErrors);
+        // logging behavior before response log is printed
+        server.ext('onPreResponse', (request, h) => {
+
+            const { response } = request;
+            const { release } = request.server.app;
+
+            if (release && release.cookieName && request.state && !request.state[release.cookieName]) {
+                h.state(release.cookieName, release.cookieValue);
+            }
+
+            // Pretty print errors
+            if (response.isBoom) {
+                const err = response;
+                const errName = err.output.payload.error;
+                const errMessage = err.message;
+                const { statusCode } = err.output.payload;
+                const stack = err.stack || errMessage;
+
+                if (statusCode === 500) {
+                    request.log(['server', 'error'], stack);
+                }
+
+                const res = {
+                    statusCode,
+                    error: errName,
+                    message: errMessage
+                };
+
+                if (err.data) {
+                    res.data = err.data;
+                }
+
+                return h.response(res).code(statusCode);
+            }
+            // Log request payload
+            if (request.payload) {
+                request.log(['payload'], {
+                    method: request.method,
+                    path: request.path,
+                    payload: request.payload,
+                    statusCode: request.response?.statusCode,
+                });
+            }
+
+            return h.continue;
+        });
 
         // Audit log
         if (config.log && config.log.audit.enabled) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,6 +9,61 @@ process.on('unhandledRejection', (reason, p) => {
 });
 
 /**
+ * @method handlePreResponseLogs
+ * @param  {Hapi.Request}    request Hapi Request object
+ * @param  {Hapi.h}     h   Hapi Response Toolkit
+ */
+function handlePreResponseLogs(request, h) {
+
+    const { response } = request;
+    const { release } = request.server.app;
+
+    if (release && release.cookieName && request.state && !request.state[release.cookieName]) {
+        h.state(release.cookieName, release.cookieValue);
+    }
+
+    // Pretty print errors
+    if (response.isBoom) {
+        const err = response;
+        const errName = err.output.payload.error;
+        const errMessage = err.message;
+        const { statusCode } = err.output.payload;
+        const stack = err.stack || errMessage;
+
+        // If we're throwing errors, let's have them say a little more than just 500
+        if (statusCode === 500) {
+            request.log(['server', 'error'], stack);
+        }
+
+        const res = {
+            statusCode,
+            error: errName,
+            message: errMessage
+        };
+
+        if (err.data) {
+            res.data = err.data;
+        }
+
+        return h.response(res).code(statusCode);
+    }
+
+    // Log request payload when it takes longer than 5 seconds to respond
+    // This is to prevent logging payloads for every request
+    if (request.info && request.info.received && Date.now() - request.info.received > 5000 && request.payload) {
+        request.log(['payload'], {
+            method: request.method,
+            path: request.path,
+            payload: request.payload,
+            statusCode: request.response && request.response.statusCode,
+            responseTime: Date.now() - request.info.received
+        });
+    }
+
+    return h.continue;
+}
+
+/**
  * Configures & starts up a HapiJS server
  * @method
  * @param  {Object}      config
@@ -123,51 +178,7 @@ module.exports = async config => {
             });
         }
 
-        // logging behavior before response log is printed
-        server.ext('onPreResponse', (request, h) => {
-            const { response } = request;
-            const { release } = request.server.app;
-
-            if (release && release.cookieName && request.state && !request.state[release.cookieName]) {
-                h.state(release.cookieName, release.cookieValue);
-            }
-
-            // Pretty print errors
-            if (response.isBoom) {
-                const err = response;
-                const errName = err.output.payload.error;
-                const errMessage = err.message;
-                const { statusCode } = err.output.payload;
-                const stack = err.stack || errMessage;
-
-                if (statusCode === 500) {
-                    request.log(['server', 'error'], stack);
-                }
-
-                const res = {
-                    statusCode,
-                    error: errName,
-                    message: errMessage
-                };
-
-                if (err.data) {
-                    res.data = err.data;
-                }
-
-                return h.response(res).code(statusCode);
-            }
-            // Log request payload
-            if (request.payload) {
-                request.log(['payload'], {
-                    method: request.method,
-                    path: request.path,
-                    payload: request.payload,
-                    statusCode: request.response && request.response.statusCode
-                });
-            }
-
-            return h.continue;
-        });
+        server.ext('onPreResponse', handlePreResponseLogs);
 
         // Audit log
         if (config.log && config.log.audit.enabled) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -125,7 +125,6 @@ module.exports = async config => {
 
         // logging behavior before response log is printed
         server.ext('onPreResponse', (request, h) => {
-
             const { response } = request;
             const { release } = request.server.app;
 
@@ -163,7 +162,7 @@ module.exports = async config => {
                     method: request.method,
                     path: request.path,
                     payload: request.payload,
-                    statusCode: request.response?.statusCode,
+                    statusCode: request.response && request.response.statusCode
                 });
             }
 


### PR DESCRIPTION
## Context

It will be useful for debugging to see the payload sent to API. 

## Objective

This PR serves to add payload prior to logging the response to help troubleshooting. 

## References

N/A

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
