### PR TITLE
fix: remove license-checker module

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "joi": "^17.7.0",
     "js-yaml": "^3.14.1",
     "jsonwebtoken": "^9.0.0",
-    "license-checker": "^25.0.1",
     "lodash.isempty": "^4.4.0",
     "lodash.mergewith": "^4.6.2",
     "ndjson": "^2.0.0",

--- a/plugins/versions.js
+++ b/plugins/versions.js
@@ -3,70 +3,299 @@
 const fs = require('fs');
 const path = require('path');
 const process = require('process');
-const checker = require('license-checker');
 const VError = require('verror');
 const schema = require('screwdriver-data-schema');
 
-/**
- * Hapi interface for plugin to return package list
- * @method register
- * @param  {Hapi.Server}    server
- */
-const versionsTemplate = {
-    name: 'versions',
-    async register(server) {
-        // Designed to match Screwdriver specific packages
-        const SD_REGEX = /^screwdriver-/;
-        let start = process.cwd();
+const UNKNOWN = 'UNKNOWN';
+const UNLICENSED = 'UNLICENSED';
+const SD_REGEX = /^screwdriver-/;
 
-        if (!fs.existsSync(path.resolve(process.cwd(), './node_modules'))) {
-            start = path.resolve(process.cwd(), '../..');
+/**
+ * Read JSON file
+ * @param {string} filePath File path
+ * @returns {Object}
+ */
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+/**
+ * Resolve project root path
+ * @returns {string}
+ */
+function findProjectRoot() {
+    if (fs.existsSync(path.resolve(process.cwd(), './node_modules'))) {
+        return process.cwd();
+    }
+
+    return path.resolve(process.cwd(), '../..');
+}
+
+/**
+ * Normalize repository url
+ * @param {Object|string} repository Repository URL
+ * @returns {string}
+ */
+function normalizeRepository(repository) {
+    const url = typeof repository === 'string' ? repository : repository && repository.url;
+
+    if (!url) {
+        return undefined;
+    }
+
+    const normalizedUrl = url
+        .replace('http:', 'https:')
+        .replace('ssh://github.com', 'https://github.com')
+        .replace('git+ssh://git@', 'git://')
+        .replace('git+https://github.com', 'https://github.com')
+        .replace('git://github.com', 'https://github.com')
+        .replace('git@github.com:', 'https://github.com/')
+        .replace('www.github.com', 'github.com')
+        .replace('github:', '')
+        .replace(/\.git$/, '');
+
+    return normalizedUrl.startsWith('http') ? normalizedUrl : `https://github.com/${normalizedUrl}`;
+}
+
+/**
+ * Normalize license
+ * @param {Array|string} value license
+ * @returns {string}
+ */
+function normalizeLicense(value) {
+    if (!value) {
+        return undefined;
+    }
+
+    if (Array.isArray(value)) {
+        const licenses = value
+            .map(item => {
+                if (typeof item === 'string') {
+                    return item;
+                }
+
+                return item && (item.type || item.name);
+            })
+            .filter(Boolean);
+
+        return licenses.length === 1 ? licenses[0] : licenses;
+    }
+
+    if (typeof value === 'object') {
+        return value.type || value.name;
+    }
+
+    return value;
+}
+
+/**
+ * Find license description from the document
+ * @param {string} text document
+ * @returns {string}
+ */
+function detectLicenseFromText(text) {
+    if (!text) {
+        return undefined;
+    }
+
+    const body = text.toLowerCase();
+
+    if (body.includes('mit license')) {
+        return 'MIT';
+    }
+
+    if (body.includes('apache license') && body.includes('version 2.0')) {
+        return 'Apache-2.0';
+    }
+
+    if (body.includes('isc license')) {
+        return 'ISC';
+    }
+
+    if (body.includes('bsd 3-clause')) {
+        return 'BSD-3-Clause';
+    }
+
+    if (body.includes('bsd 2-clause')) {
+        return 'BSD-2-Clause';
+    }
+
+    return undefined;
+}
+
+/**
+ * Find license files
+ * @param {string} dir base directory
+ * @returns {Array}
+ */
+function getLicenseFiles(dir) {
+    return fs
+        .readdirSync(dir)
+        .filter(filename => {
+            const upper = filename.toUpperCase();
+            const basename = path.basename(upper, path.extname(upper));
+
+            return (
+                basename === 'LICENSE' || basename === 'LICENCE' || basename === 'COPYING' || basename === 'COPYRIGHT'
+            );
+        })
+        .sort();
+}
+
+/**
+ * Find package directory
+ * @param {string} fromDir base directory
+ * @param {string} name package name
+ * @returns {string}
+ */
+function resolvePackageDir(fromDir, name) {
+    let current = fromDir;
+
+    while (current && current !== path.dirname(current)) {
+        const candidate = path.join(current, 'node_modules', name);
+
+        if (fs.existsSync(path.join(candidate, 'package.json'))) {
+            return candidate;
         }
 
-        // Load licenses
-        return checker.init(
-            {
-                production: true,
-                start
-            },
-            (err, json) => {
-                if (err) {
-                    return new VError(err, 'Unable to load package dependencies');
-                }
-                const depArray = Object.keys(json).map(key => ({ name: key, ...json[key] }));
-                const depDisplay = depArray.map(dep => ({
-                    name: dep.name.split('@').slice(0, -1).join('@'),
-                    repository: dep.repository || 'UNKNOWN',
-                    licenses: dep.licenses || 'UNKNOWN'
-                }));
-                const sdVersions = depArray.filter(dep => SD_REGEX.test(dep.name)).map(dep => dep.name);
+        current = path.dirname(current);
+    }
 
-                return server.route({
-                    method: 'GET',
-                    path: '/versions',
-                    handler: (request, h) =>
-                        h.response({
-                            // List of Screwdriver package versions
-                            versions: sdVersions,
-                            // List of licenses for third-party dependencies
-                            licenses: depDisplay
-                        }),
-                    config: {
-                        description: 'API Package Versions',
-                        notes: 'Returns list of Screwdriver package versions and third-party dependencies',
-                        tags: ['api'],
-                        plugins: {
-                            'hapi-rate-limit': {
-                                enabled: false
-                            }
-                        },
-                        response: {
-                            schema: schema.api.versions
-                        }
-                    }
-                });
+    return null;
+}
+
+/**
+ * List up packages infomation
+ * @param {string} pkgDir base dirctory
+ * @param {object} data result store
+ * @returns {object}
+ */
+function collectPackage(pkgDir, data) {
+    const packageJsonPath = path.join(pkgDir, 'package.json');
+
+    if (!fs.existsSync(packageJsonPath)) {
+        return data;
+    }
+
+    const json = readJson(packageJsonPath);
+    const key = `${json.name}@${json.version}`;
+
+    if (!json.name || !json.version || data[key]) {
+        return data;
+    }
+
+    const moduleInfo = {
+        licenses: UNKNOWN
+    };
+
+    if (json.private) {
+        moduleInfo.private = true;
+    }
+
+    const repository = normalizeRepository(json.repository);
+
+    if (repository) {
+        moduleInfo.repository = repository;
+    }
+
+    let licenses = normalizeLicense(json.license || json.licenses);
+
+    if (!licenses && json.readme) {
+        licenses = detectLicenseFromText(json.readme);
+    }
+
+    const readmePath = path.join(pkgDir, 'README.md');
+
+    if (!licenses && fs.existsSync(readmePath)) {
+        licenses = detectLicenseFromText(fs.readFileSync(readmePath, 'utf8'));
+    }
+
+    getLicenseFiles(pkgDir).forEach((filename, index) => {
+        const licenseFile = path.join(pkgDir, filename);
+
+        if (!fs.lstatSync(licenseFile).isFile()) {
+            return;
+        }
+
+        const content = fs.readFileSync(licenseFile, 'utf8');
+
+        if (!licenses || String(licenses).includes(UNKNOWN) || String(licenses).indexOf('Custom:') === 0) {
+            licenses = detectLicenseFromText(content) || `Custom: ${filename}`;
+        }
+
+        if (index === 0) {
+            moduleInfo.licenseFile = licenseFile;
+        }
+    });
+
+    moduleInfo.licenses = licenses || UNKNOWN;
+
+    if (json.private) {
+        moduleInfo.licenses = UNLICENSED;
+    }
+
+    data[key] = moduleInfo;
+
+    [json.dependencies, json.optionalDependencies, json.peerDependencies].forEach(dependencies => {
+        Object.keys(dependencies || {}).forEach(depName => {
+            const childDir = resolvePackageDir(pkgDir, depName);
+
+            if (childDir) {
+                collectPackage(childDir, data);
             }
-        );
+        });
+    });
+
+    return data;
+}
+
+const versionsTemplate = {
+    name: 'versions',
+
+    async register(server) {
+        try {
+            const data = collectPackage(findProjectRoot(), {});
+
+            const depArray = Object.keys(data)
+                .sort()
+                .map(key => ({
+                    name: key,
+                    ...data[key]
+                }));
+
+            const depDisplay = depArray.map(dep => ({
+                name: dep.name.split('@').slice(0, -1).join('@'),
+                repository: dep.repository || UNKNOWN,
+                licenses: dep.licenses || UNKNOWN
+            }));
+
+            const sdVersions = depArray.filter(dep => SD_REGEX.test(dep.name)).map(dep => dep.name);
+
+            return server.route({
+                method: 'GET',
+                path: '/versions',
+                handler: (request, h) =>
+                    h.response({
+                        versions: sdVersions,
+                        licenses: depDisplay
+                    }),
+                config: {
+                    description: 'API Package Versions',
+                    notes: 'Returns list of Screwdriver package versions and third-party dependencies',
+                    tags: ['api'],
+                    plugins: {
+                        'hapi-rate-limit': {
+                            enabled: false
+                        }
+                    },
+                    response: {
+                        schema: schema.api.versions
+                    }
+                }
+            });
+        } catch (err) {
+            throw new VError(err, 'Unable to load package dependencies');
+        }
     }
 };
 

--- a/test/plugins/versions.test.js
+++ b/test/plugins/versions.test.js
@@ -1,22 +1,62 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
+const process = require('process');
 const { assert } = require('chai');
 const hapi = require('@hapi/hapi');
-const licenseChecker = require('license-checker');
 const sinon = require('sinon');
 
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('versions plugin test', () => {
+    const root = '/app';
+    const packageJsons = {
+        '/app/package.json': {
+            name: 'test',
+            version: '1.0.0',
+            license: 'MIT',
+            repository: {
+                type: 'git',
+                url: 'git@github.com:screwdriver-cd/screwdriver.git'
+            },
+            dependencies: {
+                'screwdriver-foo': '^0.1.2',
+                fake1: '^1.2.3',
+                fake3: '^3.4.5',
+                fake2: '^2.3.4'
+            }
+        },
+        '/app/node_modules/screwdriver-foo/package.json': {
+            name: 'screwdriver-foo',
+            version: '0.1.2',
+            repository: 'bar',
+            license: 'baz'
+        },
+        '/app/node_modules/fake1/package.json': {
+            name: 'fake1',
+            version: '1.2.3',
+            repository: 'bark1'
+        },
+        '/app/node_modules/fake2/package.json': {
+            name: 'fake2',
+            version: '2.3.4',
+            license: 'bark2'
+        },
+        '/app/node_modules/fake3/package.json': {
+            name: 'fake3',
+            version: '3.4.5',
+            repository: 'bark3',
+            license: 'bark4'
+        }
+    };
+
     /**
      * Generate a new Hapi server with a specified init function
      * @method registerServer
      * @return {HapiServer}                  Hapi Server to use
      */
     async function registerServer() {
-        sinon.stub(fs, 'existsSync').returns(false);
-
         /* eslint-disable global-require */
         const plugin = require('../../plugins/versions');
         /* eslint-enable global-require */
@@ -30,47 +70,70 @@ describe('versions plugin test', () => {
         return server;
     }
 
+    beforeEach(() => {
+        sinon.stub(process, 'cwd').returns(root);
+    });
+
     afterEach(() => {
         sinon.restore();
     });
 
     describe('GET /versions', () => {
-        it('returns 200 for a successful yaml', async () => {
-            sinon.stub(licenseChecker, 'init').yieldsAsync(null, {
-                'screwdriver-foo@0.1.2': {
-                    repository: 'bar',
-                    licenses: 'baz'
-                },
-                'fake1@1.2.3': {
-                    repository: 'bark1'
-                },
-                'fake2@2.3.4': {
-                    licenses: 'bark2'
-                },
-                'fake3@3.4.5': {
-                    repository: 'bark3',
-                    licenses: 'bark4'
+        it('returns 200 for a successful response', async () => {
+            const originalExistsSync = fs.existsSync;
+            const originalReadFileSync = fs.readFileSync;
+
+            sinon.stub(fs, 'existsSync').callsFake(filePath => {
+                const normalized = path.normalize(filePath);
+
+                if (normalized === '/app/node_modules' || packageJsons[normalized]) {
+                    return true;
                 }
+
+                return originalExistsSync.call(fs, filePath);
             });
+
+            sinon.stub(fs, 'readFileSync').callsFake((filePath, ...args) => {
+                const normalized = path.normalize(filePath);
+
+                if (packageJsons[normalized]) {
+                    return JSON.stringify(packageJsons[normalized]);
+                }
+
+                return originalReadFileSync.call(fs, filePath, ...args);
+            });
+
+            sinon.stub(fs, 'readdirSync').callsFake(() => []);
+            sinon.stub(fs, 'lstatSync').callsFake(() => ({
+                isFile: () => true
+            }));
 
             const server = await registerServer();
             const reply = await server.inject({ url: '/versions' });
 
             assert.equal(reply.statusCode, 200);
-            assert.equal(JSON.stringify(reply.result.versions), JSON.stringify(['screwdriver-foo@0.1.2']));
-            assert.equal(
-                JSON.stringify(reply.result.licenses),
-                JSON.stringify([
-                    { name: 'screwdriver-foo', repository: 'bar', licenses: 'baz' },
-                    { name: 'fake1', repository: 'bark1', licenses: 'UNKNOWN' },
-                    { name: 'fake2', repository: 'UNKNOWN', licenses: 'bark2' },
-                    { name: 'fake3', repository: 'bark3', licenses: 'bark4' }
-                ])
-            );
+            assert.deepEqual(reply.result.versions, ['screwdriver-foo@0.1.2']);
+            assert.deepEqual(reply.result.licenses, [
+                { name: 'fake1', repository: 'https://github.com/bark1', licenses: 'UNKNOWN' },
+                { name: 'fake2', repository: 'UNKNOWN', licenses: 'bark2' },
+                { name: 'fake3', repository: 'https://github.com/bark3', licenses: 'bark4' },
+                { name: 'screwdriver-foo', repository: 'https://github.com/bar', licenses: 'baz' },
+                {
+                    name: 'test',
+                    repository: 'https://github.com/screwdriver-cd/screwdriver',
+                    licenses: 'MIT'
+                }
+            ]);
         });
 
-        it('returns 500 for being unable to parse the package.json', () => {
-            sinon.stub(licenseChecker, 'init').yieldsAsync(new Error('foobar'));
+        it('returns 500 for being unable to parse the package.json', async () => {
+            sinon.stub(fs, 'existsSync').callsFake(filePath => {
+                const normalized = path.normalize(filePath);
+
+                return normalized === '/app/node_modules' || normalized === '/app/package.json';
+            });
+
+            sinon.stub(fs, 'readFileSync').throws(new Error('foobar'));
 
             registerServer().catch(error => {
                 assert.match(error.toString(), /Unable to load package dependencies: foobar/);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

[A vulnerability](https://security.snyk.io/vuln/SNYK-JS-BRACEEXPANSION-17706650) was detected from the package `license-checker`, but `license-checker` is not maintained now.

```text
license-checker@25.0.1 › read-installed@4.0.3 › read-package-json@2.1.2 › glob@7.2.3 › minimatch@3.1.5 › brace-expansion@1.1.15
```

`license-checker` is only used at `GET /versions`, so it would be better to implement that endpoint without `license-checker` .

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

- Remove dependencies of `license-checker`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
