### PR TITLE
fix(3434): drop webhook param from POST /events payload

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -60,7 +60,6 @@ module.exports = () => ({
                 startFrom,
                 type: 'pipeline',
                 username,
-                webhooks: true,
                 meta: request.payload.meta // always exists because default is {}
             };
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -416,7 +416,6 @@ describe('event plugin test', () => {
                 sha: commitSha,
                 type: 'pipeline',
                 username,
-                webhooks: true,
                 meta
             };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/screwdriver/pull/3480 .
This PR occurs the following error:
https://cd.screwdriver.cd/pipelines/1/builds/989933/steps/test-x1-parallel

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Remove the param `webhooks: true` added in https://github.com/screwdriver-cd/screwdriver/pull/3480 from the payload.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
