### PR TITLE
feat(3322): Add a DELETING state to the pipeline to block updates during the pipeline deletion [3]

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -124,8 +124,9 @@ module.exports = () => ({
 
             if (!pipeline) {
                 throw boom.notFound();
-            } else if (pipeline.state === 'INACTIVE') {
-                throw boom.badRequest('Cannot create an event for an inactive pipeline');
+            } else if (pipeline.state !== 'ACTIVE') {
+                // INACTIVE or DELETING pipeline
+                throw boom.badRequest(`Cannot create an event for a(n) ${pipeline.state} pipeline`);
             }
 
             payload.scmContext = pipeline.scmContext;

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -29,6 +29,9 @@ module.exports = () => ({
                     if (!pipeline) {
                         throw boom.notFound('Pipeline does not exist');
                     }
+                    if (pipeline.state === 'DELETING') {
+                        throw boom.conflict('This pipeline is being deleted.');
+                    }
                     if (pipeline.configPipelineId && pipeline.state !== 'INACTIVE') {
                         throw boom.forbidden(
                             'Child pipeline can only be removed' +

--- a/plugins/pipelines/remove.js
+++ b/plugins/pipelines/remove.js
@@ -30,7 +30,7 @@ module.exports = () => ({
                         throw boom.notFound('Pipeline does not exist');
                     }
                     if (pipeline.state === 'DELETING') {
-                        throw boom.conflict('This pipeline is being deleted.');
+                        throw boom.conflict('This pipeline is already being deleted.');
                     }
                     if (pipeline.configPipelineId && pipeline.state !== 'INACTIVE') {
                         throw boom.forbidden(

--- a/plugins/pipelines/sync.js
+++ b/plugins/pipelines/sync.js
@@ -38,6 +38,9 @@ module.exports = () => ({
             if (!pipeline) {
                 throw boom.notFound('Pipeline does not exist');
             }
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
             if (!user) {
                 throw boom.notFound(`User ${username} does not exist`);
             }

--- a/plugins/pipelines/syncPRs.js
+++ b/plugins/pipelines/syncPRs.js
@@ -32,6 +32,9 @@ module.exports = () => ({
             if (!pipeline) {
                 throw boom.notFound('Pipeline does not exist');
             }
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
             if (!user) {
                 throw boom.notFound(`User ${username} does not exist`);
             }

--- a/plugins/pipelines/syncWebhooks.js
+++ b/plugins/pipelines/syncWebhooks.js
@@ -32,6 +32,9 @@ module.exports = () => ({
             if (!pipeline) {
                 throw boom.notFound('Pipeline does not exist');
             }
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
             if (!user) {
                 throw boom.notFound(`User ${username} does not exist`);
             }

--- a/plugins/pipelines/tokens/create.js
+++ b/plugins/pipelines/tokens/create.js
@@ -35,6 +35,10 @@ module.exports = () => ({
                 throw boom.notFound('Pipeline does not exist');
             }
 
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
+
             if (!user) {
                 throw boom.notFound(`User ${username} does not exist`);
             }

--- a/plugins/pipelines/tokens/refresh.js
+++ b/plugins/pipelines/tokens/refresh.js
@@ -39,6 +39,10 @@ module.exports = () => ({
                 throw boom.notFound('Pipeline does not exist');
             }
 
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
+
             if (!user) {
                 throw boom.notFound('User does not exist');
             }

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -73,6 +73,9 @@ module.exports = () => ({
             if (!oldPipeline) {
                 throw boom.notFound(`Pipeline ${id} does not exist`);
             }
+            if (oldPipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
 
             // for mysql backward compatibility
             if (!oldPipeline.adminUserIds) {

--- a/plugins/pipelines/updateBuildCluster.js
+++ b/plugins/pipelines/updateBuildCluster.js
@@ -45,10 +45,13 @@ module.exports = () => ({
 
             const { id } = request.params;
             const pipeline = await pipelineFactory.get({ id });
-            // check if pipeline exists
 
+            // check if pipeline exists
             if (!pipeline) {
                 throw boom.notFound(`Pipeline ${id} does not exist`);
+            }
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
             }
 
             const pipelineConfig = await pipeline.getConfiguration({});

--- a/plugins/secrets/create.js
+++ b/plugins/secrets/create.js
@@ -29,6 +29,10 @@ module.exports = () => ({
                 throw boom.notFound(`Pipeline ${request.payload.pipelineId} does not exist`);
             }
 
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
+
             // In pipeline scope, check if the token is allowed to the pipeline
             if (!isValidToken(pipeline.id, request.auth.credentials)) {
                 throw boom.forbidden('Token does not have permission to this pipeline');

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -331,6 +331,7 @@ describe('event plugin test', () => {
             };
             pipelineMock = {
                 id: pipelineId,
+                state: 'ACTIVE',
                 checkoutUrl,
                 scmContext: 'github:github.com',
                 scmRepo,
@@ -1021,11 +1022,28 @@ describe('event plugin test', () => {
             const error = {
                 statusCode: 400,
                 error: 'Bad Request',
-                message: 'Cannot create an event for an inactive pipeline'
+                message: 'Cannot create an event for a(n) INACTIVE pipeline'
             };
             const pipeline = { ...pipelineMock };
 
             pipeline.state = 'INACTIVE';
+
+            pipelineFactoryMock.get.resolves(pipeline);
+
+            return server.inject(options).then(reply => {
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 400 when it the pipeline is being deleted', () => {
+            const error = {
+                statusCode: 400,
+                error: 'Bad Request',
+                message: 'Cannot create an event for a(n) DELETING pipeline'
+            };
+            const pipeline = { ...pipelineMock };
+
+            pipeline.state = 'DELETING';
 
             pipelineFactoryMock.get.resolves(pipeline);
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -877,6 +877,15 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 409 when the pipeline is being deleted', () => {
+            pipeline.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
+                assert.notCalled(pipeline.remove);
+            });
+        });
+
         it('returns 403 when user does not have admin permission and is not Screwdriver admin', () => {
             const error = {
                 statusCode: 403,
@@ -2012,6 +2021,16 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 409 for updating a pipeline is being deleted', () => {
+            pipelineMock.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
+                assert.notCalled(pipelineMock.update);
+                assert.notCalled(pipelineMock.sync);
+            });
+        });
+
         it('returns 404 for updating a pipeline that does not exist', () => {
             pipelineFactoryMock.get.withArgs(id).resolves(null);
 
@@ -2132,6 +2151,14 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 409 for updating a pipeline is being deleted', () => {
+            pipelineMock.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
+            });
+        });
+
         it('returns 404 when user does not exist', () => {
             const error = {
                 statusCode: 404,
@@ -2219,6 +2246,14 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 409 for updating a pipeline that is being deleted', () => {
+            pipelineMock.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
             });
         });
 
@@ -2880,6 +2915,15 @@ describe('pipeline plugin test', () => {
             return server.inject(options).then(reply => {
                 assert.notCalled(updatedPipelineMock.addWebhooks);
                 assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('returns 409 when the pipeline is being deleted', () => {
+            pipelineMock.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.notCalled(updatedPipelineMock.addWebhooks);
+                assert.equal(reply.statusCode, 409);
             });
         });
 
@@ -3562,6 +3606,21 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 409 when pipeline is being deleted', () => {
+            const error = {
+                statusCode: 409,
+                error: 'Conflict',
+                message: 'This pipeline is being deleted.'
+            };
+
+            pipelineMock.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
         it('returns 404 when user does not exist', () => {
             const error = {
                 statusCode: 404,
@@ -3831,6 +3890,21 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
+                assert.deepEqual(reply.result, error);
+            });
+        });
+
+        it('returns 409 when pipeline is beeng deleted', () => {
+            const error = {
+                statusCode: 409,
+                error: 'Conflict',
+                message: 'This pipeline is being deleted.'
+            };
+
+            pipelineMock.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
                 assert.deepEqual(reply.result, error);
             });
         });
@@ -4342,6 +4416,18 @@ describe('pipeline plugin test', () => {
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
                 assert.equal(reply.result.message, `Pipeline ${id} does not exist`);
+            });
+        });
+
+        it('returns 409 when pipeline is being deleted', () => {
+            const pipelineMock = getPipelineMocks(testPipeline);
+
+            pipelineMock.state = 'DELETING';
+            pipelineFactoryMock.get.resolves(pipelineMock);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
+                assert.equal(reply.result.message, 'This pipeline is being deleted.');
             });
         });
 

--- a/test/plugins/secrets.test.js
+++ b/test/plugins/secrets.test.js
@@ -204,6 +204,14 @@ describe('secret plugin test', () => {
             });
         });
 
+        it('returns 409 when the pipeline is being deleted', () => {
+            pipelineMock.state = 'DELETING';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 409);
+            });
+        });
+
         it('returns 403 when the pipeline token does not have permission', () => {
             options.auth.credentials.pipelineId = 111;
             options.auth.credentials.scope = ['pipeline'];


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Pipeline related data is remaining after delete pipeline.
Details - https://github.com/screwdriver-cd/screwdriver/issues/3322

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Check the pipeline is not being deleted before start/update/etc... the pipeline.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3322
PRs
- [1] https://github.com/screwdriver-cd/data-schema/pull/598
- [2] https://github.com/screwdriver-cd/models/pull/644


## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
