### PR TITLE
fix(3491): remove groupEventId when start a new event from here

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -77,15 +77,16 @@ module.exports = () => ({
                 }
             }
 
-            if (parentBuildId) {
-                payload.parentBuildId = parentBuildId;
-            }
-
+            // The groupEventId also inherits the build status, so it is excluded.
             if (groupEventId) {
                 payload.groupEventId = groupEventId;
                 if (startAction === 'START_FROM_LATEST_COMMIT' || startAction === 'START_FROM_EVENT') {
                     delete payload.groupEventId;
                 }
+            }
+
+            if (parentBuildId) {
+                payload.parentBuildId = parentBuildId;
             }
 
             if (parentBuilds) {

--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -83,6 +83,9 @@ module.exports = () => ({
 
             if (groupEventId) {
                 payload.groupEventId = groupEventId;
+                if (startAction === 'START_FROM_LATEST_COMMIT' || startAction === 'START_FROM_EVENT') {
+                    delete payload.groupEventId;
+                }
             }
 
             if (parentBuilds) {

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -523,6 +523,7 @@ describe('event plugin test', () => {
             eventConfig.groupEventId = 888;
             eventConfig.baseBranch = 'test';
             delete eventConfig.parentBuildId;
+            delete eventConfig.groupEventId;
             testEvent.baseBranch = 'test';
             eventFactoryMock.get.resolves(getEventMock(testEvent));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
follow up https://github.com/screwdriver-cd/screwdriver/pull/3495

When executing “Start a new event”, the UI passes the `groupEventId`.
However, if the `groupEventId` remains, the status of the originating job is inherited, causing subsequent jobs that do not meet the `requires` condition to be triggered.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

We will fix this so that the build status is not inherited from the originating event.
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
