### PR TITLE
feat: configure webhook settings based on scm

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -361,18 +361,32 @@ scms:
   #         # SCM clone type (https or ssh)
   #         cloneType: SCM_GITLAB_RO_CLONE_TYPE
 webhooks:
-  # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
-  username: SCM_USERNAME
-  # Ignore commits made by these users
-  ignoreCommitsBy:
-    __name: IGNORE_COMMITS_BY
-    __format: json
-  # Restrict PR: all, none, branch, or fork
-  restrictPR: RESTRICT_PR
-  # Chain PR: true or false
-  chainPR: CHAIN_PR
-  # Upper limit on incoming uploads to builds
-  maxBytes: WEBHOOK_MAX_BYTES
+  # Object keyed by scm name with value webhook settings.
+  # Value of webhook settings is an object with the following properties:
+  # Example:
+  # {
+  #  "github": {
+  #   # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
+  #   "username": "sd-buildbot",
+  #   # Ignore commits made by these users
+  #   "ignoreCommitsBy": [],
+  #   # Restrict PR: all, none, branch, or fork
+  #   "restrictPR": "none",
+  #   # Chain PR: true or false
+  #   "chainPR": false,
+  #   # Upper limit on incoming uploads to builds
+  #   "maxBytes": 1048576 #1MB
+  #   },
+  #  "github.example.com": {
+  #     "username": "someuser",
+  #     "ignoreCommitsBy": ["someuser", "anotheruser"],
+  #     "restrictPR": "branch",
+  #     "chainPR": true,
+  #     "maxBytes": 2097152 #2MB
+  #   }
+  # }
+  __name: WEBHOOK_SETTINGS
+  __format: json
 
 bookends:
   # Object keyed by cluster name with value setup/teardown bookend.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -277,18 +277,42 @@ scms: {}
 #         accessToken: headlesstoken
 #         # SCM clone type (https or ssh)
 #         cloneType: https
-webhooks:
-  # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
-  username: sd-buildbot
-  # Ignore commits made by these users
-  ignoreCommitsBy: []
-  # Restrict PR: all, none, branch, or fork
-  restrictPR: none
-  # Chain PR: true or false
-  chainPR: false
-  # Upper limit on incoming uploads to builds
-  maxBytes: 1048576 # 1MB
-
+webhooks: 
+  github: 
+    # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
+    username: sd-buildbot
+    # Ignore commits made by these users
+    ignoreCommitsBy: []
+    # Restrict PR: all, none, branch, or fork
+    restrictPR: none
+    # Chain PR: true or false
+    chainPR: false
+    # Upper limit on incoming uploads to builds
+    maxBytes: 1048576 #1MB
+  # Object keyed by scm name with value webhook settings.
+  # Value of webhook settings is an object with the following properties:
+  # Example:
+  # {
+  #  "github:github.com": {
+  #   # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.
+  #   "username": "sd-buildbot",
+  #   # Ignore commits made by these users
+  #   "ignoreCommitsBy": [],
+  #   # Restrict PR: all, none, branch, or fork
+  #   "restrictPR": "none",
+  #   # Chain PR: true or false
+  #   "chainPR": false,
+  #   # Upper limit on incoming uploads to builds
+  #   "maxBytes": 1048576 #1MB
+  #   },
+  #  "github.example.com": {
+  #     "username": "someuser",
+  #     "ignoreCommitsBy": ["someuser", "anotheruser"],
+  #     "restrictPR": "branch",
+  #     "chainPR": true,
+  #     "maxBytes": 2097152 #2MB
+  #   }
+  # }
 coverage:
   default: "false"
   plugin: sonar

--- a/lib/server.js
+++ b/lib/server.js
@@ -80,8 +80,6 @@ function handlePreResponseLogs(request, h) {
  * @param  {String}      config.httpd.uri           Public routable address
  * @param  {Object}      config.httpd.tls           TLS Configuration
  * @param  {Object}      config.webhooks            Webhooks settings
- * @param  {String}      config.webhooks.restrictPR Restrict PR setting
- * @param  {Boolean}     config.webhooks.chainPR    Chain PR flag
  * @param  {Object}      config.ecosystem           List of hosts in the ecosystem
  * @param  {Object}      config.ecosystem.ui        URL for the User Interface
  * @param  {Factory}     config.pipelineFactory     Pipeline Factory instance


### PR DESCRIPTION
## Context

Webhook currently does not support configuration for multiple scm repo which is needed for running github enterprise and cloud

## Objective

This PR adds logic to update configuration to support multiple scms

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
