### PR TITLE
fix(3491): fix parentEventId payload for test [4]

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -71,12 +71,9 @@ module.exports = () => ({
             // Therefore, you should not specify a parentEventId in the payload except when using RESTART.
             // Prevents metadata from transferring when Start from a specific event
             if (parentEventId) {
-                // eslint-disable-next-line default-case
-                switch (startAction) {
-                    case 'RESTART_FROM_EVENT':
-                    case 'RESTART_FROM_BUILD': {
-                        payload.parentEventId = parentEventId;
-                    }
+                payload.parentEventId = parentEventId;
+                if (startAction === 'START_FROM_LATEST_COMMIT' || startAction === 'START_FROM_EVENT') {
+                    delete payload.parentEventId;
                 }
             }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

follow up https://github.com/screwdriver-cd/screwdriver/pull/3492

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The functional test case does not include the payload for `startAction`.

Restore the conditions to their previous state and, if `parentEventId` exists, ensure that it is included in the payload sent to `eventFactory`.
However, ensure that parentEventId is not included only when the process is initiated from the UI (Start).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/3492

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
