### PR TITLE
fix(3043): teardown job is not triggered in PR

### DIFF
--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -167,12 +167,12 @@ async function getStageJobBuilds({ stage, event, jobFactory }) {
             const jobName = prStageName ? `${prStageName[1]}:${n.name}` : n.name;
             const job = await jobFactory.get({ pipelineId: event.pipelineId, name: jobName });
 
-            return job.id;
+            return job ? job.id : null;
         })
     );
 
     // Get all builds in a stage for this event
-    return event.getBuilds({ params: { jobId: stageJobIds } });
+    return event.getBuilds({ params: { jobId: stageJobIds.filter(id => id !== null) } });
 }
 
 /**


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/screwdriver/pull/3352 .

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

In PR workflow, some jobs are not created since these are not in PR workflow.
This PR adds checking job existence.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3043

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
