### PR TITLE
feat(3363): Update the existing endpoint to get admin for a pipeline from the specified SCM context

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "screwdriver-executor-queue": "^6.0.0",
     "screwdriver-executor-router": "^5.0.0",
     "screwdriver-logger": "^3.0.0",
-    "screwdriver-models": "^32.4.0",
+    "screwdriver-models": "^32.8.0",
     "screwdriver-notifications-email": "^5.0.0",
     "screwdriver-notifications-slack": "^7.0.0",
     "screwdriver-request": "^3.0.0",

--- a/plugins/pipelines/admins/get.js
+++ b/plugins/pipelines/admins/get.js
@@ -16,13 +16,19 @@ module.exports = () => ({
         tags: ['api', 'pipelines'],
         auth: {
             strategies: ['token'],
-            scope: ['user', 'pipeline', '!guest']
+            scope: ['user', 'admin', 'pipeline', '!guest']
         },
 
         handler: async (request, h) => {
-            const factory = request.server.app.pipelineFactory;
+            const pipelineFactory = request.server.app.pipelineFactory;
+            const { scope } = request.auth.credentials;
             const { scmContext, includeUserToken } = request.query;
-            const pipeline = await factory.get(request.params.id);
+
+            if (includeUserToken && !scope.includes('admin')) {
+                throw boom.forbidden('Only Screwdriver admin is allowed to request user token');
+            }
+
+            const pipeline = await pipelineFactory.get(request.params.id);
 
             if (!pipeline) {
                 throw boom.notFound('Pipeline does not exist');

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -210,6 +210,9 @@ describe('pipeline plugin test', () => {
     let triggerFactoryMock;
     let secretFactoryMock;
     let bannerMock;
+    let authMock;
+    let generateTokenMock;
+    let generateProfileMock;
     let screwdriverAdminDetailsMock;
     let scmMock;
     let pipelineTemplateFactoryMock;
@@ -300,6 +303,8 @@ describe('pipeline plugin test', () => {
         buildClusterFactoryMock = {
             get: sinon.stub()
         };
+        generateProfileMock = sinon.stub();
+        generateTokenMock = sinon.stub();
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/pipelines');
@@ -336,8 +341,17 @@ describe('pipeline plugin test', () => {
         }));
         server.auth.strategy('token', 'custom');
 
+        authMock = {
+            name: 'auth',
+            register: s => {
+                s.expose('generateToken', generateTokenMock);
+                s.expose('generateProfile', generateProfileMock);
+            }
+        };
+
         server.register([
             { plugin: bannerMock },
+            { plugin: authMock },
             {
                 plugin,
                 options: {
@@ -3278,7 +3292,6 @@ describe('pipeline plugin test', () => {
 
     describe('GET /pipelines/{id}/admin', () => {
         const id = 123;
-        const scmUri = 'github.com:12345:branchName';
         const token = {
             id: 12345,
             name: 'pipelinetoken',
@@ -3288,7 +3301,9 @@ describe('pipeline plugin test', () => {
         };
         let options;
         let pipelineMock;
-        let userMock;
+        let adminUser;
+        let profile;
+        let userToken;
 
         beforeEach(() => {
             options = {
@@ -3303,34 +3318,92 @@ describe('pipeline plugin test', () => {
                     strategy: ['token']
                 }
             };
-            userMock = getUserMock({ username, scmContext });
-            userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
-            userFactoryMock.get.withArgs({ username, scmContext }).resolves(userMock);
             pipelineMock = getPipelineMocks(testPipeline);
-            pipelineMock.getFirstAdmin.resolves({
-                username: 'abc'
-            });
+            adminUser = {
+                username: 'abc',
+                scmContext
+            };
+            pipelineMock.getFirstAdmin.resolves(adminUser);
             pipelineMock.tokens = Promise.resolve(getTokenMocks([token]));
             pipelineFactoryMock.get.withArgs(id).resolves(pipelineMock);
+            profile = {
+                username: adminUser.username,
+                scmContext: adminUser.scmContext,
+                scope: ['user']
+            };
+            userToken = 'some-user-token';
+
+            generateProfileMock.returns(profile);
+            generateTokenMock.returns(userToken);
         });
         it('returns 200 with admin info for a pipeline', () =>
             server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
                 const res = JSON.parse(reply.payload);
 
-                assert.equal(res.username, 'abc');
+                assert.deepEqual(res, adminUser);
+                assert.callCount(generateProfileMock, 0);
+                assert.callCount(generateTokenMock, 0);
             }));
         it('returns 200 with admin info for a pipeline and specified scmContext', () => {
+            adminUser.scmContext = differentScmContext;
             options.url = `/pipelines/${id}/admin?scmContext=${differentScmContext}`;
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
                 const res = JSON.parse(reply.payload);
 
-                assert.equal(res.username, 'abc');
+                assert.deepEqual(res, adminUser);
                 assert.calledWith(pipelineMock.getFirstAdmin, {
                     scmContext: differentScmContext
                 });
+                assert.callCount(generateProfileMock, 0);
+                assert.callCount(generateTokenMock, 0);
+            });
+        });
+        it('returns 200 with admin info along with user token for a pipeline when requested by SD admin', () => {
+            options.auth.credentials.scope.push('admin');
+            options.url = `/pipelines/${id}/admin?includeUserToken=true`;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                const res = JSON.parse(reply.payload);
+
+                assert.deepEqual(res, { ...adminUser, userToken });
+                assert.calledWith(generateProfileMock, {
+                    username: adminUser.username,
+                    scmContext: adminUser.scmContext,
+                    scope: ['user']
+                });
+                assert.calledWith(generateTokenMock, profile);
+            });
+        });
+        it('returns 200 with admin info with out user token for a pipeline when requested by SD admin', () => {
+            options.auth.credentials.scope.push('admin');
+            options.url = `/pipelines/${id}/admin?includeUserToken=false`;
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                const res = JSON.parse(reply.payload);
+
+                assert.deepEqual(res, adminUser);
+                assert.callCount(generateProfileMock, 0);
+                assert.callCount(generateTokenMock, 0);
+            });
+        });
+        it('returns 403 when non SD admin requests for pipeline admin along with user token', () => {
+            options.url = `/pipelines/${id}/admin?includeUserToken=true`;
+
+            return server.inject(options).then(reply => {
+                const res = JSON.parse(reply.payload);
+
+                assert.equal(reply.statusCode, 403);
+                assert.equal(res.message, 'Only Screwdriver admin is allowed to request user token');
+
+                assert.callCount(pipelineFactoryMock.get, 0);
+                assert.callCount(pipelineMock.getFirstAdmin, 0);
+                assert.callCount(generateProfileMock, 0);
+                assert.callCount(generateTokenMock, 0);
             });
         });
         it('returns 404 when pipeline has no admin', () => {


### PR DESCRIPTION
## Context

The current endpoint `/pipelines/{id}/admin` returns an admin for a pipeline where the admin user is from the same SCM context as that of the pipeline.

## Objective

Update the endpoint to find admin for a pipeline where the admin user SCM context is different pipeline SCM context.
SCM context is passed via the query param `scmContext`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3363

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
