### PR TITLE
feat: configure YAML merge key limit [3]

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -62,10 +62,16 @@ const notificationConfig = config.get('notifications');
 const multiBuildClusterEnabled = convertToBool(config.get('multiBuildCluster').enabled);
 
 // Maximum total number of YAML merge keys allowed in a pipeline configuration
-const maxTotalMergeKeys = Number(config.get('yamlParser.maxTotalMergeKeys'));
+const maxTotalMergeKeys = config.has('yamlParser.maxTotalMergeKeys')
+    ? Number(config.get('yamlParser.maxTotalMergeKeys'))
+    : undefined;
 
-if (!Number.isSafeInteger(maxTotalMergeKeys) || maxTotalMergeKeys <= 0) {
-    throw new TypeError('yamlParser.maxTotalMergeKeys must be a positive safe integer.');
+if (
+    maxTotalMergeKeys !== undefined && !Number.isSafeInteger(maxTotalMergeKeys)
+) {
+    throw new TypeError(
+        'yamlParser.maxTotalMergeKeys must be a positive safe integer.'
+    );
 }
 
 // Unzip artifacts feature flag

--- a/bin/server
+++ b/bin/server
@@ -61,6 +61,13 @@ const notificationConfig = config.get('notifications');
 // Multiple build cluster feature flag
 const multiBuildClusterEnabled = convertToBool(config.get('multiBuildCluster').enabled);
 
+// Maximum total number of YAML merge keys allowed in a pipeline configuration
+const maxTotalMergeKeys = Number(config.get('yamlParser.maxTotalMergeKeys'));
+
+if (!Number.isSafeInteger(maxTotalMergeKeys) || maxTotalMergeKeys <= 0) {
+    throw new TypeError('yamlParser.maxTotalMergeKeys must be a positive safe integer.');
+}
+
 // Unzip artifacts feature flag
 const unzipArtifactsEnabled = convertToBool(config.get('unzipArtifacts').enabled);
 
@@ -145,6 +152,7 @@ const pipelineFactory = Models.PipelineFactory.getInstance({
     scm,
     externalJoin: true,
     notificationsValidationErr,
+    maxTotalMergeKeys,
     multiBuildClusterEnabled
 });
 
@@ -313,7 +321,8 @@ datastore.setup(datastoreConfig.ddlSyncEnabled).then(() =>
         log,
         validator: {
             externalJoin: true,
-            notificationsValidationErr
+            notificationsValidationErr,
+            maxTotalMergeKeys
         },
         queueWebhook: {
             executor,

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -431,6 +431,9 @@ multiBuildCluster:
   # Enabled multi build cluster feature or not
   enabled: MULTI_BUILD_CLUSTER_ENABLED
 
+yamlParser:
+  maxTotalMergeKeys: YAML_PARSER_MAX_TOTAL_MERGE_KEYS
+
 unzipArtifacts:
   # Enabled unzip artifacts feature or not
   enabled: UNZIP_ARTIFACTS_ENABLED

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -340,6 +340,10 @@ multiBuildCluster:
   # Enabled multi build cluster feature or not
   enabled: false
 
+yamlParser:
+  # Maximum total number of YAML merge keys allowed in a pipeline configuration
+  maxTotalMergeKeys: 11000
+
 unzipArtifacts:
   # Enabled unzip artifacts feature or not
   enabled: false

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -340,10 +340,6 @@ multiBuildCluster:
   # Enabled multi build cluster feature or not
   enabled: false
 
-yamlParser:
-  # Maximum total number of YAML merge keys allowed in a pipeline configuration
-  maxTotalMergeKeys: 11000
-
 unzipArtifacts:
   # Enabled unzip artifacts feature or not
   enabled: false

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "hapi-swagger": "^17.2.1",
     "ioredis": "^5.2.3",
     "joi": "^17.7.0",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^4.3.0",
     "jsonwebtoken": "^9.0.0",
     "lodash.isempty": "^4.4.0",
     "lodash.mergewith": "^4.6.2",

--- a/plugins/validator.js
+++ b/plugins/validator.js
@@ -28,7 +28,7 @@ const validatorTemplate = {
                     }
                 },
                 handler: async (request, h) => {
-                    const { notificationsValidationErr } = options;
+                    const { notificationsValidationErr, maxTotalMergeKeys } = options;
                     const {
                         buildClusterFactory,
                         templateFactory,
@@ -45,7 +45,8 @@ const validatorTemplate = {
                         pipelineTemplateVersionFactory,
                         pipelineTemplateTagFactory,
                         pipelineTemplateFactory,
-                        notificationsValidationErr
+                        notificationsValidationErr,
+                        maxTotalMergeKeys
                     }).then(pipeline => h.response(pipeline));
                 },
                 validate: {

--- a/test/plugins/validator.test.js
+++ b/test/plugins/validator.test.js
@@ -3,6 +3,7 @@
 const { assert } = require('chai');
 const sinon = require('sinon');
 const hapi = require('@hapi/hapi');
+const rewire = require('rewire');
 
 const testInput = require('./data/validator.input.json');
 const testOutput = require('./data/validator.output.json');
@@ -34,6 +35,25 @@ describe('validator plugin test', () => {
     });
 
     describe('POST /validator', () => {
+        it('passes maxTotalMergeKeys to the config parser', async () => {
+            const parserMock = sinon.stub().resolves(testOutput);
+            const validatorPlugin = rewire('../../plugins/validator');
+            const validatorServer = new hapi.Server({ port: 1235 });
+
+            validatorPlugin.__set__('parser', parserMock);
+            await validatorServer.register({
+                plugin: validatorPlugin,
+                options: { maxTotalMergeKeys: 11000 }
+            });
+            await validatorServer.inject({
+                method: 'POST',
+                url: '/validator',
+                payload: testInput
+            });
+
+            assert.calledWithMatch(parserMock, { maxTotalMergeKeys: 11000 });
+        });
+
         it('returns 200 for a successful yaml', () =>
             server
                 .inject({

--- a/test/plugins/validator.test.js
+++ b/test/plugins/validator.test.js
@@ -43,7 +43,7 @@ describe('validator plugin test', () => {
             validatorPlugin.__set__('parser', parserMock);
             await validatorServer.register({
                 plugin: validatorPlugin,
-                options: { maxTotalMergeKeys: 11000 }
+                options: { maxTotalMergeKeys: 10000 }
             });
             await validatorServer.inject({
                 method: 'POST',
@@ -51,7 +51,7 @@ describe('validator plugin test', () => {
                 payload: testInput
             });
 
-            assert.calledWithMatch(parserMock, { maxTotalMergeKeys: 11000 });
+            assert.calledWithMatch(parserMock, { maxTotalMergeKeys: 10000 });
         });
 
         it('returns 200 for a successful yaml', () =>


### PR DESCRIPTION
## Context

Large pipeline configurations can exceed js-yaml's default merge key limit.

## Objective

Add a configurable YAML merge key limit with a default value of 11,000 and pass it to pipeline and validator parsing.

## References
- https://github.com/screwdriver-cd/config-parser/pull/186
- https://github.com/screwdriver-cd/models/pull/676

These three PRs are designed to be backward-compatible, so merging them in any order should not cause failures. However, merging them in the numbered order—[1] config-parser, [2] models, and [3] screwdriver—is recommended to ensure the configuration is propagated correctly.

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.