### PR TITLE
feat: send a build notification when the virtual build is completed

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -65,14 +65,15 @@ async function deleteBuild(buildConfig, buildFactory) {
 /**
  * Trigger the next jobs of the current job
  * @param { import('./types/index').ServerConfig }  config  Configuration object
- * @param { import('./types/index').ServerApp }     app     Server app object
+ * @param { Object }                                server     Server object
+ * @param { import('./types/index').ServerApp }     server.app     Server app object
  * @return {Promise<null>}                                  Resolves to the newly created build or null
  */
-async function triggerNextJobs(config, app) {
+async function triggerNextJobs(config, server) {
     const currentPipeline = config.pipeline;
     const currentJob = config.job;
     const currentBuild = config.build;
-    const { jobFactory, buildFactory, eventFactory, pipelineFactory, stageFactory, stageBuildFactory } = app;
+    const { jobFactory, buildFactory, eventFactory, pipelineFactory, stageFactory, stageBuildFactory } = server.app;
 
     /** @type {EventModel} */
     const currentEvent = await eventFactory.get({ id: currentBuild.eventId });
@@ -92,8 +93,8 @@ async function triggerNextJobs(config, app) {
 
     // Trigger OrTrigger and AndTrigger for current pipeline jobs.
     // Helper function to handle triggering jobs in same pipeline
-    const orTrigger = new OrTrigger(app, config);
-    const andTrigger = new AndTrigger(app, config, currentEvent);
+    const orTrigger = new OrTrigger(server, config);
+    const andTrigger = new AndTrigger(server, config, currentEvent);
     const currentPipelineNextJobs = extractCurrentPipelineJoinData(pipelineJoinData, currentPipeline.id);
 
     const downstreamOfNextJobsToBeProcessed = [];
@@ -155,7 +156,8 @@ async function triggerNextJobs(config, app) {
                     eventId: currentEvent.id
                 });
 
-                if (stageBuild) {
+                // The next build is only created (not started) when nextBuild is null
+                if (stageBuild && nextBuild) {
                     await updateStageBuildStatus({ stageBuild, newStatus: nextBuild.status, job: nextJob });
                 }
 
@@ -182,8 +184,8 @@ async function triggerNextJobs(config, app) {
 
     // Trigger RemoteJoin and RemoteTrigger for current and external pipeline jobs.
     // Helper function to handle triggering jobs in external pipeline
-    const remoteTrigger = new RemoteTrigger(app, config);
-    const remoteJoin = new RemoteJoin(app, config, currentEvent);
+    const remoteTrigger = new RemoteTrigger(server, config);
+    const remoteJoin = new RemoteJoin(server, config, currentEvent);
     const externalPipelineJoinData = extractExternalJoinData(pipelineJoinData, currentPipeline.id);
 
     for (const [joinedPipelineId, joinedPipeline] of Object.entries(externalPipelineJoinData)) {
@@ -389,7 +391,7 @@ async function triggerNextJobs(config, app) {
     }
 
     for (const nextConfig of downstreamOfNextJobsToBeProcessed) {
-        await triggerNextJobs(nextConfig, app);
+        await triggerNextJobs(nextConfig, server);
     }
 
     return null;

--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -607,18 +607,66 @@ async function getParentBuildStatus({ joinListNames, joinBuilds }) {
 }
 
 /**
+ * Emit 'build_status' event to notify
+ * @param {Object} arg
+ * @param {Object} arg.server Server object
+ * @param {Build} arg.build Build
+ * @param {Pipeline} [arg.pipeline] Pipeline
+ * @param {Event} [arg.event] Event
+ * @param {Job} [arg.job] Job
+ * @returns {Promise}
+ */
+async function emitBuildStatusEvent({ server, build, pipeline, event, job }) {
+    const { buildFactory } = server.app;
+
+    event = event || (await build.event); // eslint-disable-line no-param-reassign
+    job = job || (await build.job); // eslint-disable-line no-param-reassign
+    pipeline = pipeline || (await job.pipeline); // eslint-disable-line no-param-reassign
+
+    let isFixed = false;
+
+    if (build.status === 'SUCCESS') {
+        const failureBuild = await job.getLatestBuild({ status: 'FAILURE' });
+        const successBuild = await job.getLatestBuild({ status: 'SUCCESS' });
+
+        // Identify whether this build resulted in a previously failed job to become successful.
+        isFixed = !!((failureBuild && !successBuild) || failureBuild.id > successBuild.id);
+    }
+
+    return server.events.emit('build_status', {
+        settings: job.permutations[0].settings,
+        status: build.status,
+        event: event.toJson(),
+        pipeline: pipeline.toJson(),
+        jobName: job.name,
+        build: build.toJson(),
+        buildLink: `${buildFactory.uiUri}/pipelines/${pipeline.id}/builds/${build.id}`,
+        isFixed
+    });
+}
+
+/**
  * Update virtual build status to SUCCESS and init metadata
- * @param {Build} build
+ * @param {Object} arg
+ * @param {Object} arg.server Server object
+ * @param {Build} arg.build Build
+ * @param {Pipeline} [arg.pipeline] Pipeline
+ * @param {Event} [arg.event] Event
+ * @param {Job} [arg.job] Job
  * @returns {Promise<Build>}
  */
-async function updateVirtualBuildSuccess(build) {
+async function updateVirtualBuildSuccess({ server, build, pipeline, event, job }) {
     build.status = Status.SUCCESS;
     build.statusMessage = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessage;
     build.statusMessageType = BUILD_STATUS_MESSAGES.SKIP_VIRTUAL_JOB.statusMessageType;
 
     await build.initMeta();
 
-    return build.update();
+    const newBuild = await build.update();
+
+    await emitBuildStatusEvent({ server, build: newBuild, pipeline, event, job });
+
+    return newBuild;
 }
 
 /**
@@ -628,6 +676,7 @@ async function updateVirtualBuildSuccess(build) {
  *          if no failure, start new build
  * Otherwise, do nothing
  * @param {Object} arg If the build is done or not
+ * @param {Object} arg.server Server object
  * @param {String[]} arg.joinListNames Join list names
  * @param {Build} arg.newBuild Next build
  * @param {Job} arg.job Next job
@@ -639,6 +688,7 @@ async function updateVirtualBuildSuccess(build) {
  * @returns {Promise<Build|null>} The newly updated/created build
  */
 async function handleNewBuild({
+    server,
     joinListNames,
     newBuild,
     job,
@@ -687,7 +737,7 @@ async function handleNewBuild({
 
     // Bypass execution of the build if the job is virtual
     if (isVirtualJob && !hasFreezeWindows(job)) {
-        return updateVirtualBuildSuccess(newBuild);
+        return updateVirtualBuildSuccess({ server, build: newBuild, event, job });
     }
 
     // All join builds finished successfully, and it's clear that a new build has not been started before.
@@ -1203,6 +1253,7 @@ module.exports = {
     getJoinBuilds,
     getParentBuildStatus,
     handleNewBuild,
+    emitBuildStatusEvent,
     ensureStageTeardownBuildExists,
     getBuildsForGroupEvent,
     createJoinObject,

--- a/plugins/builds/triggers/joinBase.js
+++ b/plugins/builds/triggers/joinBase.js
@@ -14,19 +14,20 @@ const { createInternalBuild, updateParentBuilds, handleNewBuild } = require('./h
 class JoinBase {
     /**
      * Base class for AND trigger and RemoteJoin
-     * @param {Object} app Server app object
-     * @param {EventFactory} app.eventFactory Server app object
-     * @param {BuildFactory} app.buildFactory Server app object
-     * @param {JobFactory} app.jobFactory Server app object
+     * @param {Object} server Server object
+     * @param {EventFactory} srever.app.eventFactory Server app object
+     * @param {BuildFactory} srever.app.buildFactory Server app object
+     * @param {JobFactory} srever.app.jobFactory Server app object
      * @param {Object} config Configuration object
      * @param {Build} config.build
      * @param {String} config.username
      * @param {String} config.scmContext
      */
-    constructor(app, config) {
-        this.eventFactory = app.eventFactory;
-        this.buildFactory = app.buildFactory;
-        this.jobFactory = app.jobFactory;
+    constructor(server, config) {
+        this.server = server;
+        this.eventFactory = server.app.eventFactory;
+        this.buildFactory = server.app.buildFactory;
+        this.jobFactory = server.app.jobFactory;
 
         this.currentBuild = config.build;
         this.username = config.username;
@@ -89,6 +90,7 @@ class JoinBase {
         }
 
         return handleNewBuild({
+            server: this.server,
             joinListNames,
             newBuild,
             job: nextJob,

--- a/plugins/builds/triggers/orBase.js
+++ b/plugins/builds/triggers/orBase.js
@@ -13,19 +13,20 @@ const { createInternalBuild, Status, updateVirtualBuildSuccess, hasFreezeWindows
 class OrBase {
     /**
      * Trigger the next jobs of the current job
-     * @param {Object} app Server app object
-     * @param {BuildFactory} app.buildFactory
-     * @param {JobFactory} app.jobFactory
-     * @param {PipelineFactory} app.pipelineFactory
+     * @param {Object} server Server object
+     * @param {BuildFactory} server.app.buildFactory
+     * @param {JobFactory} server.app.jobFactory
+     * @param {PipelineFactory} server.app.pipelineFactory
      * @param {Object} config Configuration object
      * @param {Build} config.currentBuild
      * @param {String} config.username
      * @param {String} config.scmContext
      */
-    constructor(app, config) {
-        this.buildFactory = app.buildFactory;
-        this.jobFactory = app.jobFactory;
-        this.pipelineFactory = app.pipelineFactory;
+    constructor(server, config) {
+        this.server = server;
+        this.buildFactory = server.app.buildFactory;
+        this.jobFactory = server.app.jobFactory;
+        this.pipelineFactory = server.app.pipelineFactory;
 
         this.currentBuild = config.build;
         this.username = config.username;
@@ -59,7 +60,7 @@ class OrBase {
 
             // Bypass execution of the build if the job is virtual
             if (isNextJobVirtual && !hasWindows) {
-                return updateVirtualBuildSuccess(nextBuild);
+                return updateVirtualBuildSuccess({ server: this.server, build: nextBuild, event, job: nextJob });
             }
 
             nextBuild.status = Status.QUEUED;
@@ -86,7 +87,7 @@ class OrBase {
 
         // Bypass execution of the build if the job is virtual
         if (isNextJobVirtual && !hasWindows) {
-            await updateVirtualBuildSuccess(nextBuild);
+            await updateVirtualBuildSuccess({ server: this.server, build: nextBuild, event, job: nextJob });
         }
 
         return nextBuild;

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -601,6 +601,130 @@ describe('build plugin test', () => {
             });
         });
 
+        it('emits event build_status from next virtual job', () => {
+            eventMock.workflowGraph = {
+                nodes: [
+                    { name: '~pr' },
+                    { name: '~commit' },
+                    { name: 'a', id: 1 },
+                    { name: 'b', id: 2, virtual: true }
+                ],
+                edges: [
+                    { src: '~pr', dest: 'a' },
+                    { src: '~commit', dest: 'a' },
+                    { src: 'a', dest: 'b' }
+                ]
+            };
+
+            const userMock = {
+                username: id,
+                getPermissions: sinon.stub().resolves({ push: true })
+            };
+            const options = {
+                method: 'PUT',
+                url: `/builds/1`,
+                payload: {
+                    status: 'SUCCESS'
+                },
+                auth: {
+                    credentials: {
+                        username: 1,
+                        scmContext,
+                        scope: ['build']
+                    },
+                    strategy: ['token']
+                }
+            };
+
+            const jobA = {
+                id: 1,
+                name: 'a',
+                pipelineId,
+                state: 'ENABLED',
+                getLatestBuild: sinon.stub().returns([]),
+                permutations: [
+                    {
+                        settings: {
+                            email: 'foo@bar.com'
+                        }
+                    }
+                ],
+                pipeline: Promise.resolve(pipelineMock)
+            };
+            const jobB = {
+                ...jobA,
+                id: 1234,
+                name: 'b'
+            };
+
+            const buildA = {
+                // Complete this build
+                ...buildMock,
+                id: 1,
+                jobId: 1,
+                eventId: '8888',
+                status: 'RUNNING',
+                update: sinon.stub(),
+                toJson: () => 'BUILD A JSON',
+                job: Promise.resolve(jobA)
+            };
+            const buildB = {
+                // Trigger this build as virtual
+                id: 2,
+                jobId: 1234,
+                eventId: '8888',
+                status: 'CREATED',
+                settings: { email: 'foo@example.com' },
+                update: sinon.stub(),
+                initMeta: sinon.stub(),
+                toJson: () => 'BUILD B JSON',
+                job: Promise.resolve(jobB)
+            };
+
+            buildA.update.resolves(buildA);
+            buildB.update.resolves(buildB);
+
+            jobFactoryMock.get.withArgs({ name: 'b', pipelineId }).resolves(jobB);
+            buildFactoryMock.get.withArgs(1).resolves(buildA);
+            buildFactoryMock.get.withArgs({ eventId: '8888', jobId: 1234 }).resolves(buildB);
+            buildFactoryMock.create.resolves(buildB);
+            buildFactoryMock.uiUri = 'http://foo.bar';
+            userFactoryMock.get.resolves(userMock);
+
+            server.events = {
+                emit: sinon.stub().resolves(null)
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.calledTwice(server.events.emit);
+                assert.calledWith(server.events.emit.firstCall, 'build_status', {
+                    build: 'BUILD A JSON',
+                    buildLink: 'http://foo.bar/pipelines/123/builds/1',
+                    jobName: 'a',
+                    event: { id: 123 },
+                    pipeline: { id: 123 },
+                    settings: {
+                        email: 'foo@bar.com'
+                    },
+                    status: 'SUCCESS',
+                    isFixed: false
+                });
+                assert.calledWith(server.events.emit.secondCall, 'build_status', {
+                    build: 'BUILD B JSON',
+                    buildLink: 'http://foo.bar/pipelines/123/builds/2',
+                    jobName: 'b',
+                    event: { id: 123 },
+                    pipeline: { id: 123 },
+                    settings: {
+                        email: 'foo@bar.com'
+                    },
+                    status: 'SUCCESS',
+                    isFixed: false
+                });
+            });
+        });
+
         it('does not emit build_status when status is not passed', () => {
             const userMock = {
                 username: id,
@@ -2257,6 +2381,7 @@ describe('build plugin test', () => {
 
                     teardownBuildMock.status = 'CREATED';
                     teardownBuildMock.update.resolves(teardownBuildMock);
+                    teardownBuildMock.pipeline = Promise.resolve(pipelineMock);
                     buildFactoryMock.get.withArgs({ eventId: '8888', jobId: 1234 }).resolves(buildMock);
                     buildFactoryMock.get.withArgs({ eventId: '8888', jobId: 1235 }).resolves(teardownBuildMock);
 
@@ -2597,6 +2722,7 @@ describe('build plugin test', () => {
                     pipelineId,
                     state: 'ENABLED',
                     parsePRJobName: sinon.stub().returns('b'),
+                    getLatestBuild: sinon.stub().returns([]),
                     permutations: [
                         {
                             settings: {
@@ -2770,7 +2896,8 @@ describe('build plugin test', () => {
                     const jobD = {
                         ...jobB,
                         id: 4,
-                        name: 'd'
+                        name: 'd',
+                        pipeline: Promise.resolve(pipelineMock)
                     };
 
                     const jobE = {
@@ -2781,7 +2908,8 @@ describe('build plugin test', () => {
                     const jobF = {
                         ...jobB,
                         id: 6,
-                        name: 'f'
+                        name: 'f',
+                        pipeline: Promise.resolve(pipelineMock)
                     };
 
                     const buildA = {
@@ -2817,7 +2945,8 @@ describe('build plugin test', () => {
                         endTime: '',
                         meta: {},
                         initMeta: sinon.stub(),
-                        update: sinon.stub()
+                        update: sinon.stub(),
+                        toJson: sinon.stub()
                     };
                     const buildE = {
                         // Trigger this build from buildD
@@ -2839,7 +2968,8 @@ describe('build plugin test', () => {
                         parentBuildId: buildD.id,
                         meta: {},
                         initMeta: sinon.stub(),
-                        update: sinon.stub()
+                        update: sinon.stub(),
+                        toJson: sinon.stub()
                     };
 
                     const jobEConfig = {
@@ -2871,6 +3001,7 @@ describe('build plugin test', () => {
 
                     buildA.update.resolves(buildA);
                     buildD.update.resolves(buildD);
+                    buildF.update.resolves(buildF);
 
                     jobFactoryMock.get.withArgs({ name: 'd', pipelineId: pipelineMock.id }).resolves(jobD);
                     jobFactoryMock.get.withArgs({ name: 'e', pipelineId: pipelineMock.id }).resolves(jobE);

--- a/test/plugins/trigger.test.helper.js
+++ b/test/plugins/trigger.test.helper.js
@@ -806,6 +806,7 @@ class JobFactoryMock {
         };
 
         this.records.push(job);
+        job.pipeline = job.pipeline || this.server.app.pipelineFactory.get(job.pipelineId);
         job.toJson.returns({ ...job });
         job.parsePRJobName = type => {
             const match = job.name.match(PR_JOB_NAME);

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -3492,7 +3492,7 @@ describe('trigger tests', () => {
             assert.equal(event.getBuildOf('PR-1:stage@simple:teardown').status, 'SUCCESS');
         });
 
-        it('stage jobs are triggered in PR when chainPR is enabled', async () => {
+        it('debug stage jobs are triggered in PR when chainPR is enabled', async () => {
             const pipeline = await pipelineFactoryMock.createFromFile('stage-pr.yaml');
 
             pipeline.addPRJobs(1);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Currently, the build notifications (email and slack) are not sent from the virtual builds.
Users want to receive the notifications to find the event  progress.

e.g.)
```yaml
jobs:
  before_deploy:
    annotations:
      screwdriver.cd/virtualJob: true

  deploy_a:
    requires: [ before_deploy ]
  deploy_b:
    requires: [ before_deploy ]

  after_deploy:
    requires: [ deploy_a, deploy_b ]
    annotations:
      screwdriver.cd/virtualJob: true
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Send notifications when the virtual builds are completed

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
