### PR TITLE
feat(3347): Add an endpoint to add users from a different SCM context as admins for a pipeline

### DIFF
--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -44,6 +44,7 @@ const removeTemplateTagRoute = require('./templates/removeTag');
 const removeTemplateVersionRoute = require('./templates/removeVersion');
 const updateTrustedRoute = require('./templates/updateTrusted');
 const updateBuildCluster = require('./updateBuildCluster');
+const updateAdminsRoute = require('./updateAdmins');
 
 /**
  * Pipeline API Plugin
@@ -278,7 +279,8 @@ const pipelinesPlugin = {
             removeTemplateTagRoute(),
             removeTemplateVersionRoute(),
             updateTrustedRoute(),
-            updateBuildCluster()
+            updateBuildCluster(),
+            updateAdminsRoute()
         ]);
     }
 };

--- a/plugins/pipelines/updateAdmins.js
+++ b/plugins/pipelines/updateAdmins.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const joi = require('joi');
+const schema = require('screwdriver-data-schema');
+const logger = require('screwdriver-logger');
+const idSchema = schema.models.pipeline.base.extract('id');
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/pipelines/{id}/updateAdmins',
+    options: {
+        description: 'Update admins of a pipeline',
+        notes: 'Update the admins of a specific pipeline',
+        tags: ['api', 'pipelines'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest', 'pipeline']
+        },
+        handler: async (request, h) => {
+            const { id } = request.params;
+            const { scmContext, username, scmUserId, scope } = request.auth.credentials;
+            const isPipeline = scope.includes('pipeline');
+
+            const { usernames } = request.payload;
+            const payloadScmContext = request.payload.scmContext;
+
+            if (!Array.isArray(usernames) || usernames.length === 0) {
+                throw boom.badRequest(`Payload must contain admin usernames`);
+            } else if (!payloadScmContext) {
+                throw boom.badRequest(`Payload must contain scmContext`);
+            }
+
+            const { pipelineFactory, bannerFactory, userFactory } = request.server.app;
+
+            // Check token permissions
+            if (isPipeline) {
+                if (username !== id) {
+                    throw boom.forbidden(
+                        `User ${username} is not authorized to update admins for the pipeline (id=${id})`
+                    );
+                }
+            } else {
+                // Only SD cluster admins can update the admins
+                const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
+
+                const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                    username,
+                    scmDisplayName,
+                    scmUserId
+                );
+
+                if (!adminDetails.isAdmin) {
+                    throw boom.forbidden(
+                        `User ${username} does not have Screwdriver administrative privileges to update the admins for the pipeline (id=${id})`
+                    );
+                }
+            }
+
+            const pipeline = await pipelineFactory.get({ id });
+
+            // check if pipeline exists
+            if (!pipeline) {
+                throw boom.notFound(`Pipeline ${id} does not exist`);
+            }
+            if (pipeline.state === 'DELETING') {
+                throw boom.conflict('This pipeline is being deleted.');
+            }
+
+            const users = await userFactory.list({
+                params: {
+                    username: usernames,
+                    scmContext: payloadScmContext
+                }
+            });
+
+            const adminUsernamesForUpdate = [];
+            const newAdmins = new Set(pipeline.adminUserIds);
+
+            users.forEach(user => {
+                newAdmins.add(user.id);
+                adminUsernamesForUpdate.push(user.username);
+            });
+
+            pipeline.adminUserIds = Array.from(newAdmins);
+
+            try {
+                const result = await pipeline.update();
+
+                logger.info(`Updated admins ${adminUsernamesForUpdate} for pipeline(id=${id})`);
+
+                return h.response(result.toJson()).code(200);
+            } catch (err) {
+                logger.error(
+                    `Failed to update admins ${adminUsernamesForUpdate} for pipeline(id=${id}): ${err.message}`
+                );
+                throw boom.internal(`Failed to update admins for pipeline ${id}`);
+            }
+        },
+        validate: {
+            params: joi.object({
+                id: idSchema
+            })
+        }
+    }
+});


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/screwdriver/issues/3304 made schema changes to hold users from a scmContext different from the pipeline scmContext as admins.

We need to add a new endpoint in the Screwdriver API to allow cluster admins to add add users from a different SCM context as admins for a pipeline

## Objective

Added a new endpoint `/pipelines/{id}/updateAdmins` which allows SD cluster admins and pipeline to add users from different SCM context to be added as admins

## References

https://github.com/screwdriver-cd/screwdriver/issues/3347

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
