### PR TITLE
fix: Correctly triggered branch specific triggers on pr-closed

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -47,7 +47,11 @@ function determineStartFrom(action, type, targetBranch, pipelineBranch, releaseN
     let startFrom;
 
     if (type && type === 'pr') {
-        startFrom = '~pr';
+        if (action && action === 'closed') {
+            startFrom = '~pr-closed';
+        } else {
+            startFrom = '~pr';
+        }
     } else {
         switch (action) {
             case 'release':
@@ -890,7 +894,9 @@ async function pullRequestClosed(options, request, h) {
                     j.permutations.length > 0 &&
                     j.permutations[0] &&
                     j.permutations[0].requires &&
-                    j.permutations[0].requires.includes('~pr-closed')
+                    j.permutations[0].requires.some(
+                        require => require === '~pr-closed' || require.startsWith('~pr-closed:')
+                    )
             );
 
             prClosedJobs.push(...filteredJobs);

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -3391,7 +3391,6 @@ describe('startHookEvent test', () => {
                             { src: '~pr-closed', dest: 'job4' }
                         ]
                     };
-                    expected.meta.sd.pr.merged = false;
 
                     return startHookEvent(request, responseHandler, parsed).then(reply => {
                         assert.notCalled(eventFactoryMock.create);

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -215,6 +215,43 @@ describe('determineStartFrom function', () => {
             '~tag:tagName'
         );
     });
+
+    it('determines to "~pr-closed" when type is "pr" and action is "closed"', () => {
+        type = 'pr';
+        action = 'closed';
+
+        assert.equal(
+            determineStartFrom(
+                action,
+                type,
+                targetBranch,
+                pipelineBranch,
+                releaseName,
+                tagName,
+                isReleaseOrTagFiltering
+            ),
+            '~pr-closed'
+        );
+    });
+
+    it('determines to "~pr-closed:branch" when type is "pr", action is "closed" and targetBranch is branch', () => {
+        type = 'pr';
+        action = 'closed';
+        targetBranch = 'branch';
+
+        assert.equal(
+            determineStartFrom(
+                action,
+                type,
+                targetBranch,
+                pipelineBranch,
+                releaseName,
+                tagName,
+                isReleaseOrTagFiltering
+            ),
+            '~pr-closed:branch'
+        );
+    });
 });
 
 describe('resolveChainPR function', () => {
@@ -3321,6 +3358,44 @@ describe('startHookEvent test', () => {
                     return startHookEvent(request, responseHandler, parsed).then(reply => {
                         assert.calledWith(eventFactoryMock.create, expected);
                         assert.equal(reply.statusCode, 201);
+                    });
+                });
+
+                it('starts a pr-closed event when pr is closed on specific branch', () => {
+                    parsed.prMerged = false;
+                    parsed.branch = 'stable';
+                    pipelineFactoryMock.scm.parseUrl.resolves('github.com:123456:stable');
+                    pipelineMock.workflowGraph = {
+                        nodes: [{ name: '~pr-closed:stable' }, { name: 'job4' }],
+                        edges: [{ src: '~pr-closed:stable', dest: 'job4' }]
+                    };
+                    expected.meta.sd.pr.merged = false;
+                    expected.startFrom = '~pr-closed:stable';
+                    expected.baseBranch = 'stable';
+                    expected.causeMessage = `PR-${1} ${parsed.action} by ${scmDisplayName}:${username} on branch stable`;
+
+                    return startHookEvent(request, responseHandler, parsed).then(reply => {
+                        assert.calledWith(eventFactoryMock.create, expected);
+                        assert.equal(reply.statusCode, 201);
+                    });
+                });
+
+                it('does not start a pr-closed event when pr is closed and target branch is not specified', () => {
+                    parsed.prMerged = false;
+                    parsed.branch = 'stable';
+                    pipelineFactoryMock.scm.parseUrl.resolves('github.com:123456:stable');
+                    pipelineMock.workflowGraph = {
+                        nodes: [{ name: '~pr-closed' }, { name: '~pr-closed:branch' }, { name: 'job4' }],
+                        edges: [
+                            { src: '~pr-closed:branch', dest: 'job4' },
+                            { src: '~pr-closed', dest: 'job4' }
+                        ]
+                    };
+                    expected.meta.sd.pr.merged = false;
+
+                    return startHookEvent(request, responseHandler, parsed).then(reply => {
+                        assert.notCalled(eventFactoryMock.create);
+                        assert.equal(reply.statusCode, 204);
                     });
                 });
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently, branch specific triggers on pr-closed is only triggered a pipeline has also `~pr-closed` and `~pr:{branch}` triggers.
I fixed this behavior and correctly triggered branch specific triggers without define `~pr-closed` and `~pr:{branch}` job.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- When pr-closed event is occurred, start from is not correctly determined. I fixed determineStartFrom logic for pr-closed event.
- When filtering pr-closed jobs, it is not considered on branch specific trigger. I fixed filtering criteria to account for branch-specific triggers.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
