### PR TITLE
fix: delete badge property

### DIFF
--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -166,26 +166,22 @@ module.exports = () => ({
             }
 
             if (badges) {
-                if (!oldPipeline.badges) {
-                    oldPipeline.badges = badges;
-                } else {
-                    const updatedBadges = {
-                        ...oldPipeline.badges
-                    };
+                const updatedBadges = {
+                    ...oldPipeline.badges
+                };
 
-                    Object.keys(badges).forEach(badgeKey => {
-                        if (Object.keys(badges[badgeKey]).length > 0) {
-                            updatedBadges[badgeKey] = badges[badgeKey];
-                        } else {
-                            delete updatedBadges[badgeKey];
-                        }
-                    });
-
-                    if (Object.keys(updatedBadges).length === 0) {
-                        delete oldPipeline.badges;
+                Object.keys(badges).forEach(badgeKey => {
+                    if (Object.keys(badges[badgeKey]).length > 0) {
+                        updatedBadges[badgeKey] = badges[badgeKey];
                     } else {
-                        oldPipeline.badges = updatedBadges;
+                        updatedBadges[badgeKey] = {};
                     }
+                });
+
+                if (Object.keys(updatedBadges).length === 0) {
+                    oldPipeline.badges = {};
+                } else {
+                    oldPipeline.badges = updatedBadges;
                 }
             }
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -3011,7 +3011,8 @@ describe('pipeline plugin test', () => {
             };
 
             const updatedPipelineMockLocal = {
-                ...updatedPipelineMock
+                ...updatedPipelineMock,
+                badges: {}
             };
 
             updatedPipelineMockLocal.toJson = sinon.stub().returns(updatedPipelineMockLocal);
@@ -3023,7 +3024,7 @@ describe('pipeline plugin test', () => {
                 const responsePayload = JSON.parse(reply.payload);
 
                 assert.calledOnce(pipelineMock.update);
-                assert.equal(responsePayload.badges, undefined);
+                assert.deepEqual(responsePayload.badges, {});
                 assert.equal(reply.statusCode, 200);
             });
         });
@@ -3110,7 +3111,8 @@ describe('pipeline plugin test', () => {
             const updatedPipelineMockLocal = {
                 ...updatedPipelineMock,
                 badges: {
-                    ...existingBadge
+                    ...existingBadge,
+                    sonar: {}
                 }
             };
 
@@ -3124,7 +3126,7 @@ describe('pipeline plugin test', () => {
 
                 assert.calledOnce(pipelineMock.update);
                 assert.deepEqual(responsePayload.badges.other, existingBadge.other);
-                assert.equal(responsePayload.badges.sonar, undefined);
+                assert.deepEqual(responsePayload.badges.sonar, {});
                 assert.equal(reply.statusCode, 200);
             });
         });


### PR DESCRIPTION
## Context
The `badges` property on the pipeline object is non-configurable and can not be deleted.

## Objective
Since the `badges` property is non-configurable, setting and updating of `badges` property can be consolidated as `badges` can only be initially assigned once.  To keep the remainder of the `badges` sub-properties behavior similar to `badges`, removal of data from those sub-properties should also be done by setting an empty object value.

## References
https://github.com/screwdriver-cd/screwdriver/issues/3394
https://github.com/screwdriver-cd/screwdriver/pull/3398

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
