### PR TITLE
fix: Stop all builds when the event is stopped

### DIFF
--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -8,12 +8,57 @@ const { getFullStageJobName } = require('../../helper');
 const { updateVirtualBuildSuccess } = require('../triggers/helpers');
 const TERMINAL_STATUSES = ['FAILURE', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
 const FINISHED_STATUSES = ['SUCCESS', ...TERMINAL_STATUSES];
+const nonTerminatedStatus = ['CREATED', 'RUNNING', 'QUEUED', 'BLOCKED', 'FROZEN'];
 
 /**
  * @typedef {import('screwdriver-models/lib/build')} Build
  * @typedef {import('screwdriver-models/lib/event')} Event
  * @typedef {import('screwdriver-models/lib/step')} Step
  */
+
+/**
+ * Get the message when the build is stopped from the event.
+ *
+ * @method getEventAbortedStatusMessage
+ * @param  {Build[]}          builds       Build Array
+ */
+function getEventAbortedStatusMessage(builds) {
+    for (const b of builds) {
+        if (b.status === 'ABORTED' && b.statusMessage && b.statusMessage.startsWith('Aborted event')) {
+            return b.statusMessage;
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Stop builds in the event when the event is stopped manually
+ *
+ * @method stopBuildsByEvent
+ * @param  {String}         statusMessage       Build status message
+ * @param  {Build[]}        builds              Build Array
+ */
+function stopBuildsByEvent(builds, statusMessage) {
+    const unchangedBuilds = [];
+    const changedBuilds = [];
+
+    for (const build of builds) {
+        if (nonTerminatedStatus.includes(build.status)) {
+            if (build.status === 'RUNNING') {
+                build.endTime = new Date().toISOString();
+            }
+            build.status = 'ABORTED';
+            build.statusMessage = statusMessage;
+
+            changedBuilds.push(build);
+        } else {
+            unchangedBuilds.push(build);
+        }
+    }
+
+    return { unchangedBuilds, changedBuilds };
+}
 
 /**
  * Identify whether this build resulted in a previously failed job to become successful.
@@ -363,7 +408,21 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     let isFixed = Promise.resolve(false);
     let stopFrozen = null;
 
-    updateBuildStatus(build, desiredStatus, statusMessage, statusMessageType, username);
+    // If the event is Aborted, check if there are any builds within the same event
+    // that have been stopped by the event, and if so, force this build to be Aborted.
+    if (build.status !== 'ABORTED' && event.status === 'ABORTED') {
+        const builds = await event.getBuilds();
+        const eventAbortedStatusMessage = getEventAbortedStatusMessage(builds);
+
+        if (eventAbortedStatusMessage) {
+            build.status = 'ABORTED';
+            build.statusMessage = eventAbortedStatusMessage;
+        }
+    }
+
+    if (build.status !== 'ABORTED') {
+        updateBuildStatus(build, desiredStatus, statusMessage, statusMessageType, username);
+    }
 
     // If status got updated to RUNNING or COLLAPSED, update init endTime and code
     if (['RUNNING', 'COLLAPSED', 'FROZEN'].includes(desiredStatus)) {
@@ -475,7 +534,17 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
 
     // update event status
     const latestBuilds = await newEvent.getBuilds();
-    const newEventStatus = deriveEventStatusFromBuildStatuses(latestBuilds);
+    let updatedBuilds = latestBuilds;
+
+    const eventAbortedStatusMessage = getEventAbortedStatusMessage(latestBuilds);
+
+    if (eventAbortedStatusMessage) {
+        const { unchangedBuilds, changedBuilds } = stopBuildsByEvent(latestBuilds, eventAbortedStatusMessage);
+
+        updatedBuilds = [...unchangedBuilds, ...(await Promise.all(changedBuilds.map(b => b.update())))];
+    }
+
+    const newEventStatus = deriveEventStatusFromBuildStatuses(updatedBuilds);
 
     if (newEventStatus && newEvent.status !== newEventStatus) {
         newEvent.status = newEventStatus;
@@ -486,6 +555,7 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
 }
 
 module.exports = {
+    stopBuildsByEvent,
     updateBuildAndTriggerDownstreamJobs,
     deriveEventStatusFromBuildStatuses,
     getStageBuild,

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -7,7 +7,7 @@ const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const getSchema = schema.models.event.get;
 const idSchema = schema.models.event.base.extract('id');
-const { deriveEventStatusFromBuildStatuses, stopBuildsByEvent } = require('../builds/helper/updateBuild');
+const { deriveEventStatusFromBuildStatuses, stopBuilds } = require('../builds/helper/updateBuild');
 const nonTerminatedStatus = ['CREATED', 'RUNNING', 'QUEUED', 'BLOCKED', 'FROZEN'];
 
 module.exports = () => ({
@@ -84,7 +84,7 @@ module.exports = () => ({
             // Note: COLLAPSED builds will never run
             const statusMessage = `Aborted event by ${username}`;
 
-            const { unchangedBuilds, changedBuilds } = stopBuildsByEvent(builds, statusMessage);
+            const { unchangedBuilds, changedBuilds } = stopBuilds(builds, statusMessage);
             const updatedBuilds = [...unchangedBuilds, ...(await Promise.all(changedBuilds.map(b => b.update())))];
 
             const newEventStatus = deriveEventStatusFromBuildStatuses(updatedBuilds);

--- a/test/plugins/data/trigger/sd@2:a-upstream-b.yaml
+++ b/test/plugins/data/trigger/sd@2:a-upstream-b.yaml
@@ -1,0 +1,14 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+jobs:
+  hub:
+    requires: [ ~commit, ~pr ]
+  a:
+    requires: [ ~hub ]
+  b:
+    requires: [ ~hub ]
+  target:
+    requires: [ sd@2:a ]

--- a/test/plugins/data/trigger/stage-explicit-setup-teardown-b.yaml
+++ b/test/plugins/data/trigger/stage-explicit-setup-teardown-b.yaml
@@ -1,0 +1,32 @@
+shared:
+  image: node:20
+  steps:
+    - test: echo 'test'
+
+stages:
+  red:
+    requires: [ ~a ]
+    description: First stage
+    jobs: [ target1, target2, target3 ]
+    setup:
+      image: node:14
+      steps:
+        -  init: echo 'red setup'
+    teardown:
+        image: node:14
+        steps:
+        -  init: echo 'red teardown'
+
+jobs:
+  hub:
+    requires: [ ~commit, ~pr ]
+  a:
+    requires: [ ~hub ]
+  b:
+    requires: [ ~hub ]
+  target1:
+    description: 'empty'
+  target2:
+    description: 'empty'
+  target3:
+    requires: [ target1, target2 ]

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1491,11 +1491,18 @@ describe('event plugin test', () => {
         it('returns 200 and stops all event builds', () =>
             server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
+                assert.strictEqual(builds[2].status, 'ABORTED');
+                assert.strictEqual(builds[3].status, 'ABORTED');
+                assert.strictEqual(builds[4].status, 'ABORTED');
+                assert.strictEqual(builds[2].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[3].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[4].statusMessage, 'Aborted event by myself');
                 assert.calledOnce(event.getBuilds);
                 assert.notCalled(builds[0].update);
                 assert.notCalled(builds[1].update);
                 assert.calledOnce(builds[2].update);
                 assert.calledOnce(builds[3].update);
+                assert.calledOnce(builds[4].update);
             }));
 
         it('returns 200 and stops all event builds when user has push permission and is not Screwdriver admin', () => {
@@ -1503,11 +1510,18 @@ describe('event plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
+                assert.strictEqual(builds[2].status, 'ABORTED');
+                assert.strictEqual(builds[3].status, 'ABORTED');
+                assert.strictEqual(builds[4].status, 'ABORTED');
+                assert.strictEqual(builds[2].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[3].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[4].statusMessage, 'Aborted event by myself');
                 assert.calledOnce(event.getBuilds);
                 assert.notCalled(builds[0].update);
                 assert.notCalled(builds[1].update);
                 assert.calledOnce(builds[2].update);
                 assert.calledOnce(builds[3].update);
+                assert.calledOnce(builds[4].update);
             });
         });
 
@@ -1529,11 +1543,18 @@ describe('event plugin test', () => {
 
                 return server.inject(options).then(reply => {
                     assert.equal(reply.statusCode, 200);
+                    assert.strictEqual(builds[2].status, 'ABORTED');
+                    assert.strictEqual(builds[3].status, 'ABORTED');
+                    assert.strictEqual(builds[4].status, 'ABORTED');
+                    assert.strictEqual(builds[2].statusMessage, 'Aborted event by imbatman');
+                    assert.strictEqual(builds[3].statusMessage, 'Aborted event by imbatman');
+                    assert.strictEqual(builds[4].statusMessage, 'Aborted event by imbatman');
                     assert.calledOnce(event.getBuilds);
                     assert.notCalled(builds[0].update);
                     assert.notCalled(builds[1].update);
                     assert.calledOnce(builds[2].update);
                     assert.calledOnce(builds[3].update);
+                    assert.calledOnce(builds[4].update);
                 });
             }
         );
@@ -1545,6 +1566,10 @@ describe('event plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
+                assert.strictEqual(builds[2].status, 'ABORTED');
+                assert.strictEqual(builds[4].status, 'ABORTED');
+                assert.strictEqual(builds[2].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[4].statusMessage, 'Aborted event by myself');
                 assert.calledOnce(event.update);
                 assert.strictEqual(event.status, 'ABORTED');
             });
@@ -1693,6 +1718,12 @@ describe('event plugin test', () => {
                 };
                 assert.equal(reply.statusCode, 200);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.strictEqual(builds[2].status, 'ABORTED');
+                assert.strictEqual(builds[3].status, 'ABORTED');
+                assert.strictEqual(builds[4].status, 'ABORTED');
+                assert.strictEqual(builds[2].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[3].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[4].statusMessage, 'Aborted event by myself');
                 assert.calledOnce(event.getBuilds);
                 assert.notCalled(builds[0].update);
                 assert.notCalled(builds[1].update);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When you press the stop button on the event card to stop the event, all builds are set to `ABORTED`, and normally all builds are expected to stop at that point.

However, due to synchronisation issues, if you stop event just before the build is complete, a new build is triggered after pressing stop, and the build does not actually stop and the event will continue to be held.
This occurs particularly when there are a large number of builds or when there are virtual jobs or stages.

In addition, remote join starts from downstream after the event is stopped, but it is not intuitive that the build can start after the event is stopped.

## Objective

Make it possible to determine whether the event has been stopped by using the statusMessage when the event is stopped.

Fix details
- All builds (even if triggered after event stopped) will be aborted  for events that have been suspended from the event card .
  - This also applies to stage setup and teardown, virtual jobs, and Remote join job.
- When you stop a single build from the build details screen or something, only subsequent builds will be affected as before.
  - The overall event build will not be stopped and will not be affected.  


<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
