### PR TITLE
[2] fix (3339): Add caCert property, and support for readOnly case

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -84,10 +84,10 @@ const datastoreROConfig = { ...datastorePluginConfig.readOnly };
 let datastoreRO;
 
 if (datastoreROConfig && Object.keys(datastoreROConfig).length > 0) {
-    if (datastorePluginConfig.dialectOptions) {
+    if (!datastoreROConfig.dialectOptions && datastorePluginConfig.dialectOptions) {
         datastoreROConfig.dialectOptions = datastorePluginConfig.dialectOptions;
     }
-    if (datastorePluginConfig.caCert) {
+    if (!datastoreROConfig.dialectOptions && datastorePluginConfig.caCert) {
         datastoreROConfig.caCert = datastorePluginConfig.caCert;
     }
     datastoreRO = new DatastorePlugin(hoek.applyToDefaults({ ecosystem }, datastoreROConfig));

--- a/bin/server
+++ b/bin/server
@@ -80,10 +80,16 @@ const DatastorePlugin = require(`screwdriver-datastore-${datastoreConfig.plugin}
 const datastorePluginConfig = { ...datastoreConfig[datastoreConfig.plugin] };
 
 // Readonly Datastore
-const datastoreROConfig = datastorePluginConfig.readOnly;
+const datastoreROConfig = { ...datastorePluginConfig.readOnly };
 let datastoreRO;
 
 if (datastoreROConfig && Object.keys(datastoreROConfig).length > 0) {
+    if (datastorePluginConfig.dialectOptions) {
+        datastoreROConfig.dialectOptions = datastorePluginConfig.dialectOptions;
+    }
+    if (datastorePluginConfig.caCert) {
+        datastoreROConfig.caCert = datastorePluginConfig.caCert;
+    }
     datastoreRO = new DatastorePlugin(hoek.applyToDefaults({ ecosystem }, datastoreROConfig));
 }
 delete datastorePluginConfig.readOnly;

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -96,11 +96,12 @@ datastore:
       __name: DATASTORE_SEQUELIZE_RETRY
       __format: json
     # An object of additional options, which are passed directly to the connection library
-    # Configure SSL/TLS connection settings
+    # In order to configure SSL/TLS connection settings, use this option and 'caCert' option
     # https://sequelize.org/docs/v6/other-topics/dialect-specific-things/
     dialectOptions:
       __name: DATASTORE_DIALECT_OPTIONS
       __format: json
+    # A file path of ca or a raw certificate string
     caCert: DATASTORE_CA_CERT
     buildMetricsEnabled: DATASTORE_SEQUELIZE_CAPTURE_METRICS_ENABLED
     readOnly:

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -101,6 +101,7 @@ datastore:
     dialectOptions:
       __name: DATASTORE_DIALECT_OPTIONS
       __format: json
+    caCert: DATASTORE_CA_CERT
     buildMetricsEnabled: DATASTORE_SEQUELIZE_CAPTURE_METRICS_ENABLED
     readOnly:
       __name: DATASTORE_SEQUELIZE_RO


### PR DESCRIPTION
## Context
In the following PR, I added the `dialectOptions` property for establishing SSL connections to the database. 
https://github.com/screwdriver-cd/screwdriver/pull/3340
With this PR, I added a property to configure the CA certificate.

## Objective
- Add `caCert` property to the configuration that specifies the CA certificate to be validated when connecting to the database via SSL
- Support for readOnly database connection

## References
- The `dialectOptions` and `caCert` properties will be used in `datastore-sequelize` to connect to the database via SSL.
PR is here:
https://github.com/screwdriver-cd/datastore-sequelize/pull/101

- Issue: https://github.com/screwdriver-cd/screwdriver/issues/3339

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
