### PR TITLE
fix: null-safe parentBuildId check in buildsToRestartFilter

### DIFF
--- a/plugins/builds/triggers/helpers.js
+++ b/plugins/builds/triggers/helpers.js
@@ -1232,7 +1232,8 @@ function buildsToRestartFilter(joinPipeline, groupEventBuilds, currentEvent, cur
 
             // Exist build is triggered from current build
             // Prevent double triggering same build object
-            if (existBuild.parentBuildId.includes(currentBuild.id)) return null;
+            // parentBuildId can be null for top-of-event builds; nothing to dedupe
+            if (existBuild.parentBuildId && existBuild.parentBuildId.includes(currentBuild.id)) return null;
 
             // Circle back trigger (Remote Join case)
             if (existBuild.eventId === currentEvent.parentEventId) return null;

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -1529,6 +1529,23 @@ describe('buildsToRestartFilter function', () => {
 
         assert.deepEqual(result, []);
     });
+
+   it('should not throw when an existing build has parentBuildId null', () => {
+        const joinPipeline = {
+            jobs: {
+                jobA: { id: 1 }
+            }
+        };
+        const groupEventBuilds = [
+            { jobId: 1, status: Status.SUCCESS, parentBuildId: null, eventId: 100 }
+        ];
+        const currentEvent = { parentEventId: 99 };
+        const currentBuild = { id: 3 };
+        const result = buildsToRestartFilter(joinPipeline, groupEventBuilds, currentEvent, currentBuild);
+        assert.deepEqual(result, [
+            { jobId: 1, status: Status.SUCCESS, parentBuildId: null, eventId: 100 }
+        ]);
+    });
 });
 
 describe('createEvent function', () => {

--- a/test/plugins/trigger.helper.test.js
+++ b/test/plugins/trigger.helper.test.js
@@ -1530,21 +1530,18 @@ describe('buildsToRestartFilter function', () => {
         assert.deepEqual(result, []);
     });
 
-   it('should not throw when an existing build has parentBuildId null', () => {
+    it('should not throw when an existing build has parentBuildId null', () => {
         const joinPipeline = {
             jobs: {
                 jobA: { id: 1 }
             }
         };
-        const groupEventBuilds = [
-            { jobId: 1, status: Status.SUCCESS, parentBuildId: null, eventId: 100 }
-        ];
+        const groupEventBuilds = [{ jobId: 1, status: Status.SUCCESS, parentBuildId: null, eventId: 100 }];
         const currentEvent = { parentEventId: 99 };
         const currentBuild = { id: 3 };
         const result = buildsToRestartFilter(joinPipeline, groupEventBuilds, currentEvent, currentBuild);
-        assert.deepEqual(result, [
-            { jobId: 1, status: Status.SUCCESS, parentBuildId: null, eventId: 100 }
-        ]);
+
+        assert.deepEqual(result, [{ jobId: 1, status: Status.SUCCESS, parentBuildId: null, eventId: 100 }]);
     });
 });
 


### PR DESCRIPTION
## Context

`buildsToRestartFilter` in `plugins/builds/triggers/helpers.js` assumes
`existBuild.parentBuildId` is always a non-null array, but top-of-event
builds (started directly by `~commit`, `~pr`, `~sd@X:Y`, `buildPeriodically`,
or manual trigger) have `parentBuildId: null`. When such a build appears in
the current event group, calling `.includes()` on it throws:

    TypeError: Cannot read properties of null (reading 'includes')

The exception aborts the build finalizer before the current build's `status`
and `endTime` are committed, leaving the build stuck in `RUNNING` forever
with all steps already green and the container torn down.

This is the same class of `parentBuildId` handling inconsistency addressed by
#3307, #3313, and #3142; just another instance that hadn't been null-guarded.

## Objective

- Make `buildsToRestartFilter` null-safe against `existBuild.parentBuildId === null`.
- A build with no parent cannot have `currentBuild.id` in its (non-existent)
  parent list, so falling through to the remaining checks is the correct
  behavior when the value is null.

## How to reproduce

Any build that calls `meta get --external sd@X:Y` against a pipeline whose
recent event has any build with `parentBuildId: null` will hang in `RUNNING`
with all steps green. Replacing the `meta get --external` with anything that
does not register a cross-pipeline join lets the same build finalize cleanly.

## Test plan

- Unit: added a case in `test/plugins/trigger.helper.test.js` under
  `describe('buildsToRestartFilter function')` for a `groupEventBuilds`
  entry with `parentBuildId: null`, asserting the function returns it
  without throwing. (Would throw TypeError prior to this fix.)
- Manual: reproduced the hang against a pipeline using `meta get --external`,
  confirmed the build now finalizes cleanly after the patch.

## License

I confirm that this contribution is made under a BSD license and that I have
the authority necessary to make this contribution on behalf of its copyright
owner.