### PR TITLE
fix: Improve error handling in functions triggered by event creation

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -175,12 +175,10 @@ module.exports = () => ({
                 payload.prNum = String(prNum);
                 payload.type = 'pr';
 
-                // Declare files and prInfo outside the try block
                 let files;
                 let prInfo;
 
                 try {
-                    // Assign values inside the try block
                     [files, prInfo] = await Promise.all([
                         scm.getChangedFiles({
                             webhookConfig: null,
@@ -193,7 +191,6 @@ module.exports = () => ({
                     throw boom.boomify(err, { statusCode: err.statusCode });
                 }
 
-                // These lines now correctly access files and prInfo
                 if (files && files.length) {
                     payload.changedFiles = files;
                 }
@@ -208,7 +205,6 @@ module.exports = () => ({
                     restrictPR = pipeline.annotations[ANNOT_RESTRICT_PR];
                 }
 
-                // PR author should be able to rerun their own PR build if restrictPR is not on
                 if (restrictPR !== 'none' || prInfo.username !== username) {
                     // Remove user from admins
                     try {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
There have been frequent 500 errors occurring during event creation.  
In some of these cases, improper error handling caused the default 500 status code to be returned.  
This PR improves error handling in the functions involved in event creation.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Modified the call to updateAdmins to use a try-catch block
- Improved error handling during event creation by replacing .catch() with try-catch 
  - The reason is that .catch() only handles cases where a Promise is explicitly rejected.
If an exception is thrown inside the called function, it may not be properly caught. 

## References
- https://hapi.dev/api/?v=21.4.0
> Any error thrown by a lifecycle method is converted into a boom object and defaults to status code 500 if the error is not already a boom object.

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
