### PR TITLE
fix: Can set log payload flag to false 

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -45,7 +45,15 @@ ecosystem.api = httpdConfig.uri;
 const release = config.get('release');
 
 // Logging config
-const log = config.get('log');
+const log = {...config.get('log')};
+if (log && log.audit && log.audit.enabled !== undefined) {
+    log.audit = {...log.audit}
+    log.audit.enabled = convertToBool(log.audit.enabled);
+}
+if (log && log.payload && log.payload.enabled !== undefined) {
+    log.payload = {...log.payload}
+    log.payload.enabled = convertToBool(log.payload.enabled);
+}
 
 // Notification config
 const notificationConfig = config.get('notifications');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

follow up https://github.com/screwdriver-cd/screwdriver/pull/3321

In the previous fix, when a flag (true/false) was set in an environment variable, the value was of type string, so "false" was also equivalent to true.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Flags are correctly referenced as boolean types.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
