### PR TITLE
feat(3318): Update pipeline admin user list based on the user permission

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -64,8 +64,13 @@ module.exports = () => ({
                                             const newAdmins = pipeline.admins;
 
                                             delete newAdmins[username];
+                                            const newAdminUserIds = pipeline.adminUserIds.filter(
+                                                adminUserId => adminUserId !== user.id
+                                            );
+
                                             // This is needed to make admins dirty and update db
                                             pipeline.admins = newAdmins;
+                                            pipeline.adminUserIds = newAdminUserIds;
 
                                             return pipeline.update().then(() => {
                                                 throw boom.forbidden(
@@ -83,9 +88,18 @@ module.exports = () => ({
                                             newAdmins[username] = true;
                                             // This is needed to make admins dirty and update db
                                             pipeline.admins = newAdmins;
-
-                                            return pipeline.update();
                                         }
+
+                                        const newAdminUserIds = pipeline.adminUserIds;
+
+                                        if (!newAdminUserIds.includes(user.id)) {
+                                            newAdminUserIds.push(user.id);
+
+                                            // This is needed to make admins dirty and update db
+                                            pipeline.adminUserIds = newAdminUserIds;
+                                        }
+
+                                        return pipeline.update();
                                     })
                                     // user has good permissions, sync and create a build
                                     .then(() => (job.isPR() ? pipeline.syncPR(job.prNum) : pipeline.sync()))

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -152,7 +152,7 @@ module.exports = () => ({
 
             // Update admins
             if (!prNum) {
-                await updateAdmins({ permissions, pipeline, username });
+                await updateAdmins({ permissions, pipeline, user });
             }
 
             // Get scmConfig
@@ -201,7 +201,7 @@ module.exports = () => ({
                     await updateAdmins({
                         permissions,
                         pipeline,
-                        username
+                        user
                     });
                 }
             }

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -71,7 +71,7 @@ module.exports = () => ({
                 await updateAdmins({
                     permissions,
                     pipeline,
-                    username
+                    user
                 });
             }
 

--- a/plugins/pipelines/sync.js
+++ b/plugins/pipelines/sync.js
@@ -60,8 +60,11 @@ module.exports = () => ({
                 const newAdmins = pipeline.admins;
 
                 delete newAdmins[username];
+                const newAdminUserIds = pipeline.adminUserIds.filter(adminUserId => adminUserId !== user.id);
+
                 // This is needed to make admins dirty and update db
                 pipeline.admins = newAdmins;
+                pipeline.adminUserIds = newAdminUserIds;
 
                 await pipeline.update();
 
@@ -77,10 +80,16 @@ module.exports = () => ({
             // user has good permissions, add the user as an admin
             if (!pipeline.admins[username] && hasPushPermissions) {
                 const newAdmins = pipeline.admins;
+                const newAdminUserIds = pipeline.adminUserIds;
 
                 newAdmins[username] = true;
+                if (!newAdminUserIds.includes(user.id)) {
+                    newAdminUserIds.push(user.id);
+                }
+
                 // This is needed to make admins dirty and update db
                 pipeline.admins = newAdmins;
+                pipeline.adminUserIds = newAdminUserIds;
 
                 await pipeline.update();
             }

--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -95,8 +95,11 @@ async function updateAdmins(userFactory, username, scmContext, pipeline, pipelin
             const newAdmins = pipeline.admins;
 
             delete newAdmins[username];
+            const newAdminUserIds = pipeline.adminUserIds.filter(adminUserId => adminUserId !== user.id);
+
             // This is needed to make admins dirty and update db
             pipeline.admins = newAdmins;
+            pipeline.adminUserIds = newAdminUserIds;
 
             return pipeline.update();
         }
@@ -110,7 +113,16 @@ async function updateAdmins(userFactory, username, scmContext, pipeline, pipelin
             newAdmins[name] = true;
         });
 
+        const newAdminUserIds = [user.id];
+
+        pipeline.adminUserIds.forEach(adminUserId => {
+            if (adminUserId !== user.id) {
+                newAdminUserIds.push(adminUserId);
+            }
+        });
+
         pipeline.admins = newAdmins;
+        pipeline.adminUserIds = newAdminUserIds;
 
         return pipeline.update();
     } catch (err) {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -6078,6 +6078,7 @@ describe('build plugin test', () => {
 
     describe('POST /builds', () => {
         const username = 'myself';
+        const userId = 777;
         const buildId = 12345;
         const jobId = 1234;
         const pipelineId = 123;
@@ -6124,6 +6125,7 @@ describe('build plugin test', () => {
                 checkoutUrl,
                 scmUri,
                 admins: { foo: true, bar: true },
+                adminUserIds: [888, 999],
                 sync: sinon.stub().resolves(),
                 syncPR: sinon.stub().resolves(),
                 update: sinon.stub().resolves(),
@@ -6139,6 +6141,7 @@ describe('build plugin test', () => {
                 pipeline: sinon.stub().resolves(pipelineMock)()
             };
             userMock = {
+                id: userId,
                 username,
                 getPermissions: sinon.stub(),
                 unsealToken: sinon.stub()
@@ -6216,6 +6219,7 @@ describe('build plugin test', () => {
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledWith(buildFactoryMock.create, params);
                 assert.deepEqual(pipelineMock.admins, { foo: true, bar: true, myself: true });
+                assert.deepEqual(pipelineMock.adminUserIds, [888, 999, 777]);
             });
         });
 
@@ -6254,6 +6258,7 @@ describe('build plugin test', () => {
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledWith(buildFactoryMock.create, params);
                 assert.deepEqual(pipelineMock.admins, { foo: true, bar: true, myself: true });
+                assert.deepEqual(pipelineMock.adminUserIds, [888, 999, 777]);
             });
         });
 
@@ -6298,6 +6303,7 @@ describe('build plugin test', () => {
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.calledWith(buildFactoryMock.create, params);
                 assert.deepEqual(pipelineMock.admins, { foo: true, bar: true, myself: true });
+                assert.deepEqual(pipelineMock.adminUserIds, [888, 999, 777]);
             });
         });
 
@@ -6313,11 +6319,13 @@ describe('build plugin test', () => {
 
         it('returns 403 forbidden error when user does not have push permission', () => {
             userMock.getPermissions.resolves({ push: false });
-            options.auth.credentials.username = 'bar';
+            pipelineMock.admins = { myself: true, foo: true, bar: true };
+            pipelineMock.adminUserIds = [777, 888, 999];
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 403);
-                assert.deepEqual(pipelineMock.admins, { foo: true });
+                assert.deepEqual(pipelineMock.admins, { foo: true, bar: true });
+                assert.deepEqual(pipelineMock.adminUserIds, [888, 999]);
             });
         });
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1313,6 +1313,7 @@ describe('event plugin test', () => {
             checkoutUrl,
             update: sinon.stub().resolves(),
             admins: { foo: true, bar: true },
+            adminUserIds: [888, 999],
             admin: Promise.resolve({
                 username: 'foo',
                 unsealToken: sinon.stub().resolves('token')
@@ -1322,6 +1323,7 @@ describe('event plugin test', () => {
         };
         const id = 123;
         const username = 'myself';
+        const userId = 777;
         let expectedLocation;
         let builds;
         let event;
@@ -1330,6 +1332,7 @@ describe('event plugin test', () => {
 
         beforeEach(() => {
             userMock = {
+                id: userId,
                 username,
                 getPermissions: sinon.stub().resolves({ push: true }),
                 unsealToken: sinon.stub().resolves('iamtoken')

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -301,6 +301,7 @@ describe('event plugin test', () => {
         let eventMock;
         let meta;
         const username = 'myself';
+        const userId = 777;
         const parentBuildId = 12345;
         const pipelineId = 123;
         const scmContext = 'github:github.com';
@@ -322,6 +323,7 @@ describe('event plugin test', () => {
 
         beforeEach(() => {
             userMock = {
+                id: userId,
                 username,
                 getPermissions: sinon.stub().resolves({ push: true }),
                 unsealToken: sinon.stub().resolves('iamtoken'),
@@ -334,6 +336,7 @@ describe('event plugin test', () => {
                 scmRepo,
                 update: sinon.stub().resolves(),
                 admins: { foo: true, bar: true },
+                adminUserIds: [888, 999],
                 admin: Promise.resolve({
                     username: 'foo',
                     unsealToken: sinon.stub().resolves('token')

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -266,6 +266,7 @@ describe('startHookEvent test', () => {
     const sha = '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c';
     const latestSha = 'a402964c054c610757794d9066c96cee1772daed';
     const username = 'baxterthehacker';
+    const userId = 777;
     const scmContext = 'github:github.com';
     const scmRepo = {
         branch: 'branch',
@@ -421,6 +422,7 @@ describe('startHookEvent test', () => {
             admins: {
                 baxterthehacker: false
             },
+            adminUserIds: [],
             workflowGraph,
             branch: Promise.resolve('master')
         });
@@ -431,6 +433,7 @@ describe('startHookEvent test', () => {
             update: sinon.stub()
         };
         userMock = {
+            id: userId,
             unsealToken: sinon.stub(),
             getPermissions: sinon.stub().resolves({
                 push: true
@@ -1608,6 +1611,7 @@ describe('startHookEvent test', () => {
             pipelineFactoryMock.scm.parseUrl.resolves(scmUri);
 
             const userMock1 = {
+                id: userId,
                 unsealToken: sinon.stub(),
                 getPermissions: sinon.stub().resolves({
                     push: true
@@ -1642,6 +1646,7 @@ describe('startHookEvent test', () => {
             pipelineFactoryMock.scm.parseUrl.resolves(scmUri);
 
             const userMock1 = {
+                id: userId,
                 unsealToken: sinon.stub(),
                 getPermissions: sinon.stub().resolves({
                     push: false
@@ -1713,6 +1718,8 @@ describe('startHookEvent test', () => {
                 bar: true
             };
 
+            pipelineMock.adminUserIds = [888, 999];
+
             return startHookEvent(request, responseHandler, parsed).then(reply => {
                 assert.equal(reply.statusCode, 201);
 
@@ -1720,6 +1727,7 @@ describe('startHookEvent test', () => {
 
                 assert.deepEqual({ baxterthehacker: true, foo: true, bar: true }, admins);
                 assert.deepEqual(['baxterthehacker', 'foo', 'bar'], Object.keys(admins));
+                assert.deepEqual([777, 888, 999], pipelineMock.adminUserIds);
             });
         });
 


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/data-schema/pull/595 introduced a new field `adminUserIds` to identify pipeline admins based on the user identifier. 

## Objective
Update `adminUserIds` based on user permission


## References

https://github.com/screwdriver-cd/screwdriver/issues/3318

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
