### PR TITLE
fix: get latest commit sha for pr-closed event

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -778,11 +778,17 @@ async function createPrClosedEvent(options, request) {
             try {
                 const b = await p.branch;
                 let eventConfig = {};
-
-                let configPipelineSha = '';
+                const token = await p.token;
+                const pScmConfig = {
+                    scmUri: p.scmUri,
+                    token,
+                    scmRepo: p.scmRepo,
+                    scmContext: scmConfig.scmContext
+                };
+                let latestPipelineSha = '';
 
                 try {
-                    configPipelineSha = await pipelineFactory.scm.getCommitSha(scmConfig);
+                    latestPipelineSha = await pipelineFactory.scm.getCommitSha(pScmConfig);
                 } catch (err) {
                     if (err.status >= 500) {
                         throw err;
@@ -808,14 +814,14 @@ async function createPrClosedEvent(options, request) {
                     webhooks: true,
                     username,
                     scmContext: scmConfig.scmContext,
-                    sha,
+                    sha: latestPipelineSha || sha,
                     startFrom: isPipelineBranch ? startFrom : `${startFrom}:${branch}`,
                     changedFiles,
                     causeMessage: isPipelineBranch ? causeMessage : `${causeMessage} on branch ${branch}`,
                     ref,
                     baseBranch: branch,
                     meta: createMeta(options),
-                    configPipelineSha,
+                    configPipelineSha: latestPipelineSha,
                     prNum,
                     chainPR: resolvedChainPR
                 };

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -3197,14 +3197,14 @@ describe('startHookEvent test', () => {
                         webhooks: true,
                         username,
                         scmContext,
-                        sha,
+                        sha: latestSha,
                         startFrom: '~pr-closed',
                         changedFiles,
                         causeMessage: `PR-${1} ${parsed.action} by ${scmDisplayName}:${username}`,
                         ref: undefined,
                         baseBranch: 'master',
                         meta: { sd: { pr: { name: 'pull/1/merge', merged: true, number: 1 } } },
-                        configPipelineSha: 'a402964c054c610757794d9066c96cee1772daed',
+                        configPipelineSha: latestSha,
                         prNum: 1,
                         chainPR: false
                     };


### PR DESCRIPTION
## Context

Screwdriver pr-closed event should start from latest commit only

## Objective

This PR fixes the issue with starting pr-closed event from latest pipeline sha

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
