### PR TITLE
fix: Enable environment variable for org name in feature tests

### DIFF
--- a/features/restrict-pr.feature
+++ b/features/restrict-pr.feature
@@ -24,12 +24,12 @@ Feature: Restrict-pr
             And an existing pipeline with the source directory "all" and with the workflow jobs:
             | job           | requires          |
             | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd-test" organization
+        When a branch is created for test_branch on "<repo_org>" organization
             And a new file is added to the "none" directory
             And a new file is added to the "fork" directory
             And a new file is added to the "branch" directory
             And a new file is added to the "all" directory
-            And a pull request is opened from the "screwdriver-cd-test" organization
+            And a pull request is opened from the "<repo_org>" organization
         Then the PR job of "none" is triggered because it is not restricted
             And the PR job of "fork" is triggered because it is not restricted
             And the PR job of "branch" is not triggered because it is restricted
@@ -48,12 +48,12 @@ Feature: Restrict-pr
             And an existing pipeline with the source directory "all" and with the workflow jobs:
             | job           | requires          |
             | main          | ~pr               |
-        When a branch is created for test_branch on "screwdriver-cd" organization
+        When a branch is created for test_branch on "<forked_org>" organization
             And a new file is added to the "none" directory
             And a new file is added to the "fork" directory
             And a new file is added to the "branch" directory
             And a new file is added to the "all" directory
-            And a pull request is opened from the "screwdriver-cd" organization
+            And a pull request is opened from the "<forked_org>" organization
         Then the PR job of "none" is triggered because it is not restricted
             And the PR job of "branch" is triggered because it is not restricted
             And the PR job of "fork" is not triggered because it is restricted

--- a/features/step_definitions/pipeline-template.js
+++ b/features/step_definitions/pipeline-template.js
@@ -16,7 +16,7 @@ Before(
     function hook() {
         this.repoOrg = this.testOrg;
         this.repoName = 'functional-pipeline-template';
-        this.templateNamespace = 'screwdriver-cd-test';
+        this.templateNamespace = this.testOrg;
         this.branchName = 'master';
         this.pipelineId = null;
         this.jwt = null;

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -23,11 +23,12 @@ function resolveOrg(orgNamePlaceholder, context) {
 
     if (orgName === 'repo_org') {
         return context.repoOrg;
-    } else if (orgName === 'forked_org') {
-        return context.forkedOrg;
-    } else {
-        return orgName;
     }
+    if (orgName === 'forked_org') {
+        return context.forkedOrg;
+    }
+
+    return orgName;
 }
 
 Before(

--- a/features/step_definitions/restrict-pr.js
+++ b/features/step_definitions/restrict-pr.js
@@ -10,6 +10,14 @@ const TIMEOUT = 240 * 1000;
 
 disableRunScenarioInParallel();
 
+/**
+ * Resolves an organization placeholder (e.g., "<repo_org>", "<forked_org>")
+ * into the actual organization name using the test context.
+ *
+ * @param  {string} orgNamePlaceholder The placeholder string for the organization name
+ * @param  {object} The Cucumber World context (`this`)
+ * @return {string} The resolved organization name as a plain string.
+ */
 function resolveOrg(orgNamePlaceholder, context) {
     const orgName = orgNamePlaceholder.replace(/^<|>$/g, '');
 
@@ -17,8 +25,9 @@ function resolveOrg(orgNamePlaceholder, context) {
         return context.repoOrg;
     } else if (orgName === 'forked_org') {
         return context.forkedOrg;
+    } else {
+        return orgName;
     }
-    return orgName;
 }
 
 Before(

--- a/features/step_definitions/sd-cmd.js
+++ b/features/step_definitions/sd-cmd.js
@@ -19,7 +19,7 @@ Before(
         this.jwt = null;
         this.image = null;
         this.command = null;
-        this.commandNamespace = 'screwdriver-cd-test';
+        this.commandNamespace = this.testOrg;
 
         this.startJob = jobName => {
             return this.ensurePipelineExists({

--- a/features/step_definitions/templates.js
+++ b/features/step_definitions/templates.js
@@ -16,7 +16,7 @@ Before(
     function hook() {
         this.repoOrg = this.testOrg;
         this.repoName = 'functional-template';
-        this.templateNamespace = 'screwdriver-cd-test';
+        this.templateNamespace = this.testOrg;
         this.branchName = 'master';
         this.pipelineId = null;
         this.jwt = null;

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -216,7 +216,8 @@ function CustomWorld({ attach, parameters }) {
     this.apiToken = process.env.SD_API_TOKEN;
     this.protocol = process.env.SD_API_PROTOCOL || 'https';
     this.instance = `${this.protocol}://${process.env.SD_API_HOST}`;
-    this.testOrg = process.env.TEST_ORG;
+    this.testOrg = process.env.TEST_ORG || 'screwdriver-cd-test';
+    this.testOrgSub = process.env.TEST_ORG_SUB || 'screwdriver-cd';
     this.username = process.env.TEST_USERNAME;
     this.scmHostname = process.env.TEST_SCM_HOSTNAME || 'github.com';
     this.scmContext = process.env.TEST_SCM_CONTEXT || 'github';


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Some feature tests currently use a hardcoded organization name.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Make it possible to retrieve the organization name from an environment variable
- Specifically, allow the restrict-pr test to use a configurable org name via an environment variable, such as for forks

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
