### PR TITLE
fix(3379): Non-virtual job builds may be treated as virtual when the event is created

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "screwdriver-config-parser": "^12.2.3",
     "screwdriver-coverage-bookend": "^3.0.0",
     "screwdriver-coverage-sonar": "^5.0.0",
-    "screwdriver-data-schema": "^25.6.0",
+    "screwdriver-data-schema": "^25.11.0",
     "screwdriver-datastore-sequelize": "^10.0.0",
     "screwdriver-executor-base": "^11.0.0",
     "screwdriver-executor-docker": "^8.0.1",

--- a/test/plugins/data/events.json
+++ b/test/plugins/data/events.json
@@ -19,11 +19,18 @@
         "nodes": [
             { "name": "~pr" },
             { "name": "~commit" },
-            { "name": "main",
+            {
+                "name": "main",
                 "id": 1234
             },
-            { "name": "publish" },
-            { "name": "beta" }
+            {
+                "name": "publish",
+                "id": 1235
+            },
+            {
+                "name": "beta",
+                "id": 1236
+            }
         ],
         "edges": [
             { "src": "~commit", "dest": "main" },

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -560,15 +560,19 @@ describe('event plugin test', () => {
             delete options.payload.parentBuildId;
             delete eventConfig.parentBuildId;
 
-            eventMock.builds = getBuildMocks(testBuilds);
+            eventMock.builds = [getBuildMocks(testBuilds)[0], getBuildMocks(testBuilds)[1]];
             eventMock.builds.forEach(b => {
                 b.eventId = eventMock.id;
             });
             eventMock.getBuilds = sinon.stub().returns(testBuilds);
+            eventMock.workflowGraph.nodes[2].virtual = true;
 
-            const virtualBuildMock = eventMock.builds[4];
+            const virtualBuildMock = eventMock.builds[0];
+            const nonVirtualBuildMock = eventMock.builds[1];
 
             virtualBuildMock.status = 'CREATED';
+            nonVirtualBuildMock.status = 'CREATED';
+            nonVirtualBuildMock.jobId = 1235;
 
             const virtualJobMock = {
                 id: virtualBuildMock.jobId,


### PR DESCRIPTION
## Context

Changes made in the PR https://github.com/screwdriver-cd/screwdriver/pull/3252 relied on the `status` of the builds that were created during event creation to identify virtual builds.

There could be scenarios when the non-virtual job builds may not be queued for execution and remain in `CREATED` status. This may lead to incorrectly identifying them as virtual builds (status would be updated to `SUCCESS` and downstream jobs would be triggered)

## Objective

Use the event workflow graph to identify is a build is for a virtual job.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3379

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
