### PR TITLE
fix(3367): Add support for removing badges

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -172,10 +172,12 @@ module.exports = () => ({
                     const newBadges = {};
 
                     Object.keys(oldPipeline.badges).forEach(badgeKey => {
-                        newBadges[badgeKey] = {
-                            ...oldPipeline.badges[badgeKey],
-                            ...badges[badgeKey]
-                        };
+                        if (badges[badgeKey] && Object.keys(badges[badgeKey]).length > 0) {
+                            newBadges[badgeKey] = {
+                                ...oldPipeline.badges[badgeKey],
+                                ...badges[badgeKey]
+                            };
+                        }
                     });
 
                     oldPipeline.badges = newBadges;

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2991,6 +2991,42 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 200 when updating the pipeline to remove sonar badges', () => {
+            options.auth.credentials = {
+                username,
+                scmContext,
+                pipelineId: id,
+                scope: ['pipeline']
+            };
+
+            pipelineMock.badges = {
+                sonar: {
+                    name: 'my-sonar-dashboard',
+                    uri: 'https://sonar.screwdriver.cd/pipeline112233'
+                }
+            };
+
+            options.payload.badges = {
+                sonar: {}
+            };
+
+            const updatedPipelineMockLocal = {
+                ...updatedPipelineMock,
+                badges: {}
+            };
+
+            updatedPipelineMockLocal.toJson = sinon.stub().returns(updatedPipelineMockLocal);
+            pipelineMock.sync.resolves(updatedPipelineMockLocal);
+
+            pipelineFactoryMock.get.withArgs({ id: `${id}` }).resolves(pipelineMock);
+
+            return server.inject(options).then(reply => {
+                assert.calledOnce(pipelineMock.update);
+                assert.include(reply.payload.badges, {});
+                assert.equal(reply.statusCode, 200);
+            });
+        });
+
         it('returns 404 when the pipeline id is not found', () => {
             pipelineFactoryMock.get.withArgs({ id }).resolves(null);
 


### PR DESCRIPTION
## Context
The pipeline PUT endpoint supports configuring badges; however, the endpoint does not support removing a configured badge for a pipeline.

## Objective
Add support to remove a badge with a payload of:
```
badges: {
   [service-name]: {}
}
```

## References
https://github.com/screwdriver-cd/screwdriver/issues/3367

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
