### PR TITLE
feat(3347): Add an endpoint to add users from a different SCM context as admins for multiple pipelines in a batch

### DIFF
--- a/plugins/pipelines/batchUpdateAdmins.js
+++ b/plugins/pipelines/batchUpdateAdmins.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const schema = require('screwdriver-data-schema');
+const joi = require('joi');
+const idSchema = schema.models.pipeline.base.extract('id');
+const scmContextSchema = schema.models.pipeline.base.extract('scmContext');
+const usernameSchema = schema.models.user.base.extract('username');
+const { updatePipelineAdmins } = require('./helper/updateAdmins');
+
+module.exports = () => ({
+    method: 'PUT',
+    path: '/pipelines/updateAdmins',
+    options: {
+        description: 'Update admins for a collection of pipelines',
+        notes: 'Update the admins for a collection of pipelines',
+        tags: ['api', 'pipelines'],
+        auth: {
+            strategies: ['token'],
+            scope: ['user', '!guest']
+        },
+        handler: async (request, h) => {
+            const { scmContext, username, scmUserId } = request.auth.credentials;
+            const { payload } = request;
+
+            const { bannerFactory } = request.server.app;
+
+            // Check token permissions
+            // Only SD cluster admins can update the admins
+            const scmDisplayName = bannerFactory.scm.getDisplayName({ scmContext });
+
+            const adminDetails = request.server.plugins.banners.screwdriverAdminDetails(
+                username,
+                scmDisplayName,
+                scmUserId
+            );
+
+            if (!adminDetails.isAdmin) {
+                throw boom.forbidden(
+                    `User ${username} does not have Screwdriver administrative privileges to update the admins for pipelines`
+                );
+            }
+
+            await Promise.all(
+                payload.map(e => {
+                    return updatePipelineAdmins(e, request.server);
+                })
+            );
+
+            return h.response().code(204);
+        },
+        validate: {
+            payload: joi
+                .array()
+                .items(
+                    joi.object({
+                        id: idSchema.required(),
+                        scmContext: scmContextSchema.required(),
+                        usernames: joi.array().items(usernameSchema).min(1).max(50).required()
+                    })
+                )
+                .min(1)
+        }
+    }
+});

--- a/plugins/pipelines/helper/updateAdmins.js
+++ b/plugins/pipelines/helper/updateAdmins.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const boom = require('@hapi/boom');
+const logger = require('screwdriver-logger');
+
+/**
+ * @typedef {import('screwdriver-models/lib/pipeline')} Pipeline
+ */
+
+/**
+ * Adds the users as admins for the specified pipeline
+ *
+ * @method updateBuildAndTriggerDownstreamJobs
+ * @param   {Object}    config
+ * @param   {Number}    config.id Pipeline id
+ * @param   {Array}     [config.usernames] List of usernames to be added as admins to the pipeline
+ * @param   {String}    config.scmContext SCM Context the users are associated with
+ * @param   {Object}    server
+ * @returns {Promise<Pipeline>} Updated pipeline
+ */
+async function updatePipelineAdmins(config, server) {
+    const { pipelineFactory, userFactory } = server.app;
+    const { id, scmContext, usernames } = config;
+
+    const pipeline = await pipelineFactory.get({ id });
+
+    // check if pipeline exists
+    if (!pipeline) {
+        throw boom.notFound(`Pipeline ${id} does not exist`);
+    }
+    if (pipeline.state === 'DELETING') {
+        throw boom.conflict('This pipeline is being deleted.');
+    }
+
+    const users = await userFactory.list({
+        params: {
+            username: usernames,
+            scmContext
+        }
+    });
+
+    const adminUsernamesForUpdate = [];
+    const newAdmins = new Set(pipeline.adminUserIds);
+
+    users.forEach(user => {
+        newAdmins.add(user.id);
+        adminUsernamesForUpdate.push(user.username);
+    });
+
+    pipeline.adminUserIds = Array.from(newAdmins);
+
+    try {
+        const updatedPipeline = await pipeline.update();
+
+        logger.info(`Updated admins ${adminUsernamesForUpdate} for pipeline(id=${id})`);
+
+        return updatedPipeline;
+    } catch (err) {
+        logger.error(`Failed to update admins ${adminUsernamesForUpdate} for pipeline(id=${id}): ${err.message}`);
+        throw boom.internal(`Failed to update admins for pipeline ${id}`);
+    }
+}
+
+module.exports = {
+    updatePipelineAdmins
+};

--- a/plugins/pipelines/index.js
+++ b/plugins/pipelines/index.js
@@ -45,6 +45,7 @@ const removeTemplateVersionRoute = require('./templates/removeVersion');
 const updateTrustedRoute = require('./templates/updateTrusted');
 const updateBuildCluster = require('./updateBuildCluster');
 const updateAdminsRoute = require('./updateAdmins');
+const batchUpdateAdminsRoute = require('./batchUpdateAdmins');
 
 /**
  * Pipeline API Plugin
@@ -280,7 +281,8 @@ const pipelinesPlugin = {
             removeTemplateVersionRoute(),
             updateTrustedRoute(),
             updateBuildCluster(),
-            updateAdminsRoute()
+            updateAdminsRoute(),
+            batchUpdateAdminsRoute()
         ]);
     }
 };


### PR DESCRIPTION
## Context
A new endpoint `/pipelines/{id}/updateAdmins` was added in https://github.com/screwdriver-cd/screwdriver/pull/3348 to add users from a different SCM context as admins for a single pipeline.

Need an endpoint to do the same for pipelines at once.

## Objective

Added a new endpoint `/pipelines/updateAdmins` to update admins for multiple pipelines in a batch

**Sample Payload:**
```
[
    {
        "id": 6,
        "scmContext": "bitbucket:bitbucket.org",
        "usernames": ["sagar1312"]
    },
    {
        "id": 8,
        "scmContext": "bitbucket:bitbucket.org",
        "usernames": ["sagar1312"]
    }
]
```

## References

https://github.com/screwdriver-cd/screwdriver/issues/3347

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
