### PR TITLE
fix(3475): Upgrade datastore to use the latest data schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "screwdriver-coverage-bookend": "^3.0.0",
     "screwdriver-coverage-sonar": "^5.0.0",
     "screwdriver-data-schema": "^26.1.0",
-    "screwdriver-datastore-sequelize": "^10.0.0",
+    "screwdriver-datastore-sequelize": "^10.1.0",
     "screwdriver-executor-base": "^11.0.0",
     "screwdriver-executor-docker": "^8.0.1",
     "screwdriver-executor-k8s": "^17.1.0",


### PR DESCRIPTION
## Context

The new fields (stateChanger, stateChangeTime, stateChangeMessage) that were added to capture the metadata when a pipeline is enabled/disabled is not being (persisted/retrieved) in DB.

Root cause is that `datastore-sequelize` still uses the older version of the data schema.

## Objective

Upgrade to the `datastore-sequelize` which uses the latest data schema

## References

https://github.com/screwdriver-cd/screwdriver/issues/3475

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
