### PR TITLE
fix(3390): Screwdriver admin is considered as non-admin user after fetching user token from API access token

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -230,6 +230,17 @@ const authPlugin = {
                             scmContext: user.scmContext,
                             scope: ['user']
                         };
+
+                        const scmDisplayName = scm.getDisplayName({ scmContext: profile.scmContext });
+                        const userDisplayName = pluginOptions.authCheckById
+                            ? `${scmDisplayName}:${profile.username}:${profile.scmUserId}`
+                            : `${scmDisplayName}:${profile.username}`;
+                        const admins = pluginOptions.authCheckById ? pluginOptions.sdAdmins : pluginOptions.admins;
+
+                        // Check admin
+                        if (admins.length > 0 && admins.includes(userDisplayName)) {
+                            profile.scope.push('admin');
+                        }
                     }
                     if (token.pipelineId) {
                         // if token has pipelineId then the token is for pipeline

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -175,7 +175,10 @@ describe('auth plugin test', () => {
                 oauthRedirectUri,
                 sameSite: false,
                 bell: scm.scms,
-                path: '/'
+                path: '/',
+                admins: ['github:batman', 'batman'],
+                sdAdmins: ['github:batman:1312'],
+                authCheckById: true
             }
         });
     });
@@ -1194,6 +1197,23 @@ describe('auth plugin test', () => {
                     scmUserId: 1315,
                     username: 'batman',
                     scope: ['user'],
+                    scmContext: 'github:github.com'
+                });
+            });
+        });
+
+        it('returns user signed token given an API access token for SD admin', () => {
+            tokenMock.userId = id;
+            scm.decorateAuthor.resolves({ id: 1312 });
+            collectionFactoryMock.list.resolves([[1], [2]]);
+
+            return server.inject({ url: `/auth/token?api_token=${apiKey}` }).then(reply => {
+                assert.equal(reply.statusCode, 200, 'Login route should be available');
+                assert.ok(reply.result.token, 'Token not returned');
+                expect(reply.result.token).to.be.a.jwt.and.deep.include({
+                    scmUserId: 1312,
+                    username: 'batman',
+                    scope: ['user', 'admin'],
                     scmContext: 'github:github.com'
                 });
             });


### PR DESCRIPTION
## Context

When a Screwdriver admin hits `/auth/token?api_token=${apiKey}` endpoint by passing API access token, the profile returned in the JWT token does not contain `admin` in the `scope`.

Because of this any actions performed using this JWT token, the user is treated as non-admin user and loses admin privileges.

## Objective

Include `admin` scope in the JWT token for Screwdriver admins

## References

https://github.com/screwdriver-cd/screwdriver/issues/3390

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
