### PR TITLE
fix(3322): stop builds before deleting pipeline in functional tests (part2)

### DIFF
--- a/features/step_definitions/authorization.js
+++ b/features/step_definitions/authorization.js
@@ -115,14 +115,10 @@ Then(/^they can start the "main" job$/, { timeout: TIMEOUT }, function step() {
         });
 });
 
-Then(/^they can delete the pipeline$/, { timeout: TIMEOUT }, function step() {
-    return request({
-        method: 'DELETE',
-        context: {
-            token: this.jwt
-        },
-        url: `${this.instance}/${this.namespace}/pipelines/${this.pipelineId}`
-    }).then(resp => {
-        Assert.strictEqual(resp.statusCode, 204);
-    });
+Then(/^they can delete the pipeline$/, { timeout: TIMEOUT }, async function step() {
+    const resp = await this.deletePipeline(this.pipelineId);
+
+    Assert.strictEqual(resp.statusCode, 204);
+
+    return null;
 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/screwdriver/pull/3330

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Re-fix pipeline deletion in functional tests.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
