### PR TITLE
fix: Add adminUserIds check for backward compatibility

### DIFF
--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -52,6 +52,10 @@ module.exports = () => ({
                             if (!isValidToken(pipeline.id, request.auth.credentials)) {
                                 throw boom.unauthorized('Token does not have permission to this pipeline');
                             }
+                            // for mysql backward compatibility
+                            if (!pipeline.adminUserIds) {
+                                pipeline.adminUserIds = [];
+                            }
 
                             return (
                                 user

--- a/plugins/events/index.js
+++ b/plugins/events/index.js
@@ -29,6 +29,10 @@ const eventsPlugin = {
         server.expose('updateAdmins', ({ permissions, pipeline, user }) => {
             const { username, id: userId } = user;
 
+            // for mysql backward compatibility
+            if (!pipeline.adminUserIds) {
+                pipeline.adminUserIds = [];
+            }
             // Delete user from admin list if bad permissions
             if (!permissions.push) {
                 const newAdmins = pipeline.admins;

--- a/plugins/pipelines/sync.js
+++ b/plugins/pipelines/sync.js
@@ -41,6 +41,10 @@ module.exports = () => ({
             if (!user) {
                 throw boom.notFound(`User ${username} does not exist`);
             }
+            // for mysql backward compatibility
+            if (!pipeline.adminUserIds) {
+                pipeline.adminUserIds = [];
+            }
 
             // Use parent's scmUri if pipeline is child pipeline and using read-only SCM
             const scmUri = await getScmUri({ pipeline, pipelineFactory });

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -21,6 +21,10 @@ function getPermissionsForOldPipeline({ scmContexts, pipeline, user }) {
     const isPipelineSCMContextObsolete = !scmContexts.includes(pipeline.scmContext);
     const isUserFromAnotherSCMContext = user.scmContext !== pipeline.scmContext;
 
+    // for mysql backward compatibility
+    if (!pipeline.adminUserIds) {
+        pipeline.adminUserIds = [];
+    }
     // this pipeline's scmContext has been removed, allow current admin to change it
     // also allow pipeline admins from other scmContexts to change it
     if (isPipelineSCMContextObsolete || isUserFromAnotherSCMContext) {
@@ -68,6 +72,11 @@ module.exports = () => ({
             // if the pipeline ID is invalid, reject
             if (!oldPipeline) {
                 throw boom.notFound(`Pipeline ${id} does not exist`);
+            }
+
+            // for mysql backward compatibility
+            if (!oldPipeline.adminUserIds) {
+                oldPipeline.adminUserIds = [];
             }
 
             if (oldPipeline.configPipelineId) {

--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -90,6 +90,10 @@ async function updateAdmins(userFactory, username, scmContext, pipeline, pipelin
         const user = await userFactory.get({ username, scmContext });
         const userPermissions = await user.getPermissions(pipeline.scmUri, user.scmContext, pipeline.scmRepo);
 
+        // for mysql backward compatibility
+        if (!pipeline.adminUserIds) {
+            pipeline.adminUserIds = [];
+        }
         // Delete user from admin list if bad permissions
         if (!userPermissions.push) {
             const newAdmins = pipeline.admins;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If screwdriver using mysql 5.X, default value cannot be set in TEXT field.
Because of that, old pipelines have null adminUserIds column.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Check adminUserIds and set default value if a value is null.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/data-schema/pull/596

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
