### PR TITLE
feat(3416): Allow commit sha to be specified while creating an event

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "screwdriver-config-parser": "^12.2.3",
     "screwdriver-coverage-bookend": "^3.0.0",
     "screwdriver-coverage-sonar": "^5.0.0",
-    "screwdriver-data-schema": "^25.11.0",
+    "screwdriver-data-schema": "^25.12.0",
     "screwdriver-datastore-sequelize": "^10.0.0",
     "screwdriver-executor-base": "^11.0.0",
     "screwdriver-executor-docker": "^8.0.1",


### PR DESCRIPTION
## Context

When an event is created, the commit sha used is either the latest (when parent event is not specified) or inherited from the parent event when specified.
When parent event is specified, the new event also inherits the context (`meta`, `parameters`, etc) from the parent event.

There is no way to create an event using a specific commit sha (i.e. the commit sha of any previous event) without inheriting the context from another event.

## Objective

Allow `sha` to be specified in the `create` schema for `event` model.
This is an optional field.

Exceptions:
- When both `sha` and `parentEventId` are specified in the input, parent event `sha` supersedes the input `sha`
- For PR events, the input `sha` is not considered. The event is always created with the latest commit `sha`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3416

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
