### PR TITLE
Security: Public metrics endpoint may expose sensitive operational data

### DIFF
--- a/plugins/metrics.js
+++ b/plugins/metrics.js
@@ -18,9 +18,12 @@ module.exports = {
             path: '/metrics',
             handler: async (_, h) => h.response(await getSummary()),
             config: {
+                auth: {
+                    mode: 'required'
+                },
                 plugins: {
                     'hapi-rate-limit': {
-                        enabled: false
+                        enabled: true
                     }
                 },
                 description: 'application metrics',


### PR DESCRIPTION
## Problem

The `/metrics` route is registered without authentication and explicitly disables rate limiting. Prometheus output often includes process, runtime, and request-level telemetry that can aid reconnaissance and capacity attacks.

**Severity**: `medium`
**File**: `plugins/metrics.js`

## Solution

Require authentication (or network-level allowlisting) for `/metrics`, and enable throttling. If public scraping is required, expose only a sanitized metric subset.

## Changes

- `plugins/metrics.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
