### PR TITLE
feat(3375): Allow users with push permission to delete pipeline or job cache

### DIFF
--- a/plugins/pipelines/caches/delete.js
+++ b/plugins/pipelines/caches/delete.js
@@ -48,7 +48,7 @@ module.exports = () => ({
             const scmUri = await getScmUri({ pipeline, pipelineFactory });
 
             // Check the user's permission
-            await getUserPermissions({ user, scmUri });
+            await getUserPermissions({ user, scmUri, level: 'push' });
 
             const res = await api.invoke(request);
             const statusCode = res.statusCode === 200 ? 204 : res.statusCode;


### PR DESCRIPTION
## Context
Users with `push` permission to the pipeline repo are not allowed to delete pipeline/job cache.
Only the users with `admin` permission to the pipeline repo are allowed to do so.

## Objective

Relax the permission check in the below endpoint to allow users with `push` permissions (not admin on the repo) to delete cache. 
```
    method: 'DELETE',
    path: '/pipelines/{id}/caches',
```

## References

https://github.com/screwdriver-cd/screwdriver/issues/3375

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
