### PR TITLE
fix (3339): Remove unnecessary condition

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -95,7 +95,7 @@ if (datastoreROConfig && Object.keys(datastoreROConfig).length > 0) {
     if (!datastoreROConfig.dialectOptions && datastorePluginConfig.dialectOptions) {
         datastoreROConfig.dialectOptions = datastorePluginConfig.dialectOptions;
     }
-    if (!datastoreROConfig.dialectOptions && datastorePluginConfig.caCert) {
+    if (datastorePluginConfig.caCert) {
         datastoreROConfig.caCert = datastorePluginConfig.caCert;
     }
     datastoreRO = new DatastorePlugin(hoek.applyToDefaults({ ecosystem }, datastoreROConfig));


### PR DESCRIPTION
## Context
In the previous PR, the if statement checked for the non-existence of the datastoreROConfig.dialectOptions object. However, because that object was inserted immediately before, the condition was always false.
https://github.com/screwdriver-cd/screwdriver/pull/3342

## Objective
Fix to remove the unnecessary condition

## References
Previous PR
https://github.com/screwdriver-cd/screwdriver/pull/3342

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
