### PR TITLE
fix(3491): Make it possible to inherit parentEvent branch  [3]

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -21,7 +21,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { buildFactory, jobFactory, eventFactory, pipelineFactory, userFactory } = request.server.app;
-            const { buildId, causeMessage, creator, sha } = request.payload;
+            const { buildId, causeMessage, creator, sha, startAction } = request.payload;
             const { scmContext, username, scope } = request.auth.credentials;
             const { scm } = eventFactory;
             const { isValidToken } = request.server.plugins.pipelines;
@@ -67,7 +67,8 @@ module.exports = () => ({
                 payload.sha = sha;
             }
 
-            if (parentEventId) {
+            console.info({startAction})
+            if (parentEventId && startAction === 'restart') {
                 payload.parentEventId = parentEventId;
             }
 
@@ -240,26 +241,10 @@ module.exports = () => ({
 
             // If there is parentEvent, pass workflowGraph, meta and sha to payload
             // Skip PR, for PR builds, we should always start from latest commit
-            if (payload.parentEventId) {
+            if (parentEventId) {
                 const parentEvent = await eventFactory.get(parentEventId);
-                let mergedParameters = payload.meta.parameters || {};
 
                 payload.baseBranch = parentEvent.baseBranch || null;
-
-                // Merge parameters if they exist in the parent event and not in the payload
-                if (!payload.meta.parameters && parentEvent.meta && parentEvent.meta.parameters) {
-                    mergedParameters = parentEvent.meta.parameters;
-                }
-                delete payload.meta.parameters;
-
-                // Copy meta from parent event if payload.meta is empty except for the parameters
-                if (Object.keys(payload.meta).length === 0) {
-                    payload.meta = { ...parentEvent.meta };
-                }
-
-                if (Object.keys(mergedParameters).length > 0) {
-                    payload.meta.parameters = mergedParameters;
-                }
 
                 if (!prNum) {
                     payload.workflowGraph = parentEvent.workflowGraph;
@@ -269,8 +254,26 @@ module.exports = () => ({
                         payload.configPipelineSha = parentEvent.configPipelineSha;
                     }
                 }
-            }
 
+                if (startAction === 'restart') {
+                    let mergedParameters = payload.meta.parameters || {};
+
+                    // Merge parameters if they exist in the parent event and not in the payload
+                    if (!payload.meta.parameters && parentEvent.meta && parentEvent.meta.parameters) {
+                        mergedParameters = parentEvent.meta.parameters;
+                    }
+                    delete payload.meta.parameters;
+
+                    // Copy meta from parent event if payload.meta is empty except for the parameters
+                    if (Object.keys(payload.meta).length === 0) {
+                        payload.meta = { ...parentEvent.meta };
+                    }
+
+                    if (Object.keys(mergedParameters).length > 0) {
+                        payload.meta.parameters = mergedParameters;
+                    }
+                }
+            }
             const event = await createEvent(payload, request.server);
 
             if (event.builds === null) {

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -21,7 +21,7 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { buildFactory, jobFactory, eventFactory, pipelineFactory, userFactory } = request.server.app;
-            const { buildId, causeMessage, creator, sha } = request.payload;
+            const { buildId, causeMessage, creator, sha, startAction } = request.payload;
             const { scmContext, username, scope } = request.auth.credentials;
             const { scm } = eventFactory;
             const { isValidToken } = request.server.plugins.pipelines;
@@ -67,8 +67,17 @@ module.exports = () => ({
                 payload.sha = sha;
             }
 
+            // If you specify a parentEventId in the payload, the metadata will be inherited.
+            // Therefore, you should not specify a parentEventId in the payload except when using RESTART.
+            // Prevents metadata from transferring when Start from a specific event
             if (parentEventId) {
-                payload.parentEventId = parentEventId;
+                // eslint-disable-next-line default-case
+                switch (startAction) {
+                    case 'RESTART_FROM_EVENT':
+                    case 'RESTART_FROM_BUILD': {
+                        payload.parentEventId = parentEventId;
+                    }
+                }
             }
 
             if (parentBuildId) {
@@ -240,26 +249,10 @@ module.exports = () => ({
 
             // If there is parentEvent, pass workflowGraph, meta and sha to payload
             // Skip PR, for PR builds, we should always start from latest commit
-            if (payload.parentEventId) {
+            if (parentEventId) {
                 const parentEvent = await eventFactory.get(parentEventId);
-                let mergedParameters = payload.meta.parameters || {};
 
                 payload.baseBranch = parentEvent.baseBranch || null;
-
-                // Merge parameters if they exist in the parent event and not in the payload
-                if (!payload.meta.parameters && parentEvent.meta && parentEvent.meta.parameters) {
-                    mergedParameters = parentEvent.meta.parameters;
-                }
-                delete payload.meta.parameters;
-
-                // Copy meta from parent event if payload.meta is empty except for the parameters
-                if (Object.keys(payload.meta).length === 0) {
-                    payload.meta = { ...parentEvent.meta };
-                }
-
-                if (Object.keys(mergedParameters).length > 0) {
-                    payload.meta.parameters = mergedParameters;
-                }
 
                 if (!prNum) {
                     payload.workflowGraph = parentEvent.workflowGraph;
@@ -269,8 +262,30 @@ module.exports = () => ({
                         payload.configPipelineSha = parentEvent.configPipelineSha;
                     }
                 }
-            }
 
+                // eslint-disable-next-line default-case
+                switch (startAction) {
+                    case 'RESTART_FROM_EVENT':
+                    case 'RESTART_FROM_BUILD': {
+                        let mergedParameters = payload.meta.parameters || {};
+
+                        // Merge parameters if they exist in the parent event and not in the payload
+                        if (!payload.meta.parameters && parentEvent.meta && parentEvent.meta.parameters) {
+                            mergedParameters = parentEvent.meta.parameters;
+                        }
+                        delete payload.meta.parameters;
+
+                        // Copy meta from parent event if payload.meta is empty except for the parameters
+                        if (Object.keys(payload.meta).length === 0) {
+                            payload.meta = { ...parentEvent.meta };
+                        }
+
+                        if (Object.keys(mergedParameters).length > 0) {
+                            payload.meta.parameters = mergedParameters;
+                        }
+                    }
+                }
+            }
             const event = await createEvent(payload, request.server);
 
             if (event.builds === null) {

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -397,7 +397,8 @@ describe('event plugin test', () => {
                     parentBuildId,
                     pipelineId,
                     startFrom: '~commit',
-                    meta
+                    meta,
+                    startAction: 'START_FROM_LATEST_COMMIT'
                 },
                 auth: {
                     credentials: {
@@ -449,48 +450,6 @@ describe('event plugin test', () => {
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.parentEventId = 888;
-            eventConfig.groupEventId = 888;
-            eventConfig.baseBranch = 'master';
-            eventConfig.parentBuilds = parentBuilds;
-            eventFactoryMock.get.resolves(getEventMock(testEvent));
-
-            return server.inject(options).then(reply => {
-                expectedLocation = {
-                    host: reply.request.headers.host,
-                    port: reply.request.headers.port,
-                    protocol: reply.request.server.info.protocol,
-                    pathname: `${options.url}/12345`
-                };
-                assert.calledWith(buildFactoryMock.get, 1234);
-                assert.calledWith(jobFactoryMock.get, 222);
-                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
-                assert.calledWith(eventFactoryMock.create, eventConfig);
-                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
-                assert.notCalled(eventFactoryMock.scm.getPrInfo);
-                assert.equal(reply.statusCode, 201);
-            });
-        });
-
-        it('returns 201 when it successfully creates a new event with buildId passed in', () => {
-            options.payload = {
-                buildId: 1234,
-                meta,
-                startAction: 'START_FROM_BUILD'
-            };
-            buildFactoryMock.get.resolves({
-                id: 1234,
-                jobId: 222,
-                parentBuildId,
-                eventId: 888,
-                parentBuilds
-            });
-            jobFactoryMock.get.resolves({
-                pipelineId,
-                name: 'main'
-            });
-            eventConfig.startFrom = 'main';
-            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
-            eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.groupEventId = 888;
             eventConfig.baseBranch = 'master';
             eventConfig.parentBuilds = parentBuilds;
@@ -595,7 +554,8 @@ describe('event plugin test', () => {
                 creator: {
                     name: 'Screwdriver scheduler',
                     username: 'sd:scheduler'
-                }
+                },
+                startAction: 'START_FROM_LATEST_COMMIT'
             };
 
             return server.inject(options).then(reply => {
@@ -627,7 +587,8 @@ describe('event plugin test', () => {
                 creator: {
                     name: 'foo bar',
                     username: 'foobar'
-                }
+                },
+                startAction: 'START_FROM_LATEST_COMMIT'
             };
 
             return server.inject(options).then(reply => {

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -9,6 +9,7 @@ const hoek = require('@hapi/hoek');
 const testBuild = require('./data/build.json');
 const testBuilds = require('./data/builds.json');
 const testStageBuilds = require('./data/stageBuilds.json');
+const { options: request } = require('../../plugins/commands/create');
 const testEventBase = require('./data/events.json')[0];
 const testEventPr = require('./data/eventsPr.json')[0];
 
@@ -428,10 +429,11 @@ describe('event plugin test', () => {
             pipelineFactoryMock.get.resolves(pipelineMock);
         });
 
-        it('returns 201 when it successfully creates an event with buildId passed in', () => {
+        it('returns 201 when it successfully creates restart event with buildId passed in', () => {
             options.payload = {
                 buildId: 1234,
-                meta
+                meta,
+                startAction: 'restart'
             };
             buildFactoryMock.get.resolves({
                 id: 1234,
@@ -462,6 +464,117 @@ describe('event plugin test', () => {
                 };
                 assert.calledWith(buildFactoryMock.get, 1234);
                 assert.calledWith(jobFactoryMock.get, 222);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new event with buildId passed in', () => {
+            options.payload = {
+                buildId: 1234,
+                meta,
+                startAction: 'start'
+            };
+            buildFactoryMock.get.resolves({
+                id: 1234,
+                jobId: 222,
+                parentBuildId,
+                eventId: 888,
+                parentBuilds
+            });
+            jobFactoryMock.get.resolves({
+                pipelineId,
+                name: 'main'
+            });
+            eventConfig.startFrom = 'main';
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.groupEventId = 888;
+            eventConfig.baseBranch = 'master';
+            eventConfig.parentBuilds = parentBuilds;
+            eventFactoryMock.get.resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.calledWith(buildFactoryMock.get, 1234);
+                assert.calledWith(jobFactoryMock.get, 222);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('returns 201 when it successfully creates restart event with branch specific triggered parent event', () => {
+            options.payload.startFrom = 'main';
+            options.payload.startAction = 'restart';
+            options.payload.parentEventId = 888;
+            options.payload.groupEventId = 888;
+            delete options.payload.parentBuildId;
+            jobFactoryMock.get.resolves({
+                pipelineId,
+                name: 'main'
+            });
+            eventConfig.startFrom = 'main';
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.parentEventId = 888;
+            eventConfig.groupEventId = 888;
+            eventConfig.baseBranch = 'test';
+            delete eventConfig.parentBuildId;
+            testEvent.baseBranch = 'test';
+            eventFactoryMock.get.resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new event with branch specific triggered parent event', () => {
+            options.payload.startFrom = 'main';
+            options.payload.startAction = 'start';
+            options.payload.parentEventId = 888;
+            options.payload.groupEventId = 888;
+            delete options.payload.parentBuildId;
+            jobFactoryMock.get.resolves({
+                pipelineId,
+                name: 'main'
+            });
+            eventConfig.startFrom = 'main';
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.groupEventId = 888;
+            eventConfig.baseBranch = 'test';
+            delete eventConfig.parentBuildId;
+            testEvent.baseBranch = 'test';
+            eventFactoryMock.get.resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
                 assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
@@ -843,12 +956,35 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates an event with parent event', () => {
+        it('returns 201 when it successfully creates an restart event with parent event', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.baseBranch = 'master';
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'restart';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new event with parent event', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'start';
 
             return server.inject(options).then(reply => {
                 expectedLocation = {
@@ -869,7 +1005,8 @@ describe('event plugin test', () => {
             options.payload = {
                 buildId: 1234,
                 meta,
-                parentBuilds
+                parentBuilds,
+                startAction: 'restart',
             };
             buildFactoryMock.get.resolves({
                 id: 1234,
@@ -912,7 +1049,8 @@ describe('event plugin test', () => {
                 buildId: 1234,
                 meta,
                 parentBuilds,
-                groupEventId: 2
+                groupEventId: 2,
+                startAction: 'restart',
             };
             buildFactoryMock.get.resolves({
                 id: 1234,
@@ -958,7 +1096,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates an event with parent event and the startFrom is a stage teardown', () => {
+        it('returns 201 when it successfully creates restarted event with parent event and the startFrom is a stage teardown', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -966,6 +1104,7 @@ describe('event plugin test', () => {
             eventConfig.startFrom = 'stage@integration:teardown';
             options.payload.parentEventId = parentEventId;
             options.payload.startFrom = 'stage@integration:teardown';
+            options.payload.startAction = 'restart';
 
             return server.inject(options).then(reply => {
                 expectedLocation = {
@@ -981,12 +1120,36 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates an event with parent event and the startFrom is not a stage teardown', () => {
+        it('returns 201 when it successfully creates a new event with parent event and the startFrom is a stage teardown', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            eventConfig.startFrom = 'stage@integration:teardown';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startFrom = 'stage@integration:teardown';
+            options.payload.startAction = 'start';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it successfully creates restarted event with parent event and the startFrom is not a stage teardown', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.baseBranch = 'master';
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'restart';
 
             return server.inject(options).then(reply => {
                 expectedLocation = {
@@ -1002,7 +1165,28 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with parent event for child pipeline', () => {
+        it('returns 201 when it successfully creates a new event with parent event and the startFrom is not a stage teardown', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'start';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it creates restarted event with parent event for child pipeline', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1011,15 +1195,20 @@ describe('event plugin test', () => {
             testEvent.meta = {
                 parameters: {
                     user: { value: 'adong' }
-                }
+                },
+                foo: 'bar',
+                one: 1
             };
             eventConfig.configPipelineSha = 'configPipelineSha';
             eventConfig.meta = {
                 parameters: {
                     user: { value: 'adong' }
-                }
+                },
+                foo: 'bar',
+                one: 1
             };
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'restart';
             delete options.payload.meta;
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 
@@ -1039,7 +1228,44 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with custom parameters and parent event', () => {
+        it('returns 201 when it creates a new event with parent event for child pipeline', () => {
+            // This test case ensures that when "Start" is called with a parent event specified,
+            // the parent event's metadata is not inherited.
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                },
+                foo: 'bar',
+                one: 1
+            };
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta = {};
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'start';
+            delete options.payload.meta;
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates restarted event with custom parameters and parent event', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1058,6 +1284,7 @@ describe('event plugin test', () => {
             options.payload.meta.parameters = {
                 user: { value: 'klu' }
             };
+            options.payload.startAction = 'restart';
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 
             return server.inject(options).then(reply => {
@@ -1076,7 +1303,44 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with parent event which has meta', () => {
+        it('returns 201 when it creates a new event with custom parameters and parent event', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                }
+            };
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta.parameters = {
+                user: { value: 'klu' }
+            };
+            options.payload.parentEventId = parentEventId;
+            options.payload.meta.parameters = {
+                user: { value: 'klu' }
+            };
+            options.payload.startAction = 'start';
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates restarted event with parent event which has meta', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1085,6 +1349,35 @@ describe('event plugin test', () => {
             testEvent.meta = meta;
             eventConfig.configPipelineSha = 'configPipelineSha';
             eventConfig.meta = meta;
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'restart';
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates a new event with parent event which has meta', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = meta;
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta = meta;
+            options.payload.startAction = 'start';
             options.payload.parentEventId = parentEventId;
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 
@@ -1104,7 +1397,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with custom parameters and parent event which has meta', () => {
+        it('returns 201 when it creates restarted event with custom parameters and parent event which has meta', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1126,6 +1419,52 @@ describe('event plugin test', () => {
                 one: 1
             };
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'restart';
+            options.payload.meta = {
+                parameters: {
+                    user: { value: 'klu' }
+                }
+            };
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates new event with custom parameters and parent event which has meta', () => {
+            // This test case ensures that when "Start" is called with a parent event specified,
+            // the parent event's metadata is not inherited.
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                },
+                foo: 'bar',
+                one: 1
+            };
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta = {
+                parameters: {
+                    user: { value: 'klu' }
+                }
+            };
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'start';
             options.payload.meta = {
                 parameters: {
                     user: { value: 'klu' }
@@ -1360,7 +1699,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates a PR event with parent event', () => {
+        it('returns 201 when it successfully creates restarted PR event with parent event', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.sha = commitSha;
             eventConfig.startFrom = 'PR-1:main';
@@ -1368,6 +1707,42 @@ describe('event plugin test', () => {
             eventConfig.type = 'pr';
             eventConfig.chainPR = false;
             options.payload.startFrom = 'PR-1:main';
+            options.payload.startAction = 'restart';
+            options.payload.parentEventId = parentEventId;
+            eventConfig.prInfo = prInfo;
+            ({ ref: eventConfig.prRef, prSource: eventConfig.prSource } = prInfo);
+            eventConfig.changedFiles = ['screwdriver.yaml'];
+            eventConfig.baseBranch = 'master';
+            eventConfig.meta.parameters = {
+                user: { value: 'adong' }
+            };
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledOnce(eventFactoryMock.scm.getCommitSha);
+                assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, { ...scmConfig, prNum: eventConfig.prNum });
+                assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new PR event with parent event', () => {
+            eventConfig.sha = commitSha;
+            eventConfig.startFrom = 'PR-1:main';
+            eventConfig.prNum = '1';
+            eventConfig.type = 'pr';
+            eventConfig.chainPR = false;
+            options.payload.startFrom = 'PR-1:main';
+            options.payload.startAction = 'start';
             options.payload.parentEventId = parentEventId;
             eventConfig.prInfo = prInfo;
             ({ ref: eventConfig.prRef, prSource: eventConfig.prSource } = prInfo);
@@ -1543,7 +1918,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with parent event for child pipeline', () => {
+        it('returns 404 when event have no builds', () => {
             testEvent.builds = null;
             eventFactoryMock.create.resolves(getEventMock(testEvent));
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -9,6 +9,7 @@ const hoek = require('@hapi/hoek');
 const testBuild = require('./data/build.json');
 const testBuilds = require('./data/builds.json');
 const testStageBuilds = require('./data/stageBuilds.json');
+const { options: request } = require('../../plugins/commands/create');
 const testEventBase = require('./data/events.json')[0];
 const testEventPr = require('./data/eventsPr.json')[0];
 
@@ -428,10 +429,11 @@ describe('event plugin test', () => {
             pipelineFactoryMock.get.resolves(pipelineMock);
         });
 
-        it('returns 201 when it successfully creates an event with buildId passed in', () => {
+        it('returns 201 when it successfully creates restart event with buildId passed in', () => {
             options.payload = {
                 buildId: 1234,
-                meta
+                meta,
+                startAction: 'RESTART_FROM_BUILD'
             };
             buildFactoryMock.get.resolves({
                 id: 1234,
@@ -462,6 +464,117 @@ describe('event plugin test', () => {
                 };
                 assert.calledWith(buildFactoryMock.get, 1234);
                 assert.calledWith(jobFactoryMock.get, 222);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new event with buildId passed in', () => {
+            options.payload = {
+                buildId: 1234,
+                meta,
+                startAction: 'START_FROM_BUILD'
+            };
+            buildFactoryMock.get.resolves({
+                id: 1234,
+                jobId: 222,
+                parentBuildId,
+                eventId: 888,
+                parentBuilds
+            });
+            jobFactoryMock.get.resolves({
+                pipelineId,
+                name: 'main'
+            });
+            eventConfig.startFrom = 'main';
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.groupEventId = 888;
+            eventConfig.baseBranch = 'master';
+            eventConfig.parentBuilds = parentBuilds;
+            eventFactoryMock.get.resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.calledWith(buildFactoryMock.get, 1234);
+                assert.calledWith(jobFactoryMock.get, 222);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('returns 201 when it successfully creates restart event with branch specific triggered parent event', () => {
+            options.payload.startFrom = 'main';
+            options.payload.startAction = 'RESTART_FROM_EVENT';
+            options.payload.parentEventId = 888;
+            options.payload.groupEventId = 888;
+            delete options.payload.parentBuildId;
+            jobFactoryMock.get.resolves({
+                pipelineId,
+                name: 'main'
+            });
+            eventConfig.startFrom = 'main';
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.parentEventId = 888;
+            eventConfig.groupEventId = 888;
+            eventConfig.baseBranch = 'test';
+            delete eventConfig.parentBuildId;
+            testEvent.baseBranch = 'test';
+            eventFactoryMock.get.resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                assert.equal(reply.statusCode, 201);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new event with branch specific triggered parent event', () => {
+            options.payload.startFrom = 'main';
+            options.payload.startAction = 'START_FROM_EVENT';
+            options.payload.parentEventId = 888;
+            options.payload.groupEventId = 888;
+            delete options.payload.parentBuildId;
+            jobFactoryMock.get.resolves({
+                pipelineId,
+                name: 'main'
+            });
+            eventConfig.startFrom = 'main';
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.groupEventId = 888;
+            eventConfig.baseBranch = 'test';
+            delete eventConfig.parentBuildId;
+            testEvent.baseBranch = 'test';
+            eventFactoryMock.get.resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
                 assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
                 assert.calledWith(eventFactoryMock.create, eventConfig);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
@@ -843,12 +956,35 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates an event with parent event', () => {
+        it('returns 201 when it successfully creates an restart event with parent event', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.baseBranch = 'master';
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'RESTART_FROM_EVENT';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new event with parent event', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'START_FROM_EVENT';
 
             return server.inject(options).then(reply => {
                 expectedLocation = {
@@ -869,7 +1005,8 @@ describe('event plugin test', () => {
             options.payload = {
                 buildId: 1234,
                 meta,
-                parentBuilds
+                parentBuilds,
+                startAction: 'RESTART_FROM_BUILD'
             };
             buildFactoryMock.get.resolves({
                 id: 1234,
@@ -912,7 +1049,8 @@ describe('event plugin test', () => {
                 buildId: 1234,
                 meta,
                 parentBuilds,
-                groupEventId: 2
+                groupEventId: 2,
+                startAction: 'RESTART_FROM_BUILD',
             };
             buildFactoryMock.get.resolves({
                 id: 1234,
@@ -958,7 +1096,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates an event with parent event and the startFrom is a stage teardown', () => {
+        it('returns 201 when it successfully creates restarted event with parent event and the startFrom is a stage teardown', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -966,6 +1104,7 @@ describe('event plugin test', () => {
             eventConfig.startFrom = 'stage@integration:teardown';
             options.payload.parentEventId = parentEventId;
             options.payload.startFrom = 'stage@integration:teardown';
+            options.payload.startAction = 'RESTART_FROM_EVENT';
 
             return server.inject(options).then(reply => {
                 expectedLocation = {
@@ -981,12 +1120,36 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates an event with parent event and the startFrom is not a stage teardown', () => {
+        it('returns 201 when it successfully creates a new event with parent event and the startFrom is a stage teardown', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            eventConfig.startFrom = 'stage@integration:teardown';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startFrom = 'stage@integration:teardown';
+            options.payload.startAction = 'START_FROM_EVENT';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it successfully creates restarted event with parent event and the startFrom is not a stage teardown', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
             eventConfig.baseBranch = 'master';
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'RESTART_FROM_EVENT';
 
             return server.inject(options).then(reply => {
                 expectedLocation = {
@@ -1002,7 +1165,28 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with parent event for child pipeline', () => {
+        it('returns 201 when it successfully creates a new event with parent event and the startFrom is not a stage teardown', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'START_FROM_EVENT';
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+            });
+        });
+
+        it('returns 201 when it creates restarted event with parent event for child pipeline', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1011,15 +1195,20 @@ describe('event plugin test', () => {
             testEvent.meta = {
                 parameters: {
                     user: { value: 'adong' }
-                }
+                },
+                foo: 'bar',
+                one: 1
             };
             eventConfig.configPipelineSha = 'configPipelineSha';
             eventConfig.meta = {
                 parameters: {
                     user: { value: 'adong' }
-                }
+                },
+                foo: 'bar',
+                one: 1
             };
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'RESTART_FROM_EVENT';
             delete options.payload.meta;
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 
@@ -1039,7 +1228,44 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with custom parameters and parent event', () => {
+        it('returns 201 when it creates a new event with parent event for child pipeline', () => {
+            // This test case ensures that when "Start" is called with a parent event specified,
+            // the parent event's metadata is not inherited.
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                },
+                foo: 'bar',
+                one: 1
+            };
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta = {};
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'START_FROM_EVENT';
+            delete options.payload.meta;
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates restarted event with custom parameters and parent event', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1058,6 +1284,7 @@ describe('event plugin test', () => {
             options.payload.meta.parameters = {
                 user: { value: 'klu' }
             };
+            options.payload.startAction = 'RESTART_FROM_EVENT';
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 
             return server.inject(options).then(reply => {
@@ -1076,7 +1303,44 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with parent event which has meta', () => {
+        it('returns 201 when it creates a new event with custom parameters and parent event', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                }
+            };
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta.parameters = {
+                user: { value: 'klu' }
+            };
+            options.payload.parentEventId = parentEventId;
+            options.payload.meta.parameters = {
+                user: { value: 'klu' }
+            };
+            options.payload.startAction = 'START_FROM_EVENT';
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates restarted event with parent event which has meta', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1085,6 +1349,35 @@ describe('event plugin test', () => {
             testEvent.meta = meta;
             eventConfig.configPipelineSha = 'configPipelineSha';
             eventConfig.meta = meta;
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'RESTART_FROM_EVENT';
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates a new event with parent event which has meta', () => {
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = meta;
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta = meta;
+            options.payload.startAction = 'START_FROM_EVENT';
             options.payload.parentEventId = parentEventId;
             eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
 
@@ -1104,7 +1397,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with custom parameters and parent event which has meta', () => {
+        it('returns 201 when it creates restarted event with custom parameters and parent event which has meta', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
             eventConfig.sha = getEventMock(testEvent).sha;
@@ -1126,6 +1419,52 @@ describe('event plugin test', () => {
                 one: 1
             };
             options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'RESTART_FROM_EVENT';
+            options.payload.meta = {
+                parameters: {
+                    user: { value: 'klu' }
+                }
+            };
+            eventFactoryMock.get.withArgs(parentEventId).resolves(getEventMock(testEvent));
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.notCalled(eventFactoryMock.scm.getPrInfo);
+                delete testEvent.configPipelineSha;
+            });
+        });
+
+        it('returns 201 when it creates new event with custom parameters and parent event which has meta', () => {
+            // This test case ensures that when "Start" is called with a parent event specified,
+            // the parent event's metadata is not inherited.
+            eventConfig.workflowGraph = getEventMock(testEvent).workflowGraph;
+            eventConfig.sha = getEventMock(testEvent).sha;
+            eventConfig.baseBranch = 'master';
+            testEvent.configPipelineSha = 'configPipelineSha';
+            testEvent.meta = {
+                parameters: {
+                    user: { value: 'adong' }
+                },
+                foo: 'bar',
+                one: 1
+            };
+            eventConfig.configPipelineSha = 'configPipelineSha';
+            eventConfig.meta = {
+                parameters: {
+                    user: { value: 'klu' }
+                }
+            };
+            options.payload.parentEventId = parentEventId;
+            options.payload.startAction = 'START_FROM_EVENT';
             options.payload.meta = {
                 parameters: {
                     user: { value: 'klu' }
@@ -1360,7 +1699,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it successfully creates a PR event with parent event', () => {
+        it('returns 201 when it successfully creates restarted PR event with parent event', () => {
             eventConfig.parentEventId = parentEventId;
             eventConfig.sha = commitSha;
             eventConfig.startFrom = 'PR-1:main';
@@ -1368,6 +1707,42 @@ describe('event plugin test', () => {
             eventConfig.type = 'pr';
             eventConfig.chainPR = false;
             options.payload.startFrom = 'PR-1:main';
+            options.payload.startAction = 'RESTART_FROM_EVENT';
+            options.payload.parentEventId = parentEventId;
+            eventConfig.prInfo = prInfo;
+            ({ ref: eventConfig.prRef, prSource: eventConfig.prSource } = prInfo);
+            eventConfig.changedFiles = ['screwdriver.yaml'];
+            eventConfig.baseBranch = 'master';
+            eventConfig.meta.parameters = {
+                user: { value: 'adong' }
+            };
+
+            return server.inject(options).then(reply => {
+                expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/12345`
+                };
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(userMock.getPermissions, scmUri, scmContext, scmRepo);
+                assert.calledWith(eventFactoryMock.create, eventConfig);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledOnce(eventFactoryMock.scm.getCommitSha);
+                assert.calledOnce(eventFactoryMock.scm.getPrInfo);
+                assert.calledWith(eventFactoryMock.scm.getPrInfo, { ...scmConfig, prNum: eventConfig.prNum });
+                assert.calledOnce(eventFactoryMock.scm.getChangedFiles);
+            });
+        });
+
+        it('returns 201 when it successfully creates a new PR event with parent event', () => {
+            eventConfig.sha = commitSha;
+            eventConfig.startFrom = 'PR-1:main';
+            eventConfig.prNum = '1';
+            eventConfig.type = 'pr';
+            eventConfig.chainPR = false;
+            options.payload.startFrom = 'PR-1:main';
+            options.payload.startAction = 'START_FROM_EVENT';
             options.payload.parentEventId = parentEventId;
             eventConfig.prInfo = prInfo;
             ({ ref: eventConfig.prRef, prSource: eventConfig.prSource } = prInfo);
@@ -1543,7 +1918,7 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 201 when it creates an event with parent event for child pipeline', () => {
+        it('returns 404 when event have no builds', () => {
             testEvent.builds = null;
             eventFactoryMock.create.resolves(getEventMock(testEvent));
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -9,7 +9,6 @@ const hoek = require('@hapi/hoek');
 const testBuild = require('./data/build.json');
 const testBuilds = require('./data/builds.json');
 const testStageBuilds = require('./data/stageBuilds.json');
-const { options: request } = require('../../plugins/commands/create');
 const testEventBase = require('./data/events.json')[0];
 const testEventPr = require('./data/eventsPr.json')[0];
 

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1049,7 +1049,7 @@ describe('event plugin test', () => {
                 meta,
                 parentBuilds,
                 groupEventId: 2,
-                startAction: 'RESTART_FROM_BUILD',
+                startAction: 'RESTART_FROM_BUILD'
             };
             buildFactoryMock.get.resolves({
                 id: 1234,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

If you start a new event based on an event triggered by a branch-specific trigger, the branch is not properly inherited.
As a result, the jobs and steps that are executed will be branch-specific rather than belonging to the pipeline's branch.
This is because parentEvent is not passed at the start.


The test will always fail because the payload validation fails until below PR is merged.
https://github.com/screwdriver-cd/data-schema/pull/614

We need to merge the UI before.
https://github.com/screwdriver-cd/ui/pull/1573

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Support https://github.com/screwdriver-cd/ui/pull/1573

If  `parentEventId` is present, the `baseBranch` should be inherited from the `parentEvent`.
Additionally, we will implement a mechanism to distinguish between `start` and `restart`.
This is to prevent metadata from being inherited when `Start a new event from here`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3491

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
