### PR TITLE
fix (3339): Add dialectOptions settings for datastore conifg

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -95,6 +95,12 @@ datastore:
     retry:
       __name: DATASTORE_SEQUELIZE_RETRY
       __format: json
+    # An object of additional options, which are passed directly to the connection library
+    # Configure SSL/TLS connection settings
+    # https://sequelize.org/docs/v6/other-topics/dialect-specific-things/
+    dialectOptions:
+      __name: DATASTORE_DIALECT_OPTIONS
+      __format: json
     buildMetricsEnabled: DATASTORE_SEQUELIZE_CAPTURE_METRICS_ENABLED
     readOnly:
       __name: DATASTORE_SEQUELIZE_RO

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -97,6 +97,7 @@ datastore:
     ssl: false
     pool: {}
     retry: {}
+    dialectOptions: {}
     buildMetricsEnabled: "false"
     # readOnly datastore config
     # readOnly: {}


### PR DESCRIPTION
## Context
Because there is no `dialectOptions` property in the datastore config, 
we are currently unable to connect to the database via SSL.

## Objective
This PR adds the `dialectOptions` property to the datastore config settings.

## References
Issue: https://github.com/screwdriver-cd/screwdriver/issues/3339
Sequlize Docs: https://sequelize.org/docs/v6/other-topics/dialect-specific-things/

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
