### PR TITLE
fix: Make the event creation process in the downstream pipeline sequential

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -192,10 +192,20 @@ async function triggerNextJobs(config, server) {
         const isCurrentPipeline = strToInt(joinedPipelineId) === currentPipeline.id;
         const remoteJoinName = `sd@${currentPipeline.id}:${originalCurrentJobName}`;
         const remoteTriggerName = `~${remoteJoinName}`;
-        let lock;
-        let resource;
+        let groupEventLock;
+        let groupEventResource;
+        let externalEventResource;
+        let externalEventLock;
 
         let externalEvent = joinedPipeline.event;
+
+        let isRestartPipeline = false;
+
+        if (currentEvent.parentEventId) {
+            const parentEvent = await eventFactory.get({ id: currentEvent.parentEventId });
+
+            isRestartPipeline = parentEvent && strToInt(currentEvent.pipelineId) === strToInt(parentEvent.pipelineId);
+        }
 
         // This includes CREATED builds too
         const groupEventBuilds =
@@ -210,98 +220,102 @@ async function triggerNextJobs(config, server) {
             });
 
             groupEventBuilds.push(...parallelBuilds);
-        } else {
-            const sameParentEvents = await getSameParentEvents({
-                eventFactory,
-                parentEventId: currentEvent.id,
-                pipelineId: strToInt(joinedPipelineId)
-            });
-
-            if (sameParentEvents.length > 0) {
-                externalEvent = sameParentEvents[0];
-            }
         }
 
