### PR TITLE
fix(3400)[2]:use raw query in badge api

### DIFF
--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -5,7 +5,6 @@ const schema = require('screwdriver-data-schema');
 const idSchema = schema.models.pipeline.base.extract('id');
 const logger = require('screwdriver-logger');
 const { getPipelineBadge } = require('./helper');
-const BUILD_META_KEYWORD = '%"build":%';
 
 module.exports = config => ({
     method: 'GET',
@@ -37,24 +36,7 @@ module.exports = config => ({
                 }
 
                 // Get latest pipeline events
-                const latestEvents = await eventFactory.list({
-                    params: {
-                        pipelineId,
-                        type: 'pipeline'
-                    },
-                    // Make sure build exists for event, meta will be {} for skipped builds
-                    search: {
-                        field: 'meta',
-                        keyword: BUILD_META_KEYWORD
-                    },
-                    // removing these fields trims most of the bytes
-                    exclude: ['workflowGraph', 'meta', 'commit'],
-                    paginate: {
-                        count: 1
-                    },
-                    sort: 'descending',
-                    sortBy: 'createTime'
-                });
+                const latestEvents = await eventFactory.getPipelineTypeBuildEvents(pipelineId);
 
                 if (!latestEvents || Object.keys(latestEvents).length === 0) {
                     return h.response(getPipelineBadge(badgeConfig)).header('Content-Type', contentType);

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -263,7 +263,8 @@ describe('pipeline plugin test', () => {
         };
         eventFactoryMock = {
             create: sinon.stub().resolves(null),
-            list: sinon.stub().resolves(null)
+            list: sinon.stub().resolves(null),
+            getPipelineTypeBuildEvents: sinon.stub().resolves(null)
         };
         stageFactoryMock = {
             list: sinon.stub()
@@ -1456,7 +1457,7 @@ describe('pipeline plugin test', () => {
             eventsPrMock = getEventsMocks(testEventsPr);
             eventsMock[0].getBuilds.resolves(getBuildMocks(testBuilds));
             eventsPrMock[0].getBuilds.resolves(getBuildMocks(testBuilds));
-            eventFactoryMock.list.resolves(eventsMock);
+            eventFactoryMock.getPipelineTypeBuildEvents.resolves(eventsMock);
         });
 
         it('returns 200 to for a valid build', () =>
@@ -1466,7 +1467,7 @@ describe('pipeline plugin test', () => {
             }));
 
         it('returns 200 to for a valid PR build', () => {
-            eventFactoryMock.list.resolves(eventsPrMock);
+            eventFactoryMock.getPipelineTypeBuildEvents.resolves(eventsPrMock);
 
             return server.inject(`/pipelines/${id}/badge`).then(reply => {
                 assert.equal(reply.statusCode, 200);
@@ -1484,7 +1485,7 @@ describe('pipeline plugin test', () => {
         });
 
         it('returns 200 to unknown for an event that does not exist', () => {
-            eventFactoryMock.list.resolves([]);
+            eventFactoryMock.getPipelineTypeBuildEvents.resolves([]);
 
             return server.inject(`/pipelines/${id}/badge`).then(reply => {
                 assert.equal(reply.statusCode, 200);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Pipeline id and create time index cause a loading problem in our environment.
https://github.com/screwdriver-cd/data-schema/pull/607

We want to use raw query to improve badge api instead of using an index.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- using raw query 
  - https://github.com/screwdriver-cd/models/pull/656

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
