### PR TITLE
fix: badge update and delete operations

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -169,18 +169,23 @@ module.exports = () => ({
                 if (!oldPipeline.badges) {
                     oldPipeline.badges = badges;
                 } else {
-                    const newBadges = {};
+                    const updatedBadges = {
+                        ...oldPipeline.badges
+                    };
 
-                    Object.keys(oldPipeline.badges).forEach(badgeKey => {
-                        if (badges[badgeKey] && Object.keys(badges[badgeKey]).length > 0) {
-                            newBadges[badgeKey] = {
-                                ...oldPipeline.badges[badgeKey],
-                                ...badges[badgeKey]
-                            };
+                    Object.keys(badges).forEach(badgeKey => {
+                        if (Object.keys(badges[badgeKey]).length > 0) {
+                            updatedBadges[badgeKey] = badges[badgeKey];
+                        } else {
+                            delete updatedBadges[badgeKey];
                         }
                     });
 
-                    oldPipeline.badges = newBadges;
+                    if (Object.keys(updatedBadges).length === 0) {
+                        delete oldPipeline.badges;
+                    } else {
+                        oldPipeline.badges = updatedBadges;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Context
The pipeline badges update and delete operations don't work as expected with CRUD operations.

## Objective
Fix the update and delete operation so that the updates and deletions for badges works.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3394

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
