### PR TITLE
fix: handle root package.json

### DIFF
--- a/plugins/versions.js
+++ b/plugins/versions.js
@@ -179,8 +179,9 @@ function collectPackage(pkgDir, data) {
 
     const json = readJson(packageJsonPath);
     const key = `${json.name}@${json.version}`;
+    const hasIdentity = json.name && json.version;
 
-    if (!json.name || !json.version || data[key]) {
+    if (hasIdentity && data[key]) {
         return data;
     }
 
@@ -234,7 +235,9 @@ function collectPackage(pkgDir, data) {
         moduleInfo.licenses = UNLICENSED;
     }
 
-    data[key] = moduleInfo;
+    if (hasIdentity) {
+        data[key] = moduleInfo;
+    }
 
     [json.dependencies, json.optionalDependencies, json.peerDependencies].forEach(dependencies => {
         Object.keys(dependencies || {}).forEach(depName => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up https://github.com/screwdriver-cd/screwdriver/pull/3503 .

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The root package.json does not have `name` and `version` properties.
`{ dependencies: { 'screwdriver-api': '^8.0.163' } }`

So it stops searching at root.
https://github.com/screwdriver-cd/screwdriver/blob/12ac7a594e5311670f815102cb4207b3dbc498df/plugins/versions.js#L183-L185

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/pull/3503

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
