### PR TITLE
fix(3408): remote join is not triggered properly when restart the downstream build by "Start pipeline from here"

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -196,8 +196,7 @@ async function triggerNextJobs(config, app) {
         let externalEvent = joinedPipeline.event;
 
         // This includes CREATED builds too
-        const groupEventBuilds =
-            externalEvent !== undefined ? await getBuildsForGroupEvent(externalEvent.groupEventId, buildFactory) : [];
+        const groupEventBuilds = await getBuildsForGroupEvent(currentEvent.groupEventId, buildFactory);
 
         // fetch builds created due to trigger
         if (externalEvent) {
@@ -267,7 +266,7 @@ async function triggerNextJobs(config, app) {
                 parentEventId: currentEvent.id,
                 startFrom: remoteTriggerName,
                 skipMessage: 'Skip bulk external builds creation', // Don't start builds in eventFactory.
-                groupEventId: null
+                groupEventId: currentEvent.groupEventId // groupEventId is the id of the first triggered event (use the upstream pipeline's in the downstream pipeline)
             };
 
             const buildsToRestart = buildsToRestartFilter(joinedPipeline, groupEventBuilds, currentEvent, currentBuild);
@@ -275,20 +274,7 @@ async function triggerNextJobs(config, app) {
 
             // Restart case
             if (isRestart) {
-                // 'joinedPipeline.event.id' is restart event, not group event.
-                const groupEvent = await eventFactory.get({ id: joinedPipeline.event.id });
-
-                externalEventConfig.groupEventId = groupEvent.groupEventId;
                 externalEventConfig.parentBuilds = buildsToRestart[0].parentBuilds;
-            } else {
-                const sameParentEvents = await getSameParentEvents({
-                    eventFactory,
-                    parentEventId: currentEvent.groupEventId,
-                    pipelineId: strToInt(joinedPipelineId)
-                });
-
-                externalEventConfig.groupEventId =
-                    sameParentEvents.length > 0 ? sameParentEvents[0].groupEventId : currentEvent.groupEventId;
             }
 
             try {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -413,6 +413,7 @@ describe('build plugin test', () => {
             buildMock.update.resolves(buildMock);
             buildFactoryMock.get.resolves(buildMock);
             buildFactoryMock.list.resolves([]);
+            buildFactoryMock.getLatestBuilds.resolves([]);
             stepMock = getBuildMock({
                 buildId: id,
                 name: initStepName

--- a/test/plugins/data/trigger/a_b.yaml
+++ b/test/plugins/data/trigger/a_b.yaml
@@ -12,3 +12,5 @@ jobs:
     requires: [ ~hub ]
   target:
     requires: [ a, b ]
+  detached:
+    requires: []

--- a/test/plugins/data/trigger/sd@2:a_sd@2:b-downstream.yaml
+++ b/test/plugins/data/trigger/sd@2:a_sd@2:b-downstream.yaml
@@ -8,3 +8,5 @@ jobs:
     requires: [ ~sd@1:a ]
   b:
     requires: [ ~sd@1:a ]
+  detached:
+    requires: []

--- a/test/plugins/trigger.test.helper.js
+++ b/test/plugins/trigger.test.helper.js
@@ -403,14 +403,19 @@ class EventFactoryMock {
         event.restartFrom = async jobName => {
             const restartBuild = event.getBuildOf(jobName);
 
-            const restartEvent = await this.create({
+            const restartConfig = {
                 pipelineId: pipeline.id,
                 groupEventId: event.groupEventId || event.id,
                 parentEventId: event.id,
-                parentBuilds: restartBuild.parentBuilds,
-                parentBuildId: restartBuild.parentBuildId,
                 startFrom: jobName
-            });
+            };
+
+            if (restartBuild) {
+                restartConfig.parentBuilds = restartBuild.parentBuilds;
+                restartConfig.parentBuildId = restartBuild.parentBuildId;
+            }
+
+            const restartEvent = await this.create(restartConfig);
 
             return restartEvent;
         };
@@ -504,15 +509,27 @@ class EventFactoryMock {
      * @returns {Event[]}
      */
     async list({ params }) {
-        const { parentEventId, pipelineId } = params;
+        const { parentEventId, groupEventId, pipelineId } = params;
 
-        const childEvents = this.getChildEvents(parentEventId);
+        return this.records.filter(event => {
+            if (!event) {
+                return false;
+            }
 
-        if (pipelineId) {
-            return childEvents.filter(event => event && event.pipelineId === pipelineId);
-        }
+            if (parentEventId && parseInt(event.parentEventId, 10) !== parseInt(parentEventId, 10)) {
+                return false;
+            }
 
-        return childEvents;
+            if (groupEventId && parseInt(event.groupEventId, 10) !== parseInt(groupEventId, 10)) {
+                return false;
+            }
+
+            if (pipelineId && parseInt(event.pipelineId, 10) !== parseInt(pipelineId, 10)) {
+                return false;
+            }
+
+            return true;
+        });
     }
 
     /**

--- a/test/plugins/trigger.test.js
+++ b/test/plugins/trigger.test.js
@@ -565,6 +565,25 @@ describe('trigger tests', () => {
         assert.equal(pipeline.getBuildsOf('target').length, 1);
     });
 
+    it('[ a, b ] is triggered in detached event belonging to group event', async () => {
+        const pipeline = await pipelineFactoryMock.createFromFile('a_b.yaml');
+
+        const event = await eventFactoryMock.create({
+            pipelineId: pipeline.id,
+            startFrom: 'hub'
+        });
+
+        await event.run();
+
+        // Create event from "Start pipeline from here"
+        const detachedEvent = await event.restartFrom('detached');
+        const restartEvent = await detachedEvent.restartFrom('a');
+
+        await restartEvent.getBuildOf('a').complete('SUCCESS');
+
+        assert.equal(restartEvent.getBuildOf('target').status, 'RUNNING');
+    });
+
     it('Multiple [ a, b ] is triggered', async () => {
         const pipeline = await pipelineFactoryMock.createFromFile('a_b-multiple.yaml');
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Remote join is not triggered when restart the downstream build by "Start pipeline from here".

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Trigger remote join even use "Start pipeline from here".

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/3408

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
