### PR TITLE
feat(3508): add columns to tokens creation endpoints [3]

### DIFF
--- a/plugins/pipelines/tokens/create.js
+++ b/plugins/pipelines/tokens/create.js
@@ -63,6 +63,9 @@ module.exports = () => ({
             const token = await tokenFactory.create({
                 name: request.payload.name,
                 description: request.payload.description,
+                issuerId: user.id,
+                expiresAt: request.payload.expiresAt,
+                options: request.payload.options,
                 pipelineId
             });
 

--- a/plugins/tokens/create.js
+++ b/plugins/tokens/create.js
@@ -41,6 +41,9 @@ module.exports = () => ({
                             return tokenFactory.create({
                                 name: request.payload.name,
                                 description: request.payload.description,
+                                issuerId: user.id,
+                                expiresAt: request.payload.expiresAt,
+                                options: request.payload.options,
                                 userId: user.id
                             });
                         });

--- a/test/plugins/data/pipeline-tokens.json
+++ b/test/plugins/data/pipeline-tokens.json
@@ -4,5 +4,10 @@
     "description": "a token for pipeline API",
     "pipelineId": 123,
     "hash": "abcd",
-    "lastUsed": "2018-06-13T05:58:04.296Z"
+    "lastUsed": "2018-06-13T05:58:04.296Z",
+    "expiresAt": "2026-01-01T00:00:00.000Z",
+    "options": {
+        "permission": "read",
+        "resources": {}
+    }
 }

--- a/test/plugins/data/token.json
+++ b/test/plugins/data/token.json
@@ -4,5 +4,10 @@
     "description": "a token for a mobile app",
     "userId": 4321,
     "hash": "abcd",
-    "lastUsed": "2017-05-17T23:38:10.279Z"
+    "lastUsed": "2017-05-17T23:38:10.279Z",
+    "expiresAt": "2026-01-01T00:00:00.000Z",
+    "options": {
+        "permission": "read",
+        "resources": {}
+    }
 }

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -4079,6 +4079,7 @@ describe('pipeline plugin test', () => {
         const scmUri = 'github.com:12345:branchName';
         const name = 'pipeline token';
         const description = 'a token for pipeline API';
+        const expiresAt = '2026-01-01T00:00:00.000Z';
         let options;
         let pipelineMock;
         let userMock;
@@ -4089,7 +4090,12 @@ describe('pipeline plugin test', () => {
                 url: `/pipelines/${id}/tokens`,
                 payload: {
                     name,
-                    description
+                    description,
+                    expiresAt,
+                    options: {
+                        permission: 'read',
+                        resources: {}
+                    }
                 },
                 auth: {
                     credentials: {
@@ -4100,7 +4106,7 @@ describe('pipeline plugin test', () => {
                     strategy: ['token']
                 }
             };
-            userMock = getUserMock({ username, scmContext });
+            userMock = getUserMock({ id: 12345, username, scmContext });
             userMock.getPermissions.withArgs(scmUri).resolves({ admin: true });
             userFactoryMock.get.withArgs({ username, scmContext }).resolves(userMock);
             pipelineMock = getPipelineMocks(testPipeline);
@@ -4121,7 +4127,38 @@ describe('pipeline plugin test', () => {
                 assert.deepEqual(reply.result, testTokens);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
                 assert.equal(reply.statusCode, 201);
+                assert.calledWith(tokenFactoryMock.create, {
+                    ...options.payload,
+                    pipelineId: pipelineMock.id,
+                    issuerId: userMock.id
+                });
             }));
+
+        it('returns 201 and created new minimum token', () => {
+            options.payload = { name };
+
+            return server.inject(options).then(reply => {
+                const expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/${testTokens.id}`
+                };
+
+                assert.strictEqual(reply.result.id, testTokens.id);
+                assert.strictEqual(reply.result.name, testTokens.name);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.equal(reply.statusCode, 201);
+                assert.calledWith(tokenFactoryMock.create, {
+                    name,
+                    pipelineId: pipelineMock.id,
+                    issuerId: userMock.id,
+                    options: {},
+                    expiresAt: undefined,
+                    description: undefined
+                });
+            });
+        });
 
         it('returns 403 when user does not have admin permission', () => {
             const error = {

--- a/test/plugins/tokens.test.js
+++ b/test/plugins/tokens.test.js
@@ -107,8 +107,7 @@ describe('token plugin test', () => {
 
     describe('POST /tokens', () => {
         let options;
-        const { name } = testToken;
-        const { description } = testToken;
+        const { name, description, expiresAt, options: tokenOptions } = testToken;
 
         beforeEach(() => {
             options = {
@@ -116,7 +115,9 @@ describe('token plugin test', () => {
                 url: '/tokens',
                 payload: {
                     name,
-                    description
+                    description,
+                    expiresAt,
+                    options: tokenOptions
                 },
                 auth: {
                     credentials: {
@@ -146,7 +147,35 @@ describe('token plugin test', () => {
                 assert.equal(reply.statusCode, 201);
                 assert.deepEqual(reply.result, testTokenWithValue);
                 assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
-                assert.calledWith(tokenFactoryMock.create, { ...options.payload, userId });
+                assert.calledWith(tokenFactoryMock.create, { ...options.payload, userId, issuerId: userId });
+            });
+        });
+
+        it('returns 201 and correct minimum token data', () => {
+            options.payload = { name };
+
+            tokenMock = getTokenMock(testTokenWithValue);
+            tokenFactoryMock.create.resolves(tokenMock);
+
+            return server.inject(options).then(reply => {
+                const expectedLocation = {
+                    host: reply.request.headers.host,
+                    port: reply.request.headers.port,
+                    protocol: reply.request.server.info.protocol,
+                    pathname: `${options.url}/${testToken.id}`
+                };
+
+                assert.equal(reply.statusCode, 201);
+                assert.deepEqual(reply.result, testTokenWithValue);
+                assert.strictEqual(reply.headers.location, urlLib.format(expectedLocation));
+                assert.calledWith(tokenFactoryMock.create, {
+                    name,
+                    userId,
+                    issuerId: userId,
+                    options: {},
+                    expiresAt: undefined,
+                    description: undefined
+                });
             });
         });
 
@@ -202,7 +231,9 @@ describe('token plugin test', () => {
                     name: testToken.name,
                     description: testToken.description,
                     id: testToken.id,
-                    lastUsed: testToken.lastUsed
+                    lastUsed: testToken.lastUsed,
+                    expiresAt: testToken.expiresAt,
+                    options: testToken.options
                 }
             ];
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

https://github.com/screwdriver-cd/screwdriver/issues/3508

Please review the PR https://github.com/screwdriver-cd/data-schema/pull/618 first.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR allows to set `issuerId`, `expiresAt` and `options` to tokens table.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3508

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
