### PR TITLE
fix: notify aborted when stop event

### DIFF
--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -101,11 +101,13 @@ module.exports = () => ({
 
             const abortedBuilds = updatedBuilds.filter(build => build.status === 'ABORTED');
 
-            await Promise.all(abortedBuilds.map(async build => {
+            const buildNotifies = abortedBuilds.map(async build => {
                 const job = await build.job;
 
                 return emitBuildStatusEvent({ server: request.server, build, pipeline, event, job });
-            }));
+            });
+
+            await Promise.all(buildNotifies)
 
             // Update stageBuild status to ABORTED
             const stageBuilds = await event.getStageBuilds();

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -101,11 +101,11 @@ module.exports = () => ({
 
             const abortedBuilds = updatedBuilds.filter(build => build.status === 'ABORTED');
 
-            abortedBuilds.map(async build => {
+            await Promise.all(abortedBuilds.map(async build => {
                 const job = await build.job;
 
                 return emitBuildStatusEvent({ server: request.server, build, pipeline, event, job });
-            });
+            }));
 
             // Update stageBuild status to ABORTED
             const stageBuilds = await event.getStageBuilds();

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -8,6 +8,7 @@ const schema = require('screwdriver-data-schema');
 const getSchema = schema.models.event.get;
 const idSchema = schema.models.event.base.extract('id');
 const { deriveEventStatusFromBuildStatuses, stopBuilds } = require('../builds/helper/updateBuild');
+const { emitBuildStatusEvent } = require('../builds/triggers/helpers');
 const nonTerminatedStatus = ['CREATED', 'RUNNING', 'QUEUED', 'BLOCKED', 'FROZEN'];
 
 module.exports = () => ({
@@ -97,6 +98,14 @@ module.exports = () => ({
                 event.status = newEventStatus;
                 await event.update();
             }
+
+            const abortedBuilds = updatedBuilds.filter(build => build.status === 'ABORTED');
+
+            abortedBuilds.map(async build => {
+                const job = await build.job;
+
+                return emitBuildStatusEvent({ server: request.server, build, pipeline, event, job });
+            });
 
             // Update stageBuild status to ABORTED
             const stageBuilds = await event.getStageBuilds();

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -107,7 +107,7 @@ module.exports = () => ({
                 return emitBuildStatusEvent({ server: request.server, build, pipeline, event, job });
             });
 
-            await Promise.all(buildNotifies)
+            await Promise.all(buildNotifies);
 
             // Update stageBuild status to ABORTED
             const stageBuilds = await event.getStageBuilds();

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -90,9 +90,10 @@ module.exports = () => ({
             const statusMessage = `Aborted event by ${username}`;
 
             const { unchangedBuilds, changedBuilds } = stopBuilds(builds, statusMessage);
-            const updatedBuilds = [...unchangedBuilds, ...(await Promise.all(changedBuilds.map(b => b.update())))];
+            const updatedBuilds = await Promise.all(changedBuilds.map(b => b.update()));
+            const updatedAllBuilds = [...unchangedBuilds, ...updatedBuilds];
 
-            const newEventStatus = deriveEventStatusFromBuildStatuses(updatedBuilds);
+            const newEventStatus = deriveEventStatusFromBuildStatuses(updatedAllBuilds);
 
             if (newEventStatus && event.status !== newEventStatus) {
                 event.status = newEventStatus;

--- a/test/plugins/data/builds.json
+++ b/test/plugins/data/builds.json
@@ -42,7 +42,7 @@
     }
 },{
     "id": 12346,
-    "jobId": 1234,
+    "jobId": 2345,
     "number": 1,
     "sha": "58393af682d61de87789fb4961645c42180cec5a",
     "cause": "Started by user foo",
@@ -79,7 +79,7 @@
     "status": "FAILURE"
 },{
     "id": 223344,
-    "jobId": 1234,
+    "jobId": 3456,
     "number": 5,
     "sha": "58393af682d61de87789fb4961645c42180cec5a",
     "cause": "Started by user foo",
@@ -116,7 +116,7 @@
     "status": "RUNNING"
 },{
     "id": 334455,
-    "jobId": 1234,
+    "jobId": 4567,
     "number": 5,
     "sha": "58393af682d61de87789fb4961645c42180cec5a",
     "cause": "Started by user foo",
@@ -153,7 +153,7 @@
     "status": "QUEUED"
 },{
     "id": 776677,
-    "jobId": 1234,
+    "jobId": 5678,
     "number": 5,
     "sha": "58393af682d61de87789fb4961645c42180cec5a",
     "cause": "Started by user foo",

--- a/test/plugins/data/builds.json
+++ b/test/plugins/data/builds.json
@@ -42,7 +42,7 @@
     }
 },{
     "id": 12346,
-    "jobId": 2345,
+    "jobId": 1234,
     "number": 1,
     "sha": "58393af682d61de87789fb4961645c42180cec5a",
     "cause": "Started by user foo",

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1609,6 +1609,53 @@ describe('event plugin test', () => {
             builds = getBuildMocks(testBuilds);
             stageBuilds = getStageBuildMocks(testStageBuilds);
 
+            builds[2].job = {
+                id: builds[2].jobId,
+                pipelineId,
+                name: 'build2',
+                pipeline: pipelineMock,
+                permutations: [
+                    {
+                        settings: {
+                            email: 'foo@bar.com'
+                        }
+                    }
+                ]
+            };
+            builds[3].job = {
+                id: builds[3].jobId,
+                pipelineId,
+                name: 'build3',
+                pipeline: pipelineMock,
+                permutations: [
+                    {
+                        settings: {
+                            slack: {
+                                channels: ['foo'],
+                                statuses: ['SUCCESS']
+                            }
+                        }
+                    }
+                ]
+            };
+            builds[4].job = {
+                id: builds[4].jobId,
+                pipelineId,
+                name: 'build4',
+                pipeline: pipelineMock,
+                permutations: [
+                    {
+                        settings: {
+                            email: 'bar@baz.com',
+                            slack: {
+                                channels: ['bar'],
+                                statuses: ['FAILURE']
+                            }
+                        }
+                    }
+                ]
+            };
+
             eventFactoryMock.get.withArgs(id).resolves(event);
             event.getBuilds.resolves(builds);
             event.getStageBuilds.resolves(stageBuilds);
@@ -1759,53 +1806,6 @@ describe('event plugin test', () => {
         });
 
         it('returns 200 and stops all event builds and notify', () => {
-            builds[2].job = {
-                id: builds[2].jobId,
-                pipelineId,
-                name: 'build2',
-                pipeline: pipelineMock,
-                permutations: [
-                    {
-                        settings: {
-                            email: 'foo@bar.com'
-                        }
-                    }
-                ]
-            };
-            builds[3].job = {
-                id: builds[3].jobId,
-                pipelineId,
-                name: 'build3',
-                pipeline: pipelineMock,
-                permutations: [
-                    {
-                        settings: {
-                            slack: {
-                                channels: ['foo'],
-                                statuses: ['SUCCESS']
-                            }
-                        }
-                    }
-                ]
-            };
-            builds[4].job = {
-                id: builds[4].jobId,
-                pipelineId,
-                name: 'build4',
-                pipeline: pipelineMock,
-                permutations: [
-                    {
-                        settings: {
-                            email: 'bar@baz.com',
-                            slack: {
-                                channels: ['bar'],
-                                statuses: ['FAILURE']
-                            }
-                        }
-                    }
-                ]
-            };
-
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
                 assert.strictEqual(builds[2].status, 'ABORTED');
@@ -1870,6 +1870,64 @@ describe('event plugin test', () => {
                 });
             });
         });
+
+        it('returns 200 and stops all event builds and notify without including already aborted builds', () => {
+            builds[2].status = 'ABORTED';
+            builds[2].statusMessage = 'Aborted build by myself';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.strictEqual(builds[2].status, 'ABORTED');
+                assert.strictEqual(builds[3].status, 'ABORTED');
+                assert.strictEqual(builds[4].status, 'ABORTED');
+                assert.strictEqual(builds[2].statusMessage, 'Aborted build by myself');
+                assert.strictEqual(builds[3].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[4].statusMessage, 'Aborted event by myself');
+                assert.calledOnce(event.getBuilds);
+                assert.notCalled(builds[0].update);
+                assert.notCalled(builds[1].update);
+                assert.notCalled(builds[2].update);
+                assert.calledOnce(builds[3].update);
+                assert.calledOnce(builds[4].update);
+                assert.callCount(server.events.emit, 2);
+                assert.calledWithMatch(server.events.emit.getCall(0), 'build_status', {
+                    settings: {
+                        slack: {
+                            channels: ['foo'],
+                            statuses: ['SUCCESS']
+                        }
+                    },
+                    status: 'ABORTED',
+                    pipeline: { id: 123 },
+                    jobName: 'build3',
+                    build: {
+                        id: 334455,
+                        jobId: 4567
+                    },
+                    buildLink: 'http://foo.bar/pipelines/123/builds/334455',
+                    isFixed: false
+                });
+                assert.calledWithMatch(server.events.emit.getCall(1), 'build_status', {
+                    settings: {
+                        email: 'bar@baz.com',
+                        slack: {
+                            channels: ['bar'],
+                            statuses: ['FAILURE']
+                        }
+                    },
+                    status: 'ABORTED',
+                    pipeline: { id: 123 },
+                    jobName: 'build4',
+                    build: {
+                        id: 776677,
+                        jobId: 5678
+                    },
+                    buildLink: 'http://foo.bar/pipelines/123/builds/776677',
+                    isFixed: false
+                });
+            });
+        });
+
         it(
             'returns 403 forbidden error when user does not have push permission' +
                 ' and is not Screwdriver admin and is not PR owner',

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -108,6 +108,7 @@ describe('event plugin test', () => {
             getFullDisplayName: sinon.stub().returns('Memys Elfandi')
         };
         buildFactoryMock = {
+            uiUri: 'http://foo.bar',
             get: sinon.stub(),
             create: sinon.stub()
         };
@@ -1569,7 +1570,8 @@ describe('event plugin test', () => {
                 unsealToken: sinon.stub().resolves('token')
             }),
             scmUri,
-            prChain: false
+            prChain: false,
+            toJson: sinon.stub().returns({ id: pipelineId })
         };
         const id = 123;
         const username = 'myself';
@@ -1612,7 +1614,9 @@ describe('event plugin test', () => {
             event.getStageBuilds.resolves(stageBuilds);
             screwdriverAdminDetailsMock.returns({ isAdmin: false });
 
-            builds[2].update.resolves({ status: 'ABORTED' });
+            server.events = {
+                emit: sinon.stub().resolves(null)
+            };
         });
 
         it('returns 200 and stops all event builds', () =>
@@ -1754,6 +1758,118 @@ describe('event plugin test', () => {
             });
         });
 
+        it('returns 200 and stops all event builds and notify', () => {
+            builds[2].job = {
+                id: builds[2].jobId,
+                pipelineId,
+                name: 'build2',
+                pipeline: pipelineMock,
+                permutations: [
+                    {
+                        settings: {
+                            email: 'foo@bar.com'
+                        }
+                    }
+                ]
+            };
+            builds[3].job = {
+                id: builds[3].jobId,
+                pipelineId,
+                name: 'build3',
+                pipeline: pipelineMock,
+                permutations: [
+                    {
+                        settings: {
+                            slack: {
+                                channels: ['foo'],
+                                statuses: ['SUCCESS']
+                            }
+                        }
+                    }
+                ]
+            };
+            builds[4].job = {
+                id: builds[4].jobId,
+                pipelineId,
+                name: 'build4',
+                pipeline: pipelineMock,
+                permutations: [
+                    {
+                        settings: {
+                            email: 'bar@baz.com',
+                            slack: {
+                                channels: ['bar'],
+                                statuses: ['FAILURE']
+                            }
+                        }
+                    }
+                ]
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.strictEqual(builds[2].status, 'ABORTED');
+                assert.strictEqual(builds[3].status, 'ABORTED');
+                assert.strictEqual(builds[4].status, 'ABORTED');
+                assert.strictEqual(builds[2].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[3].statusMessage, 'Aborted event by myself');
+                assert.strictEqual(builds[4].statusMessage, 'Aborted event by myself');
+                assert.calledOnce(event.getBuilds);
+                assert.notCalled(builds[0].update);
+                assert.notCalled(builds[1].update);
+                assert.calledOnce(builds[2].update);
+                assert.calledOnce(builds[3].update);
+                assert.calledOnce(builds[4].update);
+                assert.callCount(server.events.emit, 3);
+                assert.calledWithMatch(server.events.emit.getCall(0), 'build_status', {
+                    settings: { email: 'foo@bar.com' },
+                    status: 'ABORTED',
+                    pipeline: { id: 123 },
+                    jobName: 'build2',
+                    build: {
+                        id: 223344,
+                        jobId: 3456
+                    },
+                    buildLink: 'http://foo.bar/pipelines/123/builds/223344',
+                    isFixed: false
+                });
+                assert.calledWithMatch(server.events.emit.getCall(1), 'build_status', {
+                    settings: {
+                        slack: {
+                            channels: ['foo'],
+                            statuses: ['SUCCESS']
+                        }
+                    },
+                    status: 'ABORTED',
+                    pipeline: { id: 123 },
+                    jobName: 'build3',
+                    build: {
+                        id: 334455,
+                        jobId: 4567
+                    },
+                    buildLink: 'http://foo.bar/pipelines/123/builds/334455',
+                    isFixed: false
+                });
+                assert.calledWithMatch(server.events.emit.getCall(2), 'build_status', {
+                    settings: {
+                        email: 'bar@baz.com',
+                        slack: {
+                            channels: ['bar'],
+                            statuses: ['FAILURE']
+                        }
+                    },
+                    status: 'ABORTED',
+                    pipeline: { id: 123 },
+                    jobName: 'build4',
+                    build: {
+                        id: 776677,
+                        jobId: 5678
+                    },
+                    buildLink: 'http://foo.bar/pipelines/123/builds/776677',
+                    isFixed: false
+                });
+            });
+        });
         it(
             'returns 403 forbidden error when user does not have push permission' +
                 ' and is not Screwdriver admin and is not PR owner',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If the build is stopped by directly specifying it, an ABORTED notification will be executed.
However, if stopped using the event stop button, no ABORTED notification will be issued for each build.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
For builds that have been ABORTED due to an event stop, notifications will be sent if ABORTED notification settings are configured.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
