### PR TITLE
fix: resolve potential bug in virtual job triggered by remote join

### DIFF
--- a/plugins/builds/index.js
+++ b/plugins/builds/index.js
@@ -73,10 +73,9 @@ async function triggerNextJobs(config, server) {
     const currentPipeline = config.pipeline;
     const currentJob = config.job;
     const currentBuild = config.build;
+    const currentEvent = config.event;
     const { jobFactory, buildFactory, eventFactory, pipelineFactory, stageFactory, stageBuildFactory } = server.app;
 
-    /** @type {EventModel} */
-    const currentEvent = await eventFactory.get({ id: currentBuild.eventId });
     const current = {
         pipeline: currentPipeline,
         build: currentBuild,
@@ -357,10 +356,10 @@ async function triggerNextJobs(config, server) {
                         const stageBuild = await getStageBuild({
                             stageFactory,
                             stageBuildFactory,
-                            workflowGraph: currentEvent.workflowGraph,
+                            workflowGraph: externalEvent.workflowGraph,
                             jobName: nextJob.name,
                             pipelineId: currentPipeline.id,
-                            eventId: currentEvent.id
+                            eventId: externalEvent.id
                         });
 
                         if (stageBuild) {
@@ -370,7 +369,7 @@ async function triggerNextJobs(config, server) {
                         if (nextBuild && nextBuild.status === Status.SUCCESS) {
                             downstreamOfNextJobsToBeProcessed.push({
                                 build: nextBuild,
-                                event: currentEvent,
+                                event: externalEvent,
                                 job: nextJob,
                                 pipeline: await nextJob.pipeline,
                                 scmContext: config.scmContext,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When triggering downstream jobs from a virtual job that was initiated via a remote join, the event object passed to the next trigger is incorrect.
Instead of passing the event that belongs to the pipeline where the virtual job resides, the system currently passes the event from the pipeline that triggered the virtual job.

Fortunately, this has not caused any functional issues so far because the downstream trigger process (`triggerNextJobs()`) re-fetches the correct event information from the database using the `eventId` stored in the build object.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR fixes the event propagation logic for virtual jobs triggered by remote joins.

- Pass the correct event (belonging to the virtual job’s pipeline) when calling `triggerNextJobs()`.
- Update `triggerNextJobs()` to use the provided event object directly instead of performing an additional database lookup.

These changes ensure consistent event data handling across pipelines and reduce redundant database access.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
