### PR TITLE
fix: Verify signature of payloads containing control characters [6]

### DIFF
--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -77,15 +77,7 @@ const webhooksPlugin = {
                         }
 
                         const data = Buffer.concat(chunks).toString();
-                        let parsedPayload;
-
-                        try {
-                            parsedPayload = JSON.parse(data);
-                        } catch (err) {
-                            throw boom.badData('Cannot parse payload');
-                        }
-
-                        const parsed = await scm.parseHook(request.headers, parsedPayload);
+                        const parsed = await scm.parseHook(request.headers, data);
 
                         if (!parsed) {
                             // for all non-matching events or actions

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -297,6 +297,7 @@ describe('webhooks plugin test', () => {
 
             return server.inject(options).then(() => {
                 assert.calledOnce(pipelineFactoryMock.scm.parseHook);
+                assert.calledWith(pipelineFactoryMock.scm.parseHook, reqHeaders, '{}');
                 assert.calledWith(queueWebhookMock.executor.enqueueWebhook, {
                     ...parsed,
                     pluginOptions: webhookConfig,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When JSON.stringify() is applied to certain control characters, their character representation changes.

```
> JSON.stringify({x: '\u001F'})
'{"x":"\\u001f"}'
> JSON.stringify({x: '\x1F'})
'{"x":"\\u001f"}'
```

Therefore, if you use the value obtained by re-stringifying the payload after JSON.parse for verifying the signature, it will fail because the contents do not match.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- The original payload will be used for signature verification.
- Enable passing the string before parsing to the _parseHook in scm components.
  - Consequently, the following components will require modification.
  - The API must be merged after merging all dependent components.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
