### PR TITLE
fix(2907): uses cannot sync pipeline if the pipeline has invalid build cluster [2]

### DIFF
--- a/plugins/pipelines/sync.js
+++ b/plugins/pipelines/sync.js
@@ -73,9 +73,9 @@ module.exports = () => ({
                 pipeline.admins = newAdmins;
                 pipeline.adminUserIds = newAdminUserIds;
 
-                await pipeline.update();
-
                 if (!scope.includes('admin')) {
+                    await pipeline.update();
+
                     throw boom.forbidden(
                         `User ${user.getFullDisplayName()} does not have push permission for this repo`
                     );
@@ -97,8 +97,6 @@ module.exports = () => ({
                 // This is needed to make admins dirty and update db
                 pipeline.admins = newAdmins;
                 pipeline.adminUserIds = newAdminUserIds;
-
-                await pipeline.update();
             }
 
             try {

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2098,7 +2098,6 @@ describe('pipeline plugin test', () => {
         it('returns 204 for updating a pipeline that exists', () =>
             server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 204);
-                assert.calledOnce(pipelineMock.update);
                 assert.calledOnce(pipelineMock.sync);
             }));
 
@@ -2112,7 +2111,6 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 204);
-                assert.calledOnce(pipelineMock.update);
                 assert.calledOnce(pipelineMock.sync);
             });
         });
@@ -2123,7 +2121,6 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 204);
-                assert.calledOnce(pipelineMock.update);
                 assert.calledOnce(pipelineMock.sync);
             });
         });
@@ -2224,7 +2221,6 @@ describe('pipeline plugin test', () => {
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 500);
-                assert.calledOnce(pipelineMock.update);
                 assert.calledOnce(pipelineMock.sync);
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Because `pipeline.update()` method includes [checking build cluster](https://github.com/screwdriver-cd/models/blob/08585cdd432e8e6f8b790d67853f522cb07a13e1/lib/pipeline.js#L2240-L2248), uses cannot sync the pipeline if the pipeline has invalid build cluster.
Thus uses cannot fix the build cluster settings too.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Fix calling `pipeline.update()` timing.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- Issue - https://github.com/screwdriver-cd/screwdriver/issues/2907
- PR - https://github.com/screwdriver-cd/models/pull/668

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
