### PR TITLE
Update sd/dind template version to latest

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -50,7 +50,7 @@ jobs:
             screwdriver.cd/dockerCpu: HIGH
             screwdriver.cd/dockerRam: HIGH
         requires: publish
-        template: sd/dind@2.0.20
+        template: sd/dind@latest
     # Deploy to our beta environment and run tests
     beta:
         requires: [docker-publish]


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The Docker publish job is failing as shown below.
https://cd.screwdriver.cd/pipelines/1/builds/983109/steps/setup

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
To align with the configuration in `screwdriver-cd/launcher` and ensure successful Docker publishing,
this PR updates the `sd/dind` template version to latest in this repository’s pipeline.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
In the `screwdriver-cd/launcher` repository, the latest version of the `sd/dind` template is specified.
Due to the following update in the dind template, Docker publishing now succeeds when using latest.

- dind template update commit:
  - https://github.com/screwdriver-cd-test/dind-template/commit/d37b90794ef1a5a76fae7e284c10a5c884071f0b
- screwdriver.yaml:
  - https://github.com/screwdriver-cd/launcher/blob/0fcbc02ba254bdcf16a8c899c82f0ca825e6c0dc/screwdriver.yaml#L40

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
