### PR TITLE
fix(3043): commit status for virtual teardown job always shows pending when the stage does not complete succeed

### DIFF
--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -384,11 +384,12 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
             if (stageIsDone) {
                 const teardownNode = newEvent.workflowGraph.nodes.find(n => n.id === stageTeardownJob.id);
 
+                stageTeardownBuild.parentBuildId = stageJobBuilds.map(b => b.id);
+
                 if (teardownNode && teardownNode.virtual) {
                     await updateVirtualBuildSuccess(stageTeardownBuild);
                 } else {
                     stageTeardownBuild.status = 'QUEUED';
-                    stageTeardownBuild.parentBuildId = stageJobBuilds.map(b => b.id);
 
                     await stageTeardownBuild.update();
                     await stageTeardownBuild.start();

--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -5,6 +5,7 @@ const hoek = require('@hapi/hoek');
 const merge = require('lodash.mergewith');
 const { PR_JOB_NAME, PR_STAGE_NAME, STAGE_TEARDOWN_PATTERN } = require('screwdriver-data-schema').config.regex;
 const { getFullStageJobName } = require('../../helper');
+const { updateVirtualBuildSuccess } = require('../triggers/helpers');
 const TERMINAL_STATUSES = ['FAILURE', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
 const FINISHED_STATUSES = ['FAILURE', 'SUCCESS', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
 
@@ -381,12 +382,17 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
             const stageIsDone = isStageDone(stageJobBuilds);
 
             if (stageIsDone) {
-                stageTeardownBuild.status = 'QUEUED';
-                stageTeardownBuild.parentBuildId = stageJobBuilds.map(b => b.id);
+                const teardownNode = newEvent.workflowGraph.nodes.find(n => n.id === stageTeardownJob.id);
 
-                // TODO: Handle if a teardown job is virtual
-                await stageTeardownBuild.update();
-                await stageTeardownBuild.start();
+                if (teardownNode && teardownNode.virtual) {
+                    await updateVirtualBuildSuccess(stageTeardownBuild);
+                } else {
+                    stageTeardownBuild.status = 'QUEUED';
+                    stageTeardownBuild.parentBuildId = stageJobBuilds.map(b => b.id);
+
+                    await stageTeardownBuild.update();
+                    await stageTeardownBuild.start();
+                }
             }
         }
     }

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -86,7 +86,7 @@ class OrBase {
 
         // Bypass execution of the build if the job is virtual
         if (isNextJobVirtual && !hasWindows) {
-            return updateVirtualBuildSuccess(nextBuild);
+            await updateVirtualBuildSuccess(nextBuild);
         }
 
         return nextBuild;

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const merge = require('lodash.mergewith');
-const { createInternalBuild, Status, BUILD_STATUS_MESSAGES, hasFreezeWindows } = require('./helpers');
+const { createInternalBuild, Status, updateVirtualBuildSuccess, hasFreezeWindows } = require('./helpers');
 
 /**
  * @typedef {import('screwdriver-models').BuildFactory} BuildFactory
@@ -60,14 +59,7 @@ class OrBase {
 
             // Bypass execution of the build if the job is virtual
             if (isNextJobVirtual && !hasWindows) {
-                nextBuild.status = Status.SUCCESS;
-                nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
-                nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
-
-                // Overwrite metadata by current build's
-                nextBuild.meta = merge({}, this.currentBuild.meta);
-
-                return nextBuild.update();
+                return updateVirtualBuildSuccess(nextBuild);
             }
 
             nextBuild.status = Status.QUEUED;
@@ -94,14 +86,7 @@ class OrBase {
 
         // Bypass execution of the build if the job is virtual
         if (isNextJobVirtual && !hasWindows) {
-            nextBuild.status = Status.SUCCESS;
-            nextBuild.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
-            nextBuild.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
-
-            // Overwrite metadata by current build's
-            nextBuild.meta = merge({}, this.currentBuild.meta);
-
-            await nextBuild.update();
+            return updateVirtualBuildSuccess(nextBuild);
         }
 
         return nextBuild;

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2725,6 +2725,7 @@ describe('build plugin test', () => {
                         status: 'CREATED',
                         endTime: '',
                         meta: {},
+                        initMeta: sinon.stub(),
                         update: sinon.stub()
                     };
                     const buildE = {
@@ -2746,6 +2747,7 @@ describe('build plugin test', () => {
                         endTime: '',
                         parentBuildId: buildD.id,
                         meta: {},
+                        initMeta: sinon.stub(),
                         update: sinon.stub()
                     };
 
@@ -2801,14 +2803,8 @@ describe('build plugin test', () => {
                         assert.equal(buildD.status, 'SUCCESS');
                         assert.equal(buildD.statusMessage, 'Skipped execution of the virtual job');
                         assert.equal(buildD.statusMessageType, 'INFO');
-                        assert.deepEqual(buildD.parentBuildId, [buildC.id, buildA.id, buildB.id]);
-                        assert.deepEqual(buildD.meta, {
-                            jobA: 'test',
-                            jobB: 'test',
-                            jobC: 'test',
-                            acKey: 'job-a',
-                            allKey: 'job-b'
-                        });
+                        assert.sameMembers(buildD.parentBuildId, [buildC.id, buildA.id, buildB.id]);
+                        assert.calledOnce(buildD.initMeta);
 
                         // Virtual job triggers its downstream jobs
                         assert.calledWith(buildFactoryMock.create.firstCall, jobEConfig);
@@ -2819,13 +2815,7 @@ describe('build plugin test', () => {
                         assert.equal(buildF.statusMessage, 'Skipped execution of the virtual job');
                         assert.equal(buildF.statusMessageType, 'INFO');
                         assert.deepEqual(buildF.parentBuildId, buildD.id);
-                        assert.deepEqual(buildF.meta, {
-                            jobA: 'test',
-                            jobB: 'test',
-                            jobC: 'test',
-                            acKey: 'job-a',
-                            allKey: 'job-b'
-                        });
+                        assert.calledOnce(buildF.initMeta);
                     });
                 });
 

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -1134,6 +1134,7 @@ describe('handleNewBuild function', () => {
             status: Status.CREATED,
             eventId: 456,
             parentBuilds: { 123: { jobs: { a: 1 } } },
+            initMeta: sinon.stub().resolves(),
             update: sinon.stub().resolves(),
             start: sinon.stub().resolvesThis(),
             remove: sinon.stub().resolves()

--- a/test/plugins/trigger.test.helper.js
+++ b/test/plugins/trigger.test.helper.js
@@ -2,6 +2,7 @@
 
 /* eslint max-classes-per-file: off */
 
+const { PR_JOB_NAME } = require('screwdriver-data-schema').config.regex;
 const configParser = require('screwdriver-config-parser').parsePipelineYaml;
 const workflowParser = require('screwdriver-workflow-parser');
 const fs = require('fs');
@@ -568,6 +569,7 @@ class BuildFactoryMock {
             ...config,
             id: this.records.length,
             update: sinon.stub(),
+            initMeta: sinon.stub(),
             toJson: sinon.stub(),
             toJsonWithSteps: sinon.stub()
         };
@@ -806,12 +808,12 @@ class JobFactoryMock {
         this.records.push(job);
         job.toJson.returns({ ...job });
         job.parsePRJobName = type => {
-            if (!job.name.startsWith('PR-')) return null;
+            const match = job.name.match(PR_JOB_NAME);
 
-            const match = job.name.split(':');
+            if (!match) return null;
 
-            if (type === 'pr') return match[0];
-            if (type === 'job') return match[1];
+            if (type === 'pr') return match[1];
+            if (type === 'job') return match[2];
 
             return assert.fail(`Invalid argument: job.parsePRJobName(${type})`);
         };

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -3296,7 +3296,7 @@ describe('trigger tests', () => {
             await event.getBuildOf('PR-1:b').complete('SUCCESS');
 
             // teardown job is triggered
-            assert.equal(event.getBuildOf('PR-1:stage@simple:teardown').status, 'RUNNING');
+            assert.equal(event.getBuildOf('PR-1:stage@simple:teardown').status, 'SUCCESS');
         });
 
         it('stage teardown is triggered when some stage builds fail', async () => {
@@ -3315,7 +3315,7 @@ describe('trigger tests', () => {
             await event.getBuildOf('PR-1:b').complete('FAILURE');
 
             // teardown job is triggered
-            assert.equal(event.getBuildOf('PR-1:stage@simple:teardown').status, 'RUNNING');
+            assert.equal(event.getBuildOf('PR-1:stage@simple:teardown').status, 'SUCCESS');
         });
 
         it('stage jobs are triggered in PR when chainPR is enabled', async () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Stage teardown build's commit status does not updated from `pending` to `success` when that stage has some failed builds or has not triggered build.

This is always happened in PR stage case because only child jobs of the stage setup are triggered and others are not triggered in PR stage.

![eg](https://github.com/user-attachments/assets/fec00b72-9ec6-4961-9e37-5042061a4af8)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Add handling for virtual teardown job that triggered in non-completed stage
- Use `build.initMeta()` introduced by https://github.com/screwdriver-cd/models/pull/647

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/3043
- Similar fix - https://github.com/screwdriver-cd/models/pull/632

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
