### PR TITLE
Security: Missing resource-level authorization on build retrieval endpoint (potential IDOR/data leak)

### DIFF
--- a/plugins/builds/get.js
+++ b/plugins/builds/get.js
@@ -28,6 +28,11 @@ module.exports = () => ({
                         throw boom.notFound('Build does not exist');
                     }
 
+                    await request.server.plugins.pipelines.canAccessPipeline(
+                        request.auth.credentials,
+                        buildModel.pipelineId
+                    );
+
                     if (Array.isArray(buildModel.environment)) {
                         const data = await buildModel.toJsonWithSteps();
 


### PR DESCRIPTION
## Summary

Security: Missing resource-level authorization on build retrieval endpoint (potential IDOR/data leak)

## Problem

**Severity**: `High` | **File**: `plugins/builds/get.js:L23`

The `GET /builds/{id}` handler returns build data (including environment and step details) without checking whether the caller can access the associated pipeline/build. This can allow authenticated users to enumerate and read build records outside their authorization boundary.

## Solution

Before returning build data, enforce access checks against the build's pipeline/event ownership using credential-aware authorization helpers. Deny access when the token does not match the target resource.

## Changes

- `plugins/builds/get.js` (modified)