### PR TITLE
fix(3427): undefined adminUserIds for V2 UI Options

### DIFF
--- a/plugins/pipelines/admins/list.js
+++ b/plugins/pipelines/admins/list.js
@@ -60,7 +60,8 @@ function getAdminUsersFromPipelineSCMContext(pipeline, userFactory) {
  * whose registered SCM context differs from the pipeline's context.
  */
 function getAdminUsersFromOtherSCMContext(pipeline, userFactory) {
-    const { adminUserIds, scmContext } = pipeline;
+    const { scmContext } = pipeline;
+    const adminUserIds = pipeline.adminUserIds ? pipeline.adminUserIds : [];
 
     const listConfig = {
         params: {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

This is follow up for https://github.com/screwdriver-cd/screwdriver/pull/3325

Similarly, in MySQL 5, since default values cannot be set for TEXT fields, they become undefined.

Attempting to open the v2 UI Options screen for a pipeline immediately after creation, where admins have never been updated, will result in an error.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

When undefined, replace with an empty array to avoid errors.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/pull/3325

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
