### PR TITLE
fix(3460): Set adminUserIds when a pipeline is created

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "screwdriver-executor-queue": "^6.0.0",
     "screwdriver-executor-router": "^5.0.0",
     "screwdriver-logger": "^3.0.0",
-    "screwdriver-models": "^33.0.0",
+    "screwdriver-models": "^33.2.0",
     "screwdriver-notifications-email": "^5.0.0",
     "screwdriver-notifications-slack": "^7.0.0",
     "screwdriver-request": "^3.0.0",

--- a/plugins/pipelines/create.js
+++ b/plugins/pipelines/create.js
@@ -63,6 +63,7 @@ module.exports = () => ({
                 admins: {
                     [username]: true
                 },
+                adminUserIds: [user.id],
                 scmContext,
                 scmUri
             };

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2502,6 +2502,7 @@ describe('pipeline plugin test', () => {
                     admins: {
                         [username]: true
                     },
+                    adminUserIds: [userId],
                     scmUri,
                     scmContext
                 });
@@ -2556,6 +2557,7 @@ describe('pipeline plugin test', () => {
                     admins: {
                         [username]: true
                     },
+                    adminUserIds: [userId],
                     scmUri,
                     scmContext
                 });


### PR DESCRIPTION
## Context

For a pipeline, `admins` holds the administrators from the SCM that is same as pipeline SCM.
Where as `adminUserIds` holds the administrators across SCMs.

When a pipeline is created by a user, the user is set in `admins` but not in `adminUserIds`.

## Objective

When a pipeline is created by a user, the user must be set as administrator in both `admins` and `adminUserIds`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3460

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
