### PR TITLE
fix: upgrade @promster/hapi and remove obsolete overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@hapi/hoek": "^11.0.0",
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",
-    "@promster/hapi": "^14.0.0",
+    "@promster/hapi": "^15.0.0",
     "archiver": "^7.0.1",
     "async": "^3.2.4",
     "badge-maker": "^3.3.1",
@@ -168,16 +168,5 @@
     "rewiremock": "^3.14.4",
     "sinon": "^15.0.0",
     "stream-to-promise": "^3.0.0"
-  },
-  "overrides": {
-    "@mapbox/node-pre-gyp": {
-      "tar": "^7.5.9"
-    },
-    "sqlite3": {
-      "tar": "^7.5.9"
-    },
-    "ssh-keygen": {
-      "underscore": "^1.13.8"
-    }
   }
 }

--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -166,8 +166,8 @@ function unixToFullTime(timestamp, timeZone) {
     );
 
     const offsetMatch = timeZoneName.match(/GMT(.*)/)[1];
-
-    const timezoneOffset = offsetMatch === '' ? 'Z' : offsetMatch;
+    const isUtcOffset = offsetMatch === '' || offsetMatch === '+00:00' || offsetMatch === '-00:00';
+    const timezoneOffset = isUtcOffset ? 'Z' : offsetMatch;
 
     return `${year}-${month}-${day}T${hour}:${minute}:${second}.${fractionalSecond}${timezoneOffset}`;
 }

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -243,6 +243,7 @@ describe('Register Unit Test Case', () => {
 
     it('bubbles failures up', () => {
         sinon.stub(hoek, 'reach').throws(new Error('failure loading'));
+        rewiremock.enable();
 
         return main(serverMock, config)
             .then(() => {
@@ -251,6 +252,9 @@ describe('Register Unit Test Case', () => {
             .catch(err => {
                 Assert.equal(err.message, 'failure loading');
             })
+            .finally(() => {
+                rewiremock.disable();
+            });
     });
 
     it('registers data for plugin when specified in the config object', async () => {

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -243,6 +243,7 @@ describe('Register Unit Test Case', () => {
 
     it('bubbles failures up', () => {
         sinon.stub(hoek, 'reach').throws(new Error('failure loading'));
+        rewiremock.enable();
 
         return main(serverMock, config)
             .then(() => {
@@ -250,6 +251,9 @@ describe('Register Unit Test Case', () => {
             })
             .catch(err => {
                 Assert.equal(err.message, 'failure loading');
+            })
+            .finally(() => {
+                rewiremock.disable();
             });
     });
 

--- a/test/lib/registerPlugins.test.js
+++ b/test/lib/registerPlugins.test.js
@@ -243,7 +243,6 @@ describe('Register Unit Test Case', () => {
 
     it('bubbles failures up', () => {
         sinon.stub(hoek, 'reach').throws(new Error('failure loading'));
-        rewiremock.enable();
 
         return main(serverMock, config)
             .then(() => {
@@ -252,9 +251,6 @@ describe('Register Unit Test Case', () => {
             .catch(err => {
                 Assert.equal(err.message, 'failure loading');
             })
-            .finally(() => {
-                rewiremock.disable();
-            });
     });
 
     it('registers data for plugin when specified in the config object', async () => {


### PR DESCRIPTION
## Context

  A vulnerability scan detected issues in transitive dependencies related to our Hapi monitoring stack, so we updated @promster/hapi.

  We also found a critical limitation in our previous overrides-based mitigation:

  - overrides in package.json only applies when running npm install inside this repository.
  - It does not apply when this package is installed as a published dependency.

  In our Docker build flow, the image installs screwdriver-api via npm install screwdriver-api in the Dockerfile.
  In that path, the overrides from this repository are not honored, so vulnerable older versions of tar and underscore can still be installed.

Implemented a follow-up fix to keep behavior deterministic after the dependency update.
Enforced canonical UTC output (Z) for full-time step log timestamps.

  ## Objective

  This PR:

  - Upgrades @promster/hapi to pull in a safer dependency chain.
  - Removes obsolete overrides that gave a false sense of protection for downstream installs.

  The goal is to ensure vulnerability remediation is effective in real consumption paths (including Docker image builds), not only in local repository
  installs.
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Reverting the following PR
https://github.com/screwdriver-cd/screwdriver/pull/3470

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
