### PR TITLE
fix: metadata get empty when user stop the builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "jsonwebtoken": "^9.0.0",
     "license-checker": "^25.0.1",
     "lodash.mergewith": "^4.6.2",
+    "lodash.isempty": "^4.4.0",
     "ndjson": "^2.0.0",
     "node-env-file": "^0.1.8",
     "prom-client": "^12.0.0",

--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -3,6 +3,7 @@
 const boom = require('@hapi/boom');
 const hoek = require('@hapi/hoek');
 const merge = require('lodash.mergewith');
+const isEmpty = require('lodash.isempty');
 const { PR_JOB_NAME, PR_STAGE_NAME, STAGE_TEARDOWN_PATTERN } = require('screwdriver-data-schema').config.regex;
 const { getFullStageJobName } = require('../../helper');
 const { updateVirtualBuildSuccess, emitBuildStatusEvent } = require('../triggers/helpers');
@@ -370,7 +371,7 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
         build.statusMessage = statusMessage || build.statusMessage;
         build.statusMessageType = statusMessageType || build.statusMessageType;
     } else if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(desiredStatus)) {
-        build.meta = meta || {};
+        build.meta = isEmpty(meta) ? build.meta || {} : meta;
         event.meta = merge({}, event.meta, build.meta);
         build.endTime = new Date().toISOString();
     } else if (desiredStatus === 'RUNNING') {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -816,6 +816,11 @@ describe('build plugin test', () => {
                     getPermissions: sinon.stub().resolves({ push: true })
                 };
                 const expected = hoek.applyToDefaults(testBuildWithSteps, { status: 'ABORTED' });
+                const expectedMeta = {
+                    commit: { sha: '123', message: 'test message' },
+                    build: { id: 123 },
+                    foo: 'bar'
+                };
                 const options = {
                     method: 'PUT',
                     url: `/builds/${id}`,
@@ -831,6 +836,7 @@ describe('build plugin test', () => {
                     }
                 };
 
+                buildMock.meta = expectedMeta;
                 buildMock.job = sinon.stub().resolves(jobMock)();
                 buildFactoryMock.get.resolves(buildMock);
                 buildMock.toJson.returns(testBuild);
@@ -840,6 +846,7 @@ describe('build plugin test', () => {
                 return server.inject(options).then(reply => {
                     assert.deepEqual(reply.result, expected);
                     assert.calledWith(buildFactoryMock.get, id);
+                    assert.deepEqual(buildMock.meta, expectedMeta);
                     assert.equal(buildMock.statusMessage, 'Aborted by test-user');
                     assert.equal(reply.statusCode, 200);
                 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Aborting the builds from the UI sends a payload to the API without metadata, so the metadata becomes empty after aborting.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Add a check to verify whether the metadata in the payload is empty or not.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
