### PR TITLE
fix: Run sd-setup-scm acceptance tests in a different parallel group

### DIFF
--- a/features/sd-setup-scm.feature
+++ b/features/sd-setup-scm.feature
@@ -1,6 +1,5 @@
 @sd-setup-scm
 @parallel
-@x1
 Feature: sd-setup-scm
 
     Confirm that the environment variables related to Git in sd-setup-scm function works with Screwdriver.cd
@@ -41,6 +40,7 @@ Feature: sd-setup-scm
         And the "not-shallow-clone-single-branch" job is triggered
         Then the "not-shallow-clone-single-branch" build succeeded
 
+    @x1
     Scenario: External config build
         Given an existing pipeline for sd-setup-scm:parent
         Given an existing pipeline for sd-setup-scm:child


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Running the `Normal build` and `External config build` scenarios in parallel can lead to failures, as new commits may be added during the execution of the `Normal build` tests.
(Example: https://beta.cd.screwdriver.cd/pipelines/19904/builds/220243/steps/teardown-test-sha)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

To address this, the two scenarios are moved to different parallel groups, which resolves the flaky test issue.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

This order of execution causes a mismatch between the event SHA and the latest SHA, resulting in a failure of the branch job.

1. [Given having two commit before an hour](https://github.com/screwdriver-cd/screwdriver/blob/d0d27531aef1eb5a48b2aba7da50cfb47dd5e745/features/sd-setup-scm.feature#L11)
2. [When start "~commit" job](https://github.com/screwdriver-cd/screwdriver/blob/d0d27531aef1eb5a48b2aba7da50cfb47dd5e745/features/sd-setup-scm.feature#L12)
3. [Given having two commit to child before an hour](https://github.com/screwdriver-cd/screwdriver/blob/d0d27531aef1eb5a48b2aba7da50cfb47dd5e745/features/sd-setup-scm.feature#L47)
4. [start "branch" job](https://github.com/screwdriver-cd/screwdriver/blob/d0d27531aef1eb5a48b2aba7da50cfb47dd5e745/features/sd-setup-scm.feature#L20)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