-        let isRestartPipeline = false;
+        try {
+            // serialize external-event selection/creation and prevent duplicate events under concurrent triggers.
+            groupEventResource = `pipeline:${joinedPipelineId}:groupEvent:${currentEvent.groupEventId}`;
+            groupEventLock = await locker.lock(groupEventResource);
 
-        if (currentEvent.parentEventId) {
-            const parentEvent = await eventFactory.get({ id: currentEvent.parentEventId });
-
-            isRestartPipeline = parentEvent && strToInt(currentEvent.pipelineId) === strToInt(parentEvent.pipelineId);
-        }
-
-        // If user used external trigger syntax, the jobs are triggered as external
-        if (isCurrentPipeline) {
-            externalEvent = null;
-        } else if (isRestartPipeline) {
-            // If parentEvent and currentEvent have the same pipelineId, then currentEvent is the event that started the restart
-            // If restarted from the downstream pipeline, the remote trigger must create a new event in the upstream pipeline
-            const sameParentEvents = await getSameParentEvents({
-                eventFactory,
-                parentEventId: currentEvent.id,
-                pipelineId: strToInt(joinedPipelineId)
-            });
-
-            externalEvent = sameParentEvents.length > 0 ? sameParentEvents[0] : null;
-        }
-
-        // no need to lock if there is no external event
-        if (externalEvent) {
-            resource = `pipeline:${joinedPipelineId}:event:${externalEvent.id}`;
-        }
-
-        // Create a new external event
-        // First downstream trigger, restart case, same pipeline trigger as external
-        if (!externalEvent) {
-            const { parentBuilds } = parseJobInfo({
-                currentBuild,
-                currentPipeline,
-                currentJob
-            });
-
-            const externalEventConfig = {
-                pipelineFactory,
-                eventFactory,
-                externalPipelineId: joinedPipelineId,
-                parentBuildId: currentBuild.id,
-                parentBuilds,
-                causeMessage: `Triggered by ${remoteJoinName}`,
-                parentEventId: currentEvent.id,
-                startFrom: remoteTriggerName,
-                skipMessage: 'Skip bulk external builds creation', // Don't start builds in eventFactory.
-                groupEventId: null
-            };
-
-            const buildsToRestart = buildsToRestartFilter(joinedPipeline, groupEventBuilds, currentEvent, currentBuild);
-            const isRestart = buildsToRestart.length > 0;
-
-            // Restart case
-            if (isRestart) {
-                // 'joinedPipeline.event.id' is restart event, not group event.
-                const groupEvent = await eventFactory.get({ id: joinedPipeline.event.id });
-
-                externalEventConfig.groupEventId = groupEvent.groupEventId;
-                externalEventConfig.parentBuilds = buildsToRestart[0].parentBuilds;
-            } else {
+            if (!externalEvent) {
                 const sameParentEvents = await getSameParentEvents({
                     eventFactory,
-                    parentEventId: currentEvent.groupEventId,
+                    parentEventId: currentEvent.id,
                     pipelineId: strToInt(joinedPipelineId)
                 });
 
-                externalEventConfig.groupEventId =
-                    sameParentEvents.length > 0 ? sameParentEvents[0].groupEventId : currentEvent.groupEventId;
+                if (sameParentEvents.length > 0) {
+                    externalEvent = sameParentEvents[0];
+                }
             }
 
-            try {
-                externalEvent = await createExternalEvent(externalEventConfig);
-            } catch (err) {
-                // The case of triggered external pipeline which is already deleted from DB, etc
-                logger.error(
-                    `Error in createExternalEvent:${joinedPipelineId} from pipeline:${currentPipeline.id}-${currentJob.name}-event:${currentEvent.id}`,
-                    err
-                );
+            // If user used external trigger syntax, the jobs are triggered as external
+            if (isCurrentPipeline) {
+                externalEvent = null;
+            } else if (isRestartPipeline) {
+                // If parentEvent and currentEvent have the same pipelineId, then currentEvent is the event that started the restart
+                // If restarted from the downstream pipeline, the remote trigger must create a new event in the upstream pipeline
+                const sameParentEvents = await getSameParentEvents({
+                    eventFactory,
+                    parentEventId: currentEvent.id,
+                    pipelineId: strToInt(joinedPipelineId)
+                });
+
+                externalEvent = sameParentEvents.length > 0 ? sameParentEvents[0] : null;
             }
+
+            // no need to lock if there is no external event
+            if (externalEvent) {
+                externalEventResource = `pipeline:${joinedPipelineId}:event:${externalEvent.id}`;
+            }
+
+            // Create a new external event
+            // First downstream trigger, restart case, same pipeline trigger as external
+            if (!externalEvent) {
+                const { parentBuilds } = parseJobInfo({
+                    currentBuild,
+                    currentPipeline,
+                    currentJob
+                });
+
+                const externalEventConfig = {
+                    pipelineFactory,
+                    eventFactory,
+                    externalPipelineId: joinedPipelineId,
+                    parentBuildId: currentBuild.id,
+                    parentBuilds,
+                    causeMessage: `Triggered by ${remoteJoinName}`,
+                    parentEventId: currentEvent.id,
+                    startFrom: remoteTriggerName,
+                    skipMessage: 'Skip bulk external builds creation', // Don't start builds in eventFactory.
+                    groupEventId: null
+                };
+
+                const buildsToRestart = buildsToRestartFilter(
+                    joinedPipeline,
+                    groupEventBuilds,
+                    currentEvent,
+                    currentBuild
+                );
+                const isRestart = buildsToRestart.length > 0;
+
+                // Restart case
+                if (isRestart) {
+                    // 'joinedPipeline.event.id' is restart event, not group event.
+                    const groupEvent = await eventFactory.get({ id: joinedPipeline.event.id });
+
+                    externalEventConfig.groupEventId = groupEvent.groupEventId;
+                    externalEventConfig.parentBuilds = buildsToRestart[0].parentBuilds;
+                } else {
+                    const sameParentEvents = await getSameParentEvents({
+                        eventFactory,
+                        parentEventId: currentEvent.groupEventId,
+                        pipelineId: strToInt(joinedPipelineId)
+                    });
+
+                    externalEventConfig.groupEventId =
+                        sameParentEvents.length > 0 ? sameParentEvents[0].groupEventId : currentEvent.groupEventId;
+                }
+
+                externalEvent = await createExternalEvent(externalEventConfig);
+            }
+        } catch (err) {
+            logger.error(
+                `Error in selection/creation externalEvent:${joinedPipelineId} from pipeline:${currentPipeline.id}-${currentJob.name}-event:${currentEvent.id}`,
+                err
+            );
+        } finally {
+            await locker.unlock(groupEventLock, groupEventResource);
         }
 
         // Skip trigger process if createExternalEvent fails
@@ -324,7 +338,7 @@ async function triggerNextJobs(config, server) {
                 let nextBuild;
 
                 try {
-                    if (resource) lock = await locker.lock(resource);
+                    if (externalEventResource) externalEventLock = await locker.lock(externalEventResource);
 
                     if (isOrTrigger(externalEvent.workflowGraph, remoteTriggerName, nextJobName)) {
                         nextBuild = await remoteTrigger.execute(
@@ -383,9 +397,9 @@ async function triggerNextJobs(config, server) {
                         `Error in triggerJobsInExternalPipeline:${joinedPipelineId} from pipeline:${currentPipeline.id}-${currentJob.name}-event:${currentEvent.id} `,
                         err
                     );
+                } finally {
+                    await locker.unlock(externalEventLock, externalEventResource);
                 }
-
-                await locker.unlock(lock, resource);
             }
         }
     }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -3972,7 +3972,7 @@ describe('build plugin test', () => {
                         assert.calledWith(eventFactoryMock.create.secondCall, expectedEventArgs2);
                         sinon.assert.calledOnceWithMatch(
                             loggerMock.error,
-                            'Error in createExternalEvent:2 from pipeline:123-a-event:8888'
+                            'Error in selection/creation externalEvent:2 from pipeline:123-a-event:8888'
                         );
                     });
                 });
@@ -6285,7 +6285,7 @@ describe('build plugin test', () => {
                         return newServer.inject(options).then(() => {
                             const { lock, unlock } = lockMock;
 
-                            assert.calledOnce(lock);
+                            assert.calledTwice(lock);
                             assert.called(unlock);
                         });
                     });
@@ -6297,7 +6297,7 @@ describe('build plugin test', () => {
                         return newServer.inject(options).then(() => {
                             const { lock, unlock } = lockMock;
 
-                            assert.calledOnce(lock);
+                            assert.calledTwice(lock);
                             assert.called(unlock);
                         });
                     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

If trigger processing for downstream events in the same pipeline runs simultaneously, builds may be created for separate events.

<img width="226" height="374" alt="image" src="https://github.com/user-attachments/assets/a5b257a5-3446-401a-a5e0-37451bcef4d8" />
<img width="217" height="375" alt="image" src="https://github.com/user-attachments/assets/5e8ea9af-104d-40a5-9b3d-7d077b681e72" />

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Acquire a lock using the downstream pipeline ID and groupEventID to ensure external event creation processes execute sequentially.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
