### PR TITLE
feat(3434): skip execution of virtual jobs when the event start from UI [2]

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -60,6 +60,7 @@ module.exports = () => ({
                 startFrom,
                 type: 'pipeline',
                 username,
+                webhooks: true,
                 meta: request.payload.meta // always exists because default is {}
             };
 

--- a/plugins/events/helper/createEvent.js
+++ b/plugins/events/helper/createEvent.js
@@ -76,20 +76,20 @@ async function createEvent(config, server) {
     const event = await eventFactory.create(config);
 
     if (event.builds) {
-        const jobIds = event.builds.map(b => b.jobId);
-
+        // Virtual builds are just CREATED. Not started(QUEUED, RUNNNING, ...).
+        const createdBuilds = event.builds.filter(b => b.status === 'CREATED');
+        const jobIds = createdBuilds.map(b => b.jobId);
         const virtualNodeNames = getVirtualJobNames(event.workflowGraph);
 
-        if (virtualNodeNames.length > 0) {
-            const prJobs = await jobFactory.list({
+        if (createdBuilds.length > 0 && virtualNodeNames.length > 0) {
+            const jobs = await jobFactory.list({
                 params: {
                     id: jobIds
                 }
             });
 
-            const virtualJobIds = getVirtualJobIds(virtualNodeNames, prJobs);
-
-            const virtualJobBuilds = event.builds.filter(b => virtualJobIds.includes(b.jobId));
+            const virtualJobIds = getVirtualJobIds(virtualNodeNames, jobs);
+            const virtualJobBuilds = createdBuilds.filter(b => virtualJobIds.includes(b.jobId));
 
             for (const build of virtualJobBuilds) {
                 await updateBuildAndTriggerDownstreamJobs(

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -416,6 +416,7 @@ describe('event plugin test', () => {
                 sha: commitSha,
                 type: 'pipeline',
                 username,
+                webhooks: true,
                 meta
             };
 
@@ -676,8 +677,8 @@ describe('event plugin test', () => {
             const virtualBuildMock = eventMock.builds[0];
             const nonVirtualBuildMock = eventMock.builds[1];
 
-            virtualBuildMock.status = 'CREATED';
-            nonVirtualBuildMock.status = 'CREATED';
+            virtualBuildMock.status = 'QUEUED';
+            nonVirtualBuildMock.status = 'QUEUED';
             nonVirtualBuildMock.jobId = 1235;
 
             const virtualJobMock = {
@@ -747,7 +748,7 @@ describe('event plugin test', () => {
                 assert.notCalled(eventFactoryMock.scm.getPrInfo);
 
                 // virtual job should not be auto-skipped when blockedBy is present
-                assert.equal(virtualBuildMock.status, 'CREATED');
+                assert.equal(virtualBuildMock.status, 'QUEUED');
                 assert.notCalled(virtualBuildMock.update);
                 assert.notCalled(buildFactoryMock.create);
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The API response is too slow when a virtual job has a large number of connected downstream jobs.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Skip execution of the virtual job in the webhook request and `Start a new event` button request.
They will be executed in the queue-service's request and they also trigger their downstream jobs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3434
PR - https://github.com/screwdriver-cd/models/pull/667

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
