### PR TITLE
feat(3235): check tag/release test build status in feature tests [2]

### DIFF
--- a/features/git-flow.feature
+++ b/features/git-flow.feature
@@ -46,11 +46,13 @@ Feature: Git Flow
     Scenario: New Tag
         When a tag "v1.0" is created
         Then a new build from "tag-triggered" should be created to test that change
+        And the build succeeded
         And a new build from "tag-specific-triggered" should be created to test that change
 
     Scenario: New Specific Tag
         When a tag "v2.0" is created
         Then a new build from "tag-triggered" should be created to test that change
+        And the build succeeded
         And a new build from "tag-specific-triggered" should not be created to test that change
 
     Scenario: New Annotated Tag
@@ -60,10 +62,12 @@ Feature: Git Flow
     Scenario: New Release
         When a release "v1.0" is created
         Then a new build from "release-triggered" should be created to test that change
+        And the build succeeded
 
     Scenario: New Specific Release
         When a release "v2.0" is created
         Then a new build from "release-triggered" should be created to test that change
+        And the build succeeded
         And a new build from "release-specific-triggered" should not be created to test that change
 
     Scenario: New Release with Annotated Tag

--- a/features/step_definitions/git-flow.js
+++ b/features/step_definitions/git-flow.js
@@ -300,6 +300,7 @@ Then(
 
                 Assert.oneOf(build.status, ['QUEUED', 'RUNNING', 'SUCCESS']);
                 this.jobId = build.jobId;
+                this.buildId = build.id;
             });
     }
 );


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The builds triggered from tag/release have special metadata such as `sd.tag.name`.
We should test that these metadata is prepared properly.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The following PR will add test for the metadata for tag/release.
https://github.com/screwdriver-cd-test/functional-git/pull/11766

This PR add checking that builds are succeed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/3235
- PRs
  - https://github.com/screwdriver-cd-test/functional-git/pull/11766
  - https://github.com/screwdriver-cd/launcher/pull/493

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
