### PR TITLE
fix(3373): Improving the performance of the GET badge API [2]

### DIFF
--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -57,7 +57,7 @@ module.exports = config => ({
                         'baseBranch'
                     ],
                     paginate: {
-                        count: 100
+                        count: 100 // Set a large value for LIMIT so that the efficient index is used in SQL.
                     },
                     sort: 'descending',
                     sortBy: 'createTime'


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This is a correction related to https://github.com/screwdriver-cd/screwdriver/issues/3373.
Improves excessive API execution times in MySQL environments with large amounts of events data.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Use events.status to filter events where build exists.
- When paginate.count is 1, the MySQL optimizer selects the createTime index, resulting in a very inefficient search. Setting a large value such as 100 will cause the pipelineId index to be used.

Please see the comments on the issue for details.
https://github.com/screwdriver-cd/screwdriver/issues/3373#issuecomment-3116924377

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Please merge the data-schema PR first.
https://github.com/screwdriver-cd/data-schema/pull/606


## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
