### PR TITLE
fix: dedupe webhook deliveries within a short TTL

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -278,6 +278,20 @@ scms: {}
 #         # SCM clone type (https or ssh)
 #         cloneType: https
 webhooks:
+  # Replay protection for incoming webhook deliveries. Dedupes identical
+  # x-github-delivery values within a short TTL so a captured webhook cannot be
+  # replayed by an attacker. The Redis backend reuses the connection configured
+  # under redisLock.options.redisConnection (a single Redis instance generally
+  # serves both features). When no Redis host is configured, falls back to a
+  # per-process in-memory store. Fail-open: infrastructure errors never block
+  # legitimate webhook deliveries.
+  replayProtection:
+    # Master switch. Set to false to disable replay protection entirely.
+    enabled: true
+    # Window in which a duplicate x-github-delivery is rejected. Defaults to 5
+    # minutes — long enough to defeat realistic fast-replay attempts, short
+    # enough that legitimate manual redelivery from the SCM UI is unaffected.
+    ttlSeconds: 300
   scms:
     github:
       # Obtains the SCM token for a given user. If a user does not have a valid SCM token registered with Screwdriver, it will use this user's token instead.

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "screwdriver-request": "^3.0.0",
     "screwdriver-scm-base": "^10.0.1",
     "screwdriver-scm-bitbucket": "^7.4.1",
-    "screwdriver-scm-github": "^14.5.1",
+    "screwdriver-scm-github": "^14.6.2",
     "screwdriver-scm-gitlab": "^5.5.1",
     "screwdriver-scm-router": "^9.0.0",
     "screwdriver-template-validator": "^10.0.0",

--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -133,6 +133,22 @@ function isStageTeardown(jobName) {
     return STAGE_TEARDOWN_PATTERN.test(jobName);
 }
 
