### PR TITLE
feat: Wrap webhook SCM handling in request cache context [3]

### DIFF
--- a/plugins/webhooks/helper.js
+++ b/plugins/webhooks/helper.js
@@ -1413,77 +1413,80 @@ async function startHookEvent(request, h, webhookConfig) {
     const { type, hookId, username, scmContext, ref, checkoutUrl, action, prNum } = webhookConfig;
 
     parsedHookId = hookId;
+    webhookConfig.requestCache = new Map();
 
     try {
-        // skipping checks
-        if (/\[(skip ci|ci skip)\]/.test(webhookConfig.lastCommitMessage)) {
-            skipMessage = 'Skipping due to the commit message: [skip ci]';
-        }
-
-        // if skip ci then don't return
-        if (action !== 'tag' && action !== 'release' && ignoreUser && ignoreUser.length !== 0 && !skipMessage) {
-            const commitAuthors =
-                Array.isArray(webhookConfig.commitAuthors) && webhookConfig.commitAuthors.length !== 0
-                    ? webhookConfig.commitAuthors
-                    : [username];
-            const validCommitAuthors = commitAuthors.filter(author => !ignoreUser.includes(author));
-
-            if (!validCommitAuthors.length) {
-                message = `Skipping because user ${username} is ignored`;
-                request.log(['webhook', hookId], message);
-
-                return h.response({ message }).code(204);
+        return scm.withRequestCache(webhookConfig.requestCache, async () => {
+            // skipping checks
+            if (/\[(skip ci|ci skip)\]/.test(webhookConfig.lastCommitMessage)) {
+                skipMessage = 'Skipping due to the commit message: [skip ci]';
             }
-        }
 
-        const token = await obtainScmToken({
-            pluginOptions: webhookConfig.pluginOptions,
-            userFactory,
-            username,
-            scmContext,
-            scm
-        });
+            // if skip ci then don't return
+            if (action !== 'tag' && action !== 'release' && ignoreUser && ignoreUser.length !== 0 && !skipMessage) {
+                const commitAuthors =
+                    Array.isArray(webhookConfig.commitAuthors) && webhookConfig.commitAuthors.length !== 0
+                        ? webhookConfig.commitAuthors
+                        : [username];
+                const validCommitAuthors = commitAuthors.filter(author => !ignoreUser.includes(author));
 
-        if (action !== 'release' && action !== 'tag') {
-            let scmUri;
+                if (!validCommitAuthors.length) {
+                    message = `Skipping because user ${username} is ignored`;
+                    request.log(['webhook', hookId], message);
+
+                    return h.response({ message }).code(204);
+                }
+            }
+
+            const token = await obtainScmToken({
+                pluginOptions: webhookConfig.pluginOptions,
+                userFactory,
+                username,
+                scmContext,
+                scm
+            });
+
+            if (action !== 'release' && action !== 'tag') {
+                let scmUri;
+
+                if (type === 'pr') {
+                    scmUri = await scm.parseUrl({ checkoutUrl, token, scmContext });
+                }
+                webhookConfig.changedFiles = await scm.getChangedFiles({
+                    webhookConfig,
+                    type,
+                    token,
+                    scmContext,
+                    scmUri,
+                    prNum
+                });
+                request.log(['webhook', hookId], `Changed files are ${webhookConfig.changedFiles}`);
+            } else {
+                // The payload has no sha when webhook event is tag or release, so we need to get it.
+                try {
+                    webhookConfig.sha = await getCommitRefSha({
+                        scm,
+                        token,
+                        ref,
+                        refType: 'tags',
+                        checkoutUrl,
+                        scmContext
+                    });
+                } catch (err) {
+                    request.log(['webhook', hookId, 'getCommitRefSha'], err);
+
+                    // there is a possibility of scm.getCommitRefSha() is not implemented yet
+                    return h.response({ message }).code(204);
+                }
+            }
 
             if (type === 'pr') {
-                scmUri = await scm.parseUrl({ checkoutUrl, token, scmContext });
+                // disregard skip ci for pull request events
+                return pullRequestEvent(webhookConfig.pluginOptions, request, h, webhookConfig, token);
             }
-            webhookConfig.changedFiles = await scm.getChangedFiles({
-                webhookConfig,
-                type,
-                token,
-                scmContext,
-                scmUri,
-                prNum
-            });
-            request.log(['webhook', hookId], `Changed files are ${webhookConfig.changedFiles}`);
-        } else {
-            // The payload has no sha when webhook event is tag or release, so we need to get it.
-            try {
-                webhookConfig.sha = await getCommitRefSha({
-                    scm,
-                    token,
-                    ref,
-                    refType: 'tags',
-                    checkoutUrl,
-                    scmContext
-                });
-            } catch (err) {
-                request.log(['webhook', hookId, 'getCommitRefSha'], err);
 
-                // there is a possibility of scm.getCommitRefSha() is not implemented yet
-                return h.response({ message }).code(204);
-            }
-        }
-
-        if (type === 'pr') {
-            // disregard skip ci for pull request events
-            return pullRequestEvent(webhookConfig.pluginOptions, request, h, webhookConfig, token);
-        }
-
-        return pushEvent(request, h, webhookConfig, skipMessage, token);
+            return pushEvent(request, h, webhookConfig, skipMessage, token);
+        });
     } catch (err) {
         logger.error(`[${parsedHookId}]: ${err}`);
 

--- a/test/plugins/webhooks.helper.test.js
+++ b/test/plugins/webhooks.helper.test.js
@@ -370,7 +370,8 @@ describe('startHookEvent test', () => {
                 getChangedFiles: sinon.stub(),
                 getCommitSha: sinon.stub(),
                 getCommitRefSha: sinon.stub(),
-                getReadOnlyInfo: sinon.stub().returns({ enabled: false })
+                getReadOnlyInfo: sinon.stub().returns({ enabled: false }),
+                withRequestCache: sinon.stub().callsFake((requestCache, method) => method())
             }
         };
         userFactoryMock = {
@@ -548,6 +549,8 @@ describe('startHookEvent test', () => {
 
             return startHookEvent(request, responseHandler, parsed).then(reply => {
                 assert.equal(reply.statusCode, 201);
+                assert.calledOnce(pipelineFactoryMock.scm.withRequestCache);
+                assert.instanceOf(pipelineFactoryMock.scm.withRequestCache.firstCall.args[0], Map);
                 assert.calledOnce(pipelineFactoryMock.scm.getCommitRefSha);
                 assert.calledWith(pipelineFactoryMock.scm.getCommitRefSha, sinon.match({ refType: 'tags' }));
                 assert.calledTwice(pipelineFactoryMock.list);
@@ -2717,6 +2720,8 @@ describe('startHookEvent test', () => {
 
             it('returns 201 on success', () =>
                 startHookEvent(request, responseHandler, parsed).then(reply => {
+                    assert.calledWithExactly(pipelineFactoryMock.scm.getCommitSha, scmConfig);
+                    assert.calledWithExactly(eventFactoryMock.scm.getPrInfo, scmConfig);
                     assert.calledWith(eventFactoryMock.create, {
                         prInfo,
                         pipelineId,


### PR DESCRIPTION
## Context

scm-github and scm-router now support request-local caching for repeated SCM calls.
- https://github.com/screwdriver-cd/scm-github/pull/255
- https://github.com/screwdriver-cd/scm-router/pull/40

screwdriver needs to establish a per-request cache scope during webhook processing so those cached results can actually be reused.

## Objective

Add request-scoped cache handling to webhook SCM processing.

This PR:
- creates a request-local cache for each webhook request
- runs webhook SCM calls inside `scm.withRequestCache(...)`
- preserves existing behavior while enabling cache reuse within a single request

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
