### PR TITLE
fix: Exclusive control over meta updates

### DIFF
--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -6,6 +6,7 @@ const merge = require('lodash.mergewith');
 const isEmpty = require('lodash.isempty');
 const { PR_JOB_NAME, PR_STAGE_NAME, STAGE_TEARDOWN_PATTERN } = require('screwdriver-data-schema').config.regex;
 const { getFullStageJobName } = require('../../helper');
+const { locker } = require('../../lock');
 const { updateVirtualBuildSuccess, emitBuildStatusEvent, isFixedBuild } = require('../triggers/helpers');
 const TERMINAL_STATUSES = ['FAILURE', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
 const FINISHED_STATUSES = ['SUCCESS', ...TERMINAL_STATUSES];
@@ -358,6 +359,7 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     const { triggerNextJobs, removeJoinBuilds, createOrUpdateStageTeardownBuild } = server.plugins.builds;
 
     const currentStatus = build.status;
+    const isEndBuildStatus = ['SUCCESS', 'FAILURE', 'ABORTED'].includes(desiredStatus);
 
     const event = await eventFactory.get(build.eventId);
 
@@ -370,9 +372,8 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     if (!desiredStatus) {
         build.statusMessage = statusMessage || build.statusMessage;
         build.statusMessageType = statusMessageType || build.statusMessageType;
-    } else if (['SUCCESS', 'FAILURE', 'ABORTED'].includes(desiredStatus)) {
+    } else if (isEndBuildStatus) {
         build.meta = isEmpty(meta) ? build.meta || {} : meta;
-        event.meta = merge({}, event.meta, build.meta);
         build.endTime = new Date().toISOString();
     } else if (desiredStatus === 'RUNNING') {
         build.startTime = new Date().toISOString();
@@ -416,7 +417,30 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     const pipeline = await job.pipeline;
     const isFixed = await isFixedBuild({ build, job });
 
+    let eventLock;
+    const eventResource = `event:${event.id}`;
+
+    if (isEndBuildStatus) {
+        try {
+            eventLock = await locker.lock(eventResource);
+        } catch (err) {
+            eventLock = null;
+        }
+
+        const latestEvent = await eventFactory.get(build.eventId);
+
+        event.meta = merge({}, latestEvent ? latestEvent.meta : event.meta, build.meta);
+    }
+
     const [newBuild, newEvent] = await Promise.all([build.update(), event.update(), stopFrozen]);
+
+    if (isEndBuildStatus) {
+        try {
+            await locker.unlock(eventLock, eventResource);
+        } catch (err) {
+            // ignore unlock errors for parity with lock helper behavior
+        }
+    }
 
     if (desiredStatus) {
         await emitBuildStatusEvent({ server, build: newBuild, pipeline, event: newEvent, job, isFixed });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -1316,6 +1316,53 @@ describe('build plugin test', () => {
                 });
             });
 
+            it('merges build meta with the latest event meta for terminal status updates', () => {
+                const options = {
+                    method: 'PUT',
+                    url: `/builds/${id}`,
+                    auth: {
+                        credentials: {
+                            username: id,
+                            scope: ['build']
+                        },
+                        strategy: ['token']
+                    },
+                    payload: {
+                        meta: {
+                            keyFromBuild: 'buildValue',
+                            sharedKey: 'newValue'
+                        },
+                        status: 'SUCCESS'
+                    }
+                };
+                const staleEvent = {
+                    ...eventMock,
+                    meta: {
+                        staleOnlyKey: 'staleValue',
+                        sharedKey: 'staleValue'
+                    }
+                };
+                const latestEvent = {
+                    ...eventMock,
+                    meta: {
+                        latestOnlyKey: 'latestValue',
+                        sharedKey: 'oldValue'
+                    }
+                };
+
+                eventFactoryMock.get.onFirstCall().resolves(staleEvent);
+                eventFactoryMock.get.onSecondCall().resolves(latestEvent);
+
+                return server.inject(options).then(reply => {
+                    assert.equal(reply.statusCode, 200);
+                    assert.deepEqual(staleEvent.meta, {
+                        latestOnlyKey: 'latestValue',
+                        keyFromBuild: 'buildValue',
+                        sharedKey: 'newValue'
+                    });
+                });
+            });
+
             it('defaults meta to {}', () => {
                 const status = 'SUCCESS';
                 const options = {
@@ -4776,7 +4823,7 @@ describe('build plugin test', () => {
                     return newServer.inject(options).then(() => {
                         assert.notCalled(eventFactoryMock.create);
                         assert.calledOnce(buildFactoryMock.create);
-                        assert.calledTwice(eventFactoryMock.get);
+                        assert.calledThrice(eventFactoryMock.get);
                     });
                 });
 

--- a/test/plugins/pipelines.templates.test.js
+++ b/test/plugins/pipelines.templates.test.js
@@ -5,6 +5,7 @@ const badgeMaker = require('badge-maker');
 const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
 const hoek = require('@hapi/hoek');
+const rewiremock = require('rewiremock/node');
 const testPipeline = require('./data/pipeline.json');
 const testTemplate = require('./data/pipeline-template.json');
 const testTemplateUntrusted = require('./data/pipeline-template-untrusted.json');
@@ -89,6 +90,7 @@ describe('pipeline plugin test', () => {
     let pipelineTemplateTagFactoryMock;
     let plugin;
     let server;
+    let lockMock;
     const password = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
 
     before(() => {
@@ -178,9 +180,16 @@ describe('pipeline plugin test', () => {
             create: sinon.stub(),
             remove: sinon.stub()
         };
+        lockMock = {
+            lock: sinon.stub().resolves(null),
+            unlock: sinon.stub().resolves(null)
+        };
+        lockMock.locker = lockMock;
 
         /* eslint-disable global-require */
-        plugin = require('../../plugins/pipelines');
+        plugin = rewiremock.proxy('../../plugins/pipelines', {
+            '../../plugins/lock': lockMock
+        });
         /* eslint-enable global-require */
         server = new hapi.Server({
             port: 1234

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -6,6 +6,7 @@ const badgeMaker = require('badge-maker');
 const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
 const hoek = require('@hapi/hoek');
+const rewiremock = require('rewiremock/node');
 const testPipeline = require('./data/pipeline.json');
 const testPipelines = require('./data/pipelines.json');
 const testPrivatePipelines = require('./data/privatePipelines.json');
@@ -226,6 +227,7 @@ describe('pipeline plugin test', () => {
     let pipelineTemplateFactoryMock;
     let pipelineTemplateVersionFactoryMock;
     let buildClusterFactoryMock;
+    let lockMock;
     let plugin;
     let server;
     const password = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
@@ -314,9 +316,16 @@ describe('pipeline plugin test', () => {
         };
         generateProfileMock = sinon.stub();
         generateTokenMock = sinon.stub();
+        lockMock = {
+            lock: sinon.stub().resolves(null),
+            unlock: sinon.stub().resolves(null)
+        };
+        lockMock.locker = lockMock;
 
         /* eslint-disable global-require */
-        plugin = require('../../plugins/pipelines');
+        plugin = rewiremock.proxy('../../plugins/pipelines', {
+            '../../plugins/lock': lockMock
+        });
         /* eslint-enable global-require */
         server = new hapi.Server({
             port: 1234

--- a/test/plugins/processHooks.test.js
+++ b/test/plugins/processHooks.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
-const rewire = require('rewire');
+const rewiremock = require('rewiremock/node');
 const { assert } = chai;
 
 chai.use(require('chai-as-promised'));
@@ -34,9 +34,11 @@ describe('processHooks plugin test', () => {
 
         startHookEventMock = sinon.stub();
 
-        plugin = rewire('../../plugins/processHooks');
-
-        plugin.__set__('startHookEvent', startHookEventMock);
+        plugin = rewiremock.proxy('../../plugins/processHooks', {
+            '../../plugins/webhooks/helper': {
+                startHookEvent: startHookEventMock
+            }
+        });
 
         server = new hapi.Server({
             host: 'localhost',

--- a/test/plugins/secrets.test.js
+++ b/test/plugins/secrets.test.js
@@ -5,6 +5,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
 const hoek = require('@hapi/hoek');
+const rewiremock = require('rewiremock/node');
 const testPipeline = require('./data/pipeline.json');
 const testSecret = require('./data/secret.json');
 
@@ -45,7 +46,9 @@ describe('secret plugin test', () => {
     let userFactoryMock;
     let pipelineFactoryMock;
     let plugin;
+    let pipelinesPlugin;
     let server;
+    let lockMock;
     const password = 'this_is_a_password_that_needs_to_be_atleast_32_characters';
 
     beforeEach(async () => {
@@ -63,9 +66,17 @@ describe('secret plugin test', () => {
         userFactoryMock = {
             get: sinon.stub()
         };
+        lockMock = {
+            lock: sinon.stub().resolves(null),
+            unlock: sinon.stub().resolves(null)
+        };
+        lockMock.locker = lockMock;
 
         /* eslint-disable global-require */
         plugin = require('../../plugins/secrets');
+        pipelinesPlugin = rewiremock.proxy('../../plugins/pipelines', {
+            '../../plugins/lock': lockMock
+        });
         /* eslint-enable global-require */
         server = new hapi.Server({
             port: 1234
@@ -94,9 +105,7 @@ describe('secret plugin test', () => {
                 }
             },
             {
-                /* eslint-disable global-require */
-                plugin: require('../../plugins/pipelines')
-                /* eslint-enable global-require */
+                plugin: pipelinesPlugin
             }
         ]);
     });

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
-const rewire = require('rewire');
+const rewiremock = require('rewiremock/node');
 const { assert } = chai;
 const { ValidationError } = require('joi');
 
@@ -43,9 +43,11 @@ describe('webhooks plugin test', () => {
 
         startHookEventMock = sinon.stub();
 
-        plugin = rewire('../../plugins/webhooks');
-
-        plugin.__set__('startHookEvent', startHookEventMock);
+        plugin = rewiremock.proxy('../../plugins/webhooks', {
+            '../../plugins/webhooks/helper': {
+                startHookEvent: startHookEventMock
+            }
+        });
 
         server = new hapi.Server({
             host: 'localhost',


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When builds finish at nearly the same time within the same event, a conflict may occur between the event's meta and the meta of each build, resulting in the entire event meta being overwritten by the meta of one of the builds.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
We have updated the code to lock the event resource when updating the meta upon build completion, ensuring that the latest event meta at that time is updated. This ensures that the meta from each completed build is properly merged and reflected as the event's meta.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
