### PR TITLE
fix: the payload size limit for webhooks reverts to the default value

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -15,8 +15,7 @@ const providerSchema = joi
             .string()
             .valid('all', 'none', 'branch', 'fork', 'all-admin', 'none-admin', 'branch-admin', 'fork-admin')
             .optional(),
-        chainPR: joi.boolean().optional(),
-        maxBytes: joi.number().integer().optional()
+        chainPR: joi.boolean().optional()
     })
     .unknown(false);
 
@@ -44,6 +43,7 @@ const webhooksPlugin = {
             joi.object().pattern(joi.string(), providerSchema).min(1).required(),
             'Invalid config for plugin-webhooks'
         );
+        const maxBytes = parseInt(options.maxBytes, 10) || DEFAULT_MAX_BYTES;
 
         server.route({
             method: 'POST',
@@ -58,7 +58,7 @@ const webhooksPlugin = {
                     }
                 },
                 payload: {
-                    maxBytes: parseInt(pluginOptions.maxBytes, 10) || DEFAULT_MAX_BYTES,
+                    maxBytes,
                     parse: false,
                     output: 'stream'
                 },

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -74,10 +74,10 @@ describe('webhooks plugin test', () => {
                         username: 'sd-buildbot',
                         ignoreCommitsBy: ['batman', 'superman'],
                         restrictPR: 'fork',
-                        chainPR: false,
-                        maxBytes: 10
+                        chainPR: false
                     }
-                }
+                },
+                maxBytes: 100
             }
         });
         server.app.buildFactory.apiUri = apiUri;
@@ -93,8 +93,11 @@ describe('webhooks plugin test', () => {
     });
 
     it('registers the plugin', () => {
+        const route = server.table().find(r => r.path === '/webhooks' && r.method === 'post');
+
         assert.isOk(server.registrations.webhooks);
         assert.equal(server.app.buildFactory.tokenGen('12345'), '{"username":"12345","scope":["temporal"]}');
+        assert.equal(route.settings.payload.maxBytes, 100);
     });
 
     it('throws exception when config not passed', () => {
@@ -256,8 +259,7 @@ describe('webhooks plugin test', () => {
                 username: 'sd-buildbot',
                 ignoreCommitsBy: ['batman', 'superman'],
                 restrictPR: 'fork',
-                chainPR: false,
-                maxBytes: 10
+                chainPR: false
             };
 
             pipelineFactoryMock.scm.parseHook.resolves(parsed);
@@ -287,8 +289,7 @@ describe('webhooks plugin test', () => {
                 username: 'sd-buildbot',
                 ignoreCommitsBy: ['batman', 'superman'],
                 restrictPR: 'fork',
-                chainPR: false,
-                maxBytes: 10
+                chainPR: false
             };
 
             pipelineFactoryMock.scm.parseHook.resolves(parsed);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The maximum payload size for webhooks was always falling back to the default value instead of respecting the custom value provided in the configuration.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

`pluginOptions` contains the settings from `webhook.scms`, but since `maxBytes` is defined directly under `webhook`, it cannot be accessed via `pluginOptions.maxBytes`.

I will fix it so that `maxBytes` is referenced directly from `options`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