+/**
+ * Coerce a YAML-derived boolean-or-string into a Boolean. Accepts the
+ * common YAML 1.1 truthy strings ('on', 'true', 'yes', 'y') for
+ * consistency with the convention historically used by plugins/lock.js.
+ * @method parseBool
+ * @param  {Boolean|String} value
+ * @returns {Boolean}
+ */
+function parseBool(value) {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+
+    return ['on', 'true', 'yes', 'y'].includes(String(value).toLowerCase());
+}
+
 module.exports = {
     getReadOnlyInfo,
     getScmUri,
@@ -140,5 +156,6 @@ module.exports = {
     setDefaultTimeRange,
     validTimeRange,
     getFullStageJobName,
-    isStageTeardown
+    isStageTeardown,
+    parseBool
 };

--- a/plugins/lock.js
+++ b/plugins/lock.js
@@ -4,21 +4,7 @@ const Redis = require('ioredis');
 const Redlock = require('redlock');
 const config = require('config');
 const logger = require('screwdriver-logger');
-
-/**
- * parse value to Boolean
- * @method parseBool
- * @param {(Boolean|String)} value
- * @return {Boolean}
- */
-function parseBool(value) {
-    if (typeof value === 'boolean') {
-        return value;
-    }
-
-    // True values refers to https://yaml.org/type/bool.html
-    return ['on', 'true', 'yes', 'y'].includes(String(value).toLowerCase());
-}
+const { parseBool } = require('./helper');
 
 class Lock {
     /**

--- a/plugins/webhooks/dedupStore.js
+++ b/plugins/webhooks/dedupStore.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const config = require('config');
+const logger = require('screwdriver-logger');
+const lock = require('../lock');
+const { parseBool } = require('../helper');
+
+/**
+ * Webhook replay-protection store. Tracks `x-github-delivery` IDs (or the
+ * equivalent for other SCMs) for a short TTL and reports whether an incoming
+ * delivery is fresh or a duplicate.
+ *
+ * Reuses the Redis client that plugins/lock.js creates from
+ * redisLock.options. When that client is unavailable (redisLock.enabled is
+ * false, or Redis init failed), falls back to a per-process in-memory Map.
+ * The in-memory path is per-process and does NOT protect across multiple API
+ * instances — it's a fail-degraded fallback for deployments where Redis is
+ * unavailable.
+ *
+ * All errors are caught and the caller is told the delivery is fresh
+ * (fail-open) — webhook processing is never blocked because of replay-
+ * protection infrastructure failure.
+ *
+ * Exported as a singleton, mirroring plugins/lock.js.
+ */
+class WebhookDedupStore {
+    /**
+     * Read config and initialize the store. webhooks.replayProtection holds
+     *   { enabled: Boolean, ttlSeconds: Number }
+     * Redis is sourced from plugins/lock.js, which is in turn driven by
+     * redisLock.options — operators configure one Redis target, both features
+     * use it.
+     */
+    constructor() {
+        // Tolerate `replayProtection: null` in YAML — config.has() reports
+        // true but config.get() returns null in that case. Coalesce to {}
+        // so the rest of the constructor reads default values.
+        const options =
+            (config.has('webhooks.replayProtection') ? config.get('webhooks.replayProtection') : null) || {};
+
+        this.enabled = parseBool(options.enabled);
+        this.ttlSeconds = parseInt(options.ttlSeconds, 10) || 300;
+
+        if (!this.enabled) {
+            this.redis = null;
+            this.memorySeen = null;
+
+            return;
+        }
+
+        this.redis = lock.redis || null;
+        this.memorySeen = this.redis ? null : new Map();
+
+        if (this.redis) {
+            // ioredis emits 'error' events on connection / protocol failures.
+            // Without a listener, an unhandled error event crashes the Node
+            // process. lock.js owns this client but doesn't register a
+            // handler, so we register one here. Listener is attached once
+            // because dedupStore is a module-level singleton.
+            this.redis.on('error', err => {
+                logger.warn(`Webhook dedup store: Redis error (failing open): ${err.message}`);
+            });
+        } else {
+            logger.info(
+                'Webhook dedup store: Redis not available (redisLock disabled or uninitialized), using in-memory fallback (single-instance protection only)'
+            );
+        }
+    }
+
+    /**
+     * Attempt to claim a dedup key. Returns true if this is the first time the
+     * key has been seen within the TTL window (fresh delivery — proceed), or
+     * false if the key was already claimed (duplicate — reject upstream).
+     *
+     * Any infrastructure error returns true (fail-open).
+     *
+     * @method claim
+     * @param  {String} key
+     * @returns {Promise<Boolean>} true if fresh, false if duplicate
+     */
+    async claim(key) {
+        if (!this.enabled) {
+            return true;
+        }
+
+        if (this.redis) {
+            try {
+                // SET key 1 EX <ttl> NX — atomic test-and-set with TTL.
+                // Resolves to 'OK' on success, null if the key already exists.
+                const result = await this.redis.set(key, '1', 'EX', this.ttlSeconds, 'NX');
+
+                return result === 'OK';
+            } catch (err) {
+                logger.warn(`Webhook dedup store: claim failed (failing open): ${err.message}`);
+
+                return true;
+            }
+        }
+
+        // In-memory fallback path. Constructor guarantees memorySeen is set
+        // here (when enabled and lock.redis is unavailable).
+        if (this.memorySeen.has(key)) {
+            return false;
+        }
+        this.memorySeen.set(key, true);
+        setTimeout(() => this.memorySeen.delete(key), this.ttlSeconds * 1000).unref();
+
+        return true;
+    }
+}
+
+module.exports = new WebhookDedupStore();

--- a/plugins/webhooks/index.js
+++ b/plugins/webhooks/index.js
@@ -5,6 +5,7 @@ const logger = require('screwdriver-logger');
 const boom = require('@hapi/boom');
 const { ValidationError } = require('joi');
 const { startHookEvent } = require('./helper');
+const dedupStore = require('./dedupStore');
 
 const DEFAULT_MAX_BYTES = 1048576; // 1MB
 const providerSchema = joi
@@ -98,6 +99,20 @@ const webhooksPlugin = {
                         hookId = parsed.hookId;
 
                         request.log(['webhook', hookId], `Received event type ${type}`);
+
+                        // Replay protection: dedupe identical x-github-delivery within a short window.
+                        // On duplicate, return 204 No Content with no body so the SCM stops
+                        // retrying and an attacker probing IDs cannot distinguish a seen ID from
+                        // an unseen one based on the response. The replay decision is recorded
+                        // server-side via request.log. Fail-open is handled inside dedupStore.claim().
+                        const dedupKey = `webhook:${parsed.scmContext}:${hookId}`;
+                        const fresh = await dedupStore.claim(dedupKey);
+
+                        if (!fresh) {
+                            request.log(['webhook', hookId], 'Duplicate delivery — skipping (replay protection)');
+
+                            return h.response().code(204);
+                        }
 
                         if (queueWebhookEnabled) {
                             parsed.token = request.server.plugins.auth.generateToken({

--- a/test/plugins/webhooks.dedupStore.test.js
+++ b/test/plugins/webhooks.dedupStore.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const rewiremock = require('rewiremock/node');
+const { assert } = chai;
+
+chai.use(require('chai-as-promised'));
+sinon.assert.expose(assert, { prefix: '' });
+
+describe('webhook dedup store', () => {
+    /**
+     * Build a config mock that returns the given replayProtection block when
+     * the dedupStore singleton constructor reads
+     *   config.get('webhooks.replayProtection')
+     * at module load time.
+     * @param  {Object} replayProtection
+     * @returns {Object}
+     */
+    function makeConfigMock(replayProtection) {
+        return {
+            has: key => key === 'webhooks.replayProtection' && replayProtection !== undefined,
+            get: key => {
+                if (key === 'webhooks.replayProtection') {
+                    return replayProtection || {};
+                }
+                throw new Error(`Unexpected config.get(${key})`);
+            }
+        };
+    }
+
+    /**
+     * Load the dedupStore module with config + lock replaced. The module
+     * exports a singleton, so the returned value is the configured instance.
+     * @param  {Object} options
+     * @param  {Object} [options.replayProtection]  config block driving the singleton
+     * @param  {Object} [options.lockMock]          replacement for plugins/lock
+     * @returns {Object} the dedupStore singleton
+     */
+    function loadStore({ replayProtection, lockMock } = {}) {
+        return rewiremock.proxy('../../plugins/webhooks/dedupStore', {
+            config: makeConfigMock(replayProtection),
+            '../../plugins/lock': lockMock || { redis: null }
+        });
+    }
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('when disabled', () => {
+        it('claim() always returns true', async () => {
+            const store = loadStore({ replayProtection: { enabled: false } });
+
+            assert.isTrue(await store.claim('any'));
+            assert.isTrue(await store.claim('any'));
+        });
+
+        it('claim() returns true when the replayProtection block is missing entirely', async () => {
+            const store = loadStore();
+
+            assert.isTrue(await store.claim('any'));
+        });
+    });
+
+    describe('Redis backend (shared lock.redis client)', () => {
+        let redisSet;
+
+        beforeEach(() => {
+            redisSet = sinon.stub();
+        });
+
+        it('returns true when SET NX succeeds (fresh delivery)', async () => {
+            redisSet.resolves('OK');
+            const store = loadStore({
+                replayProtection: { enabled: true, ttlSeconds: 60 },
+                lockMock: { redis: { set: redisSet, on: sinon.stub() } }
+            });
+
+            assert.isTrue(await store.claim('webhook:gh:1'));
+            assert.calledWith(redisSet, 'webhook:gh:1', '1', 'EX', 60, 'NX');
+        });
+
+        it('returns false when SET NX reports the key already exists (duplicate)', async () => {
+            redisSet.resolves(null);
+            const store = loadStore({
+                replayProtection: { enabled: true, ttlSeconds: 60 },
+                lockMock: { redis: { set: redisSet, on: sinon.stub() } }
+            });
+
+            assert.isFalse(await store.claim('webhook:gh:2'));
+        });
+
+        it('fails open when the Redis call throws', async () => {
+            redisSet.rejects(new Error('ECONNREFUSED'));
+            const store = loadStore({
+                replayProtection: { enabled: true, ttlSeconds: 60 },
+                lockMock: { redis: { set: redisSet, on: sinon.stub() } }
+            });
+
+            assert.isTrue(await store.claim('webhook:gh:3'));
+        });
+
+        it('uses the default 5-minute TTL when ttlSeconds is omitted', async () => {
+            redisSet.resolves('OK');
+            const store = loadStore({
+                replayProtection: { enabled: true },
+                lockMock: { redis: { set: redisSet, on: sinon.stub() } }
+            });
+
+            await store.claim('webhook:gh:4');
+            assert.calledWith(redisSet, 'webhook:gh:4', '1', 'EX', 300, 'NX');
+        });
+    });
+
+    describe('in-memory fallback (lock.redis unavailable)', () => {
+        let clock;
+
+        beforeEach(() => {
+            clock = sinon.useFakeTimers();
+        });
+
+        afterEach(() => {
+            clock.restore();
+        });
+
+        it('first claim returns true, duplicate returns false', async () => {
+            const store = loadStore({ replayProtection: { enabled: true, ttlSeconds: 60 } });
+
+            assert.isTrue(await store.claim('mem-1'));
+            assert.isFalse(await store.claim('mem-1'));
+        });
+
+        it('keys expire after the TTL window', async () => {
+            const store = loadStore({ replayProtection: { enabled: true, ttlSeconds: 1 } });
+
+            assert.isTrue(await store.claim('mem-2'));
+            assert.isFalse(await store.claim('mem-2'));
+
+            // Advance past the TTL.
+            clock.tick(1500);
+
+            assert.isTrue(await store.claim('mem-2'));
+        });
+
+        it('tracks different keys independently', async () => {
+            const store = loadStore({ replayProtection: { enabled: true, ttlSeconds: 60 } });
+
+            assert.isTrue(await store.claim('mem-a'));
+            assert.isTrue(await store.claim('mem-b'));
+            assert.isFalse(await store.claim('mem-a'));
+            assert.isFalse(await store.claim('mem-b'));
+        });
+
+        it('falls back when lock module has no redis client', async () => {
+            const store = loadStore({
+                replayProtection: { enabled: true, ttlSeconds: 60 },
+                lockMock: { redis: undefined }
+            });
+
+            assert.isTrue(await store.claim('mem-c'));
+            assert.isFalse(await store.claim('mem-c'));
+        });
+    });
+});

--- a/test/plugins/webhooks.test.js
+++ b/test/plugins/webhooks.test.js
@@ -19,6 +19,7 @@ describe('webhooks plugin test', () => {
     let eventFactoryMock;
     let queueWebhookMock;
     let startHookEventMock;
+    let dedupStoreMock;
     let plugin;
     let server;
     const apiUri = 'http://foo.bar:12345';
@@ -43,10 +44,15 @@ describe('webhooks plugin test', () => {
 
         startHookEventMock = sinon.stub();
 
+        dedupStoreMock = {
+            claim: sinon.stub().resolves(true)
+        };
+
         plugin = rewiremock.proxy('../../plugins/webhooks', {
             '../../plugins/webhooks/helper': {
                 startHookEvent: startHookEventMock
-            }
+            },
+            '../../plugins/webhooks/dedupStore': dedupStoreMock
         });
 
         server = new hapi.Server({
@@ -190,6 +196,21 @@ describe('webhooks plugin test', () => {
             return server.inject(options).then(() => {
                 assert.calledOnce(pipelineFactoryMock.scm.parseHook);
                 assert.calledWith(startHookEventMock, sinon.match.any, sinon.match.any, parsed);
+                assert.notCalled(queueWebhookMock.executor.enqueueWebhook);
+            });
+        });
+
+        it('returns 204 with empty body when the delivery is a duplicate', () => {
+            pipelineFactoryMock.scm.parseHook.resolves(parsed);
+            dedupStoreMock.claim.resolves(false);
+
+            return server.inject(options).then(reply => {
+                // 204 with no body so an attacker probing hookIds cannot
+                // distinguish a seen ID from an unseen one.
+                assert.equal(reply.statusCode, 204);
+                assert.equal(reply.payload, '');
+                assert.calledWith(dedupStoreMock.claim, `webhook:${parsed.scmContext}:${parsed.hookId}`);
+                assert.notCalled(startHookEventMock);
                 assert.notCalled(queueWebhookMock.executor.enqueueWebhook);
             });
         });


### PR DESCRIPTION
## Summary
- New singleton `plugins/webhooks/dedupStore.js` tracks each incoming `x-github-delivery` for a configurable TTL (default 5 minutes) and silently drops duplicates.
- Webhook handler returns `204 No Content` with an empty body on duplicate so the SCM stops retrying and an attacker probing IDs cannot distinguish a seen ID from an unseen one.
- Reuses the Redis client owned by `plugins/lock.js` — operators configure one Redis target via `redisLock.options` and both features use it. Falls back to a per-process in-memory `Map` when Redis is unavailable.
- Fail-open: any Redis error logs a warning and lets the delivery through, so replay-protection infrastructure cannot block legitimate webhooks. Includes an `error` listener on the shared Redis client to prevent unhandled error events from crashing the process.
- `parseBool` is lifted to `plugins/helper.js` so `lock.js` and `dedupStore.js` share a single implementation.
- Bumps `screwdriver-scm-github` to `^14.6.2`.

## Why 5 minutes
Long enough to defeat realistic fast-replay attempts (an attacker who captured a delivery and replays it within minutes), short enough that legitimate manual redelivery from the SCM UI — which preserves the original `x-github-delivery` ID — is unaffected in practice. The TTL is configurable via \`webhooks.replayProtection.ttlSeconds\`.

## Test plan
- New \`test/plugins/webhooks.dedupStore.test.js\` covers: disabled state, Redis-backed claim (fresh + duplicate + fail-open + default TTL), in-memory fallback (claim + TTL eviction with fake timers + per-key independence + fallback when lock has no Redis).
- New test in \`test/plugins/webhooks.test.js\` asserts the handler returns 204 with empty body and skips downstream processing on duplicate.
- Existing webhook plugin tests continue to pass.
- \`npm run lint\` clean; full plugin suite green except one pre-existing unrelated jobs.test.js failure.