### PR TITLE
fix(3399): Bump models version

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "screwdriver-executor-queue": "^6.0.0",
     "screwdriver-executor-router": "^5.0.0",
     "screwdriver-logger": "^3.0.0",
-    "screwdriver-models": "^32.8.0",
+    "screwdriver-models": "^33.0.0",
     "screwdriver-notifications-email": "^5.0.0",
     "screwdriver-notifications-slack": "^7.0.0",
     "screwdriver-request": "^3.0.0",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Bump model version in screwdriver backend for https://github.com/screwdriver-cd/models/pull/660
This version update changes the fetch logic for metadata from external pipelines.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- If parent builds/events are external, triggered build does not fetch metadata.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#3399 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
