### PR TITLE
feat: create acceptance tests for PR closed trigger [2]

### DIFF
--- a/features/git-flow.feature
+++ b/features/git-flow.feature
@@ -31,9 +31,23 @@ Feature: Git Flow
         Then a new build from "main" should be created to test that change
 
     Scenario: Closed Pull Request
+        When a new Skip CI commit is pushed against the pipeline's branch
         And an existing pull request targeting the pipeline's branch
-        When the pull request is closed
+        And the pull request is closed
         Then any existing builds should be stopped
+        And a new build from "closed-trigger" should be created on the latest sha
+        And the build succeeded
+        And the build should have a metadata for a closed pr
+        And a new build from "branch-specific-closed-trigger" should not be created on the latest sha
+
+    Scenario: Closed Pull Request Targeting Specific Branch
+        When a new Skip CI commit is pushed against the pipeline's branch
+        And a pull request is opened to "pr-closed-trigger" branch
+        And the pull request is merged
+        Then a new build from "branch-specific-closed-trigger" should be created on the latest sha
+        And the build succeeded
+        And the build should have a metadata for a merged pr
+        And a new build from "closed-trigger" should not be created on the latest sha
 
     Scenario: New Commit
         When a new commit is pushed against the pipeline's branch


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

PR closed trigger is available now. We need to test this feature in the acceptance test.

## Note

This PR requires the following PR for the test repository.
https://github.com/screwdriver-cd-test/functional-git/pull/11776

After merging that PR, please create a `pr-closed-trigger` branch on that repository.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Create acceptance tests for PR closed trigger

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- PR - https://github.com/screwdriver-cd-test/functional-git/pull/11776

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
