### PR TITLE
fix: upgrade js-yaml dependency paths to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "hapi-swagger": "^17.2.1",
     "ioredis": "^5.2.3",
     "joi": "^17.7.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.2.3",
     "jsonwebtoken": "^9.0.0",
     "lodash.isempty": "^4.4.0",
     "lodash.mergewith": "^4.6.2",
@@ -169,6 +169,9 @@
     "stream-to-promise": "^3.0.0"
   },
   "overrides": {
+    "@apidevtools/json-schema-ref-parser": {
+      "js-yaml": "^5.2.3"
+    },
     "screwdriver-datastore-sequelize": {
       "sequelize": {
         "uuid": "^11.1.1"


### PR DESCRIPTION
## Context

Snyk detected a vulnerability in js-yaml dependency paths used by the Screwdriver API.

## Objective

Upgrade js-yaml to v5.2.3 and override remaining json-schema-ref-parser dependency paths to use the fixed version.

Merge this PR after the updated command-validator, config-parser, executor-k8s, models, and template-validator packages are released.

## References

- https://github.com/screwdriver-cd/screwdriver/issues/3510
- https://github.com/screwdriver-cd/command-validator/pull/19
- https://github.com/screwdriver-cd/config-parser/pull/188
- https://github.com/screwdriver-cd/executor-k8s/pull/214
- https://github.com/screwdriver-cd/models/pull/679
- https://github.com/screwdriver-cd/template-validator/pull/44