### PR TITLE
fix: determine latestCommitEvent based on the latest git SHA [2]

### DIFF
--- a/plugins/pipelines/latestCommitEvent.js
+++ b/plugins/pipelines/latestCommitEvent.js
@@ -20,28 +20,15 @@ module.exports = () => ({
 
         handler: async (request, h) => {
             const { eventFactory } = request.server.app;
+            const event = await eventFactory.getLatestCommitEvent({
+                pipelineId: request.params.id
+            });
 
-            return eventFactory
-                .list({
-                    params: {
-                        pipelineId: request.params.id,
-                        parentEventId: null,
-                        type: 'pipeline'
-                    },
-                    paginate: {
-                        count: 1
-                    }
-                })
-                .then(async events => {
-                    if (!events || Object.keys(events).length === 0) {
-                        throw boom.notFound('Event does not exist');
-                    }
+            if (!event) {
+                throw boom.notFound('Event does not exist');
+            }
 
-                    return h.response(await events[0].toJson());
-                })
-                .catch(err => {
-                    throw err;
-                });
+            return h.response(await event.toJson());
         },
         response: {
             schema: getSchema

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -274,6 +274,7 @@ describe('pipeline plugin test', () => {
         eventFactoryMock = {
             create: sinon.stub().resolves(null),
             list: sinon.stub().resolves(null),
+            getLatestCommitEvent: sinon.stub().resolves(null),
             getPipelineTypeBuildEvents: sinon.stub().resolves(null)
         };
         stageFactoryMock = {
@@ -1433,7 +1434,7 @@ describe('pipeline plugin test', () => {
     describe('GET /pipelines/{id}/latestCommitEvent', () => {
         const id = 1234;
         let options;
-        let events;
+        let event;
 
         beforeEach(() => {
             options = {
@@ -1441,13 +1442,12 @@ describe('pipeline plugin test', () => {
                 url: `/pipelines/${id}/latestCommitEvent`
             };
 
-            events = getEventsMocks(testEvents);
-
-            eventFactoryMock.list.resolves(events);
+            event = getEventsMocks(testEvents[0]);
+            eventFactoryMock.getLatestCommitEvent.resolves(event);
         });
 
         it('returns 404 if event does not exist', () => {
-            eventFactoryMock.list.resolves(null);
+            eventFactoryMock.getLatestCommitEvent.resolves(null);
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 404);
@@ -1457,15 +1457,8 @@ describe('pipeline plugin test', () => {
         it('returns 200 if found last commit event', () =>
             server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
-                assert.calledWith(eventFactoryMock.list, {
-                    params: {
-                        pipelineId: id,
-                        parentEventId: null,
-                        type: 'pipeline'
-                    },
-                    paginate: {
-                        count: 1
-                    }
+                assert.calledWith(eventFactoryMock.getLatestCommitEvent, {
+                    pipelineId: id
                 });
                 assert.deepEqual(reply.result, testEvents[0]);
             }));


### PR DESCRIPTION
## Context

This PR is the second step to fix the issue where `GET /pipelines/{id}/latestCommitEvent` incorrectly returns an event that is not linked to the latest commit (e.g., when a user triggers `New Run (Fresh)` from an older event in the UI).

In the [previous PR](https://github.com/screwdriver-cd/models/pull/672), we added the `getLatestCommitEvent` function to the `models` layer as a foundation. Now, we need to update the API repository side to actually utilize this function so that the system determines the latest commit event based on the true latest SHA from the git repository.

## Objective

The objective of this PR is to integrate the new Git-based validation logic into the API handler. By switching to the new model function, we ensure that the API accurately identifies and returns the true `latestCommitEvent`.

### Key Changes
* Update the API endpoint/handler logic to use the `getLatestCommitEvent` function from `models`.
* Switch the source of truth for `latestCommitEvent` determination from the internal pipeline data to the git repository's latest SHA.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/models/pull/672
## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
