### PR TITLE
fix: update archiver to v8 for brace-expansion vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@hapi/inert": "^7.0.0",
     "@hapi/vision": "^7.0.0",
     "@promster/hapi": "^15.0.0",
-    "archiver": "^7.0.1",
+    "archiver": "^8.0.0",
     "async": "^3.2.4",
     "badge-maker": "^3.3.1",
     "config": "^3.3.8",

--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -5,13 +5,18 @@ const joi = require('joi');
 const jwt = require('jsonwebtoken');
 const request = require('got');
 const schema = require('screwdriver-data-schema');
-const archiver = require('archiver');
 const { PassThrough } = require('stream');
 const logger = require('screwdriver-logger');
 const { v4: uuidv4 } = require('uuid');
 const idSchema = schema.models.build.base.extract('id');
 const artifactSchema = joi.string().label('Artifact Name');
 const typeSchema = joi.string().default('preview').valid('download', 'preview').label('Flag to trigger type either to download or preview');
+
+async function createZipArchive() {
+    const { ZipArchive } = await import('archiver');
+
+    return new ZipArchive({ zlib: { level: 9 } });
+}
 
 module.exports = config => ({
     method: 'GET',
@@ -90,7 +95,7 @@ module.exports = config => ({
                             }
 
                             // Create a stream and set up archiver
-                            const archive = archiver('zip', { zlib: { level: 9 } });
+                            const archive = await createZipArchive();
                             const passThrough = new PassThrough();
 
                             // Handle archiver errors

--- a/plugins/builds/artifacts/getAll.js
+++ b/plugins/builds/artifacts/getAll.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const archiver = require('archiver');
 const boom = require('@hapi/boom');
 const request = require('got');
 const joi = require('joi');
@@ -10,6 +9,12 @@ const { PassThrough } = require('stream');
 const schema = require('screwdriver-data-schema');
 const { v4: uuidv4 } = require('uuid');
 const idSchema = schema.models.build.base.extract('id');
+
+async function createZipArchive() {
+    const { ZipArchive } = await import('archiver');
+
+    return new ZipArchive({ zlib: { level: 9 } });
+}
 
 
 module.exports = config => ({
@@ -63,7 +68,7 @@ module.exports = config => ({
                     const manifestArray = manifest.trim().split('\n');
 
                     // Create a stream and set up archiver
-                    const archive = archiver('zip', { zlib: { level: 9 } });
+                    const archive = await createZipArchive();
                     // PassThrough stream to make archiver readable by Hapi
                     const passThrough = new PassThrough();
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Snyk reported a high severity vulnerability in `brace-expansion` through the `archiver` dependency chain in `screwdriver`.

The vulnerable path was:
`archiver@7.x -> readdir-glob -> minimatch -> brace-expansion`

To remove this path, `archiver` needs to be updated to `v8`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR updates `archiver` from `^7.0.1` to `^8.0.0`.

Since `archiver@8` changed its module/API usage, this PR also updates the artifact ZIP download handlers to use the new `ZipArchive` initialization pattern via dynamic import.

The intended result is:
- remove the vulnerable `brace-expansion` path introduced through `archiver`
- keep the existing artifact ZIP download behavior for directory and full artifact archive endpoints

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- Snyk vulnerability: SNYK-JS-BRACEEXPANSION-17706650
  - https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-17706650
- `archiver` v8 release notes
  - https://github.com/archiverjs/node-archiver/releases#release-8.0.0

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
