### PR TITLE
feat: Add tests for GIT_RECURSIVE_CLONE env [2]

### DIFF
--- a/features/sd-setup-scm.feature
+++ b/features/sd-setup-scm.feature
@@ -39,6 +39,12 @@ Feature: sd-setup-scm
         # not-shallow-clone-single-branch
         And the "not-shallow-clone-single-branch" job is triggered
         Then the "not-shallow-clone-single-branch" build succeeded
+        # recursive-clone
+        And the "recursive-clone" job is triggered
+        Then the pipeline job "recursive-clone" is success
+        # not-recursive-clone
+        And the "not-recursive-clone" job is triggered
+        Then the pipeline job "not-recursive-clone" is success
 
     @x1
     Scenario: External config build
@@ -76,6 +82,12 @@ Feature: sd-setup-scm
         # not-shallow-clone-single-branch
         And the "not-shallow-clone-single-branch" job is triggered
         Then the "not-shallow-clone-single-branch" build succeeded
+        # recursive-clone
+        And the "recursive-clone" job is triggered
+        Then the pipeline job "recursive-clone" is success
+        # not-recursive-clone
+        And the "not-recursive-clone" job is triggered
+        Then the pipeline job "not-recursive-clone" is success
 
     Scenario: PR build
         Given an existing pipeline for sd-setup-scm
@@ -92,3 +104,9 @@ Feature: sd-setup-scm
         # not-shallow-clone
         And the "not-shallow-clone-single-branch" PR job is triggered
         Then the "not-shallow-clone-single-branch" PR build succeeded
+        # recursive-clone
+        And the "recursive-clone" job is triggered
+        Then the pipeline job "recursive-clone" is success
+        # not-recursive-clone
+        And the "not-recursive-clone" job is triggered
+        Then the pipeline job "not-recursive-clone" is success


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
There are no functional tests for recursive cloning.

## Objective

Add a test scenario for environment variables related to sd-setup-scm provided by screwdriver.
This change tests whether submodules can be recursively cloned and shallowly cloned.

Environment variables:
- GIT_RECURSIVE_CLONE

This change relates to the following PR
- https://github.com/screwdriver-cd/scm-github/pull/251

The following PR adds the test contents.
The test will fail because there are no jobs until the following PR is merged.
- https://github.com/screwdriver-cd-test/functional-sd-setup-scm/pull/190

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
