### PR TITLE
feat(3508): enforce API token permissions and expiration

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -227,7 +227,13 @@ module.exports = async config => {
         server.app.buildFactory.apiUri = server.info.uri;
         server.app.buildFactory.tokenGen = (buildId, metadata, scmContext, expiresIn, scope = ['temporal']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile({ username: buildId, scmContext, scope, auth: { type: 'temporary' }, metadata }),
+                server.plugins.auth.generateProfile({
+                    username: buildId,
+                    scmContext,
+                    scope,
+                    auth: { type: 'temporary' },
+                    metadata
+                }),
                 expiresIn
             );
         server.app.buildFactory.executor.tokenGen = server.app.buildFactory.tokenGen;
@@ -236,7 +242,13 @@ module.exports = async config => {
         server.app.jobFactory.apiUri = server.info.uri;
         server.app.jobFactory.tokenGen = (username, metadata, scmContext, scope = ['user']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile({ username, scmContext, scope, auth: { type: 'temporary' }, metadata })
+                server.plugins.auth.generateProfile({
+                    username,
+                    scmContext,
+                    scope,
+                    auth: { type: 'temporary' },
+                    metadata
+                })
             );
         server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -227,7 +227,7 @@ module.exports = async config => {
         server.app.buildFactory.apiUri = server.info.uri;
         server.app.buildFactory.tokenGen = (buildId, metadata, scmContext, expiresIn, scope = ['temporal']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile({ username: buildId, scmContext, scope, metadata }),
+                server.plugins.auth.generateProfile({ username: buildId, scmContext, scope, auth: { type: 'temporary' }, metadata }),
                 expiresIn
             );
         server.app.buildFactory.executor.tokenGen = server.app.buildFactory.tokenGen;
@@ -236,7 +236,7 @@ module.exports = async config => {
         server.app.jobFactory.apiUri = server.info.uri;
         server.app.jobFactory.tokenGen = (username, metadata, scmContext, scope = ['user']) =>
             server.plugins.auth.generateToken(
-                server.plugins.auth.generateProfile({ username, scmContext, scope, metadata })
+                server.plugins.auth.generateProfile({ username, scmContext, scope, auth: { type: 'temporary' }, metadata })
             );
         server.app.jobFactory.executor.userTokenGen = server.app.jobFactory.tokenGen;
 

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -106,8 +106,8 @@ const authPlugin = {
          * @return {Object}                     The profile to be stored in jwt and/or cookie
          */
         server.expose('generateProfile', config => {
-            const { username, scmUserId, scmContext, scope, metadata } = config;
-            const profile = { username, scmContext, scmUserId, scope, ...(metadata || {}) };
+            const { username, scmUserId, scmContext, scope, auth, options, metadata } = config;
+            const profile = { username, scmContext, scmUserId, scope, auth, ...(options || {}), ...(metadata || {}) };
 
             if (pluginOptions.jwtEnvironment) {
                 profile.environment = pluginOptions.jwtEnvironment;
@@ -228,7 +228,13 @@ const authPlugin = {
                             username: user.username,
                             scmUserId: scmUser.id,
                             scmContext: user.scmContext,
-                            scope: ['user']
+                            scope: ['user'],
+                            auth: {
+                                type: 'api_token',
+                                apiTokenId: token.id,
+                                apiTokenType: 'user'
+                            },
+                            ...(token.options || {})
                         };
 
                         const scmDisplayName = scm.getDisplayName({ scmContext: profile.scmContext });
@@ -256,7 +262,13 @@ const authPlugin = {
                             username: admin.username,
                             scmContext: pipeline.scmContext,
                             pipelineId: token.pipelineId,
-                            scope: ['pipeline']
+                            scope: ['pipeline'],
+                            auth: {
+                                type: 'api_token',
+                                apiTokenId: token.id,
+                                apiTokenType: 'pipeline'
+                            },
+                            ...(token.options || {})
                         };
                     }
                     if (!profile) {

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -9,6 +9,7 @@ const keyRoute = require('./key');
 const loginRoute = require('./login');
 const logoutRoute = require('./logout');
 const tokenRoute = require('./token');
+const boom = require('@hapi/boom');
 
 const DEFAULT_TIMEOUT = 2 * 60; // 2h in minutes
 const ALGORITHM = 'RS256';
@@ -93,6 +94,55 @@ const authPlugin = {
     name: 'auth',
     async register(server, options) {
         const pluginOptions = joi.attempt(options, AUTH_PLUGIN_SCHEMA, 'Invalid config for plugin-auth');
+
+        server.ext('onPostAuth', (request, h) => {
+            const { tokenFactory } = request.server.app;
+
+            const permissionLevels = {
+                read: 1,
+                execute: 2,
+                write: 3,
+                all: 4
+            };
+
+            const authSettings = request.route.settings.plugins?.authorization;
+
+            if (!authSettings) {
+                return h.continue;
+            }
+
+            if (!request.auth.isAuthenticated) {
+                throw boom.unauthorized();
+            }
+
+            const credentials = request.auth.credentials;
+
+            if (credentials.auth.type !== 'api_token') {
+                return h.continue;
+            }
+
+            const apiTokenId = credentials.auth.apiTokenId;
+            const token = await tokenFactory.get({ id: apiTokenId });
+
+            if (token.expiresAt && new Date(token.expiresAt) < new Date()) {
+                throw boom.forbidden(`Your token is expired: token id ${token.auth.apiTokenId}`);
+            }
+
+            const actualPermission = credentials.permission || 'all';
+            const requiredPermission = authSettings.permission;
+
+            if (
+                !permissionLevels[actualPermission] ||
+                permissionLevels[actualPermission] <
+                permissionLevels[requiredPermission]
+            ) {
+                throw boom.forbidden(
+                `This endpoint requires "${requiredPermission}" permission`
+                );
+            }
+
+            return h.continue;
+        });
 
         /**
          * Generates a profile for storage in cookie and jwt

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const boom = require('@hapi/boom');
 const joi = require('joi');
 const jwt = require('jsonwebtoken');
 const { v4: uuidv4 } = require('uuid');
@@ -9,7 +10,6 @@ const keyRoute = require('./key');
 const loginRoute = require('./login');
 const logoutRoute = require('./logout');
 const tokenRoute = require('./token');
-const boom = require('@hapi/boom');
 
 const DEFAULT_TIMEOUT = 2 * 60; // 2h in minutes
 const ALGORITHM = 'RS256';
@@ -122,11 +122,13 @@ const authPlugin = {
             }
 
             const apiTokenId = credentials.auth.apiTokenId;
+
             if (!apiTokenId) {
                 throw boom.forbidden(`Your token is invalid`);
             }
 
             const token = await tokenFactory.get({ id: apiTokenId });
+
             if (!token) {
                 throw boom.forbidden(`Your token is invalid`);
             }
@@ -159,12 +161,22 @@ const authPlugin = {
          * @param  {String}   config.scmUserId  User ID in the SCM
          * @param  {String}   config.scmContext Scm to which the person logged in belongs
          * @param  {Array}    config.scope      Scope for this profile (usually build or user)
+         * @param  {Object}   config.auth       Authentication method information
+         * @param  {Object}   config.options    Additional token options
          * @param  {Object}   config.metadata   Additional information to tag along with the login
          * @return {Object}                     The profile to be stored in jwt and/or cookie
          */
         server.expose('generateProfile', config => {
-            const { username, scmUserId, scmContext, scope, auth, options, metadata } = config;
-            const profile = { username, scmContext, scmUserId, scope, auth, ...(options || {}), ...(metadata || {}) };
+            const { username, scmUserId, scmContext, scope, auth, options: profileOptions, metadata } = config;
+            const profile = {
+                username,
+                scmContext,
+                scmUserId,
+                scope,
+                auth,
+                ...(profileOptions || {}),
+                ...(metadata || {})
+            };
 
             if (pluginOptions.jwtEnvironment) {
                 profile.environment = pluginOptions.jwtEnvironment;

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -95,7 +95,7 @@ const authPlugin = {
     async register(server, options) {
         const pluginOptions = joi.attempt(options, AUTH_PLUGIN_SCHEMA, 'Invalid config for plugin-auth');
 
-        server.ext('onPostAuth', (request, h) => {
+        server.ext('onPostAuth', async (request, h) => {
             const { tokenFactory } = request.server.app;
 
             const permissionLevels = {
@@ -105,7 +105,7 @@ const authPlugin = {
                 all: 4
             };
 
-            const authSettings = request.route.settings.plugins?.authorization;
+            const authSettings = request.route.settings.plugins ? request.route.settings.plugins.authorization : null;
 
             if (!authSettings) {
                 return h.continue;
@@ -117,28 +117,35 @@ const authPlugin = {
 
             const credentials = request.auth.credentials;
 
-            if (credentials.auth.type !== 'api_token') {
+            if (!credentials.auth || credentials.auth.type !== 'api_token') {
                 return h.continue;
             }
 
             const apiTokenId = credentials.auth.apiTokenId;
+            if (!apiTokenId) {
+                throw boom.forbidden(`Your token is invalid`);
+            }
+
             const token = await tokenFactory.get({ id: apiTokenId });
+            if (!token) {
+                throw boom.forbidden(`Your token is invalid`);
+            }
 
             if (token.expiresAt && new Date(token.expiresAt) < new Date()) {
-                throw boom.forbidden(`Your token is expired: token id ${token.auth.apiTokenId}`);
+                throw boom.forbidden(`Your token is expired: token id ${apiTokenId}`);
             }
 
             const actualPermission = credentials.permission || 'all';
             const requiredPermission = authSettings.permission;
+            const actualPermissionLevel = permissionLevels[actualPermission];
+            const requiredPermissionLevel = permissionLevels[requiredPermission];
 
-            if (
-                !permissionLevels[actualPermission] ||
-                permissionLevels[actualPermission] <
-                permissionLevels[requiredPermission]
-            ) {
-                throw boom.forbidden(
-                `This endpoint requires "${requiredPermission}" permission`
-                );
+            if (!requiredPermissionLevel) {
+                throw boom.badImplementation(`Invalid required permission: "${requiredPermission}"`);
+            }
+
+            if (!actualPermissionLevel || actualPermissionLevel < requiredPermissionLevel) {
+                throw boom.forbidden(`This endpoint requires "${requiredPermission}" permission`);
             }
 
             return h.continue;

--- a/plugins/auth/login.js
+++ b/plugins/auth/login.js
@@ -35,6 +35,12 @@ function addGuestRoute(config) {
                     const profile = request.server.plugins.auth.generateProfile({
                         username,
                         scope: ['user', 'guest'],
+                        auth: {
+                            type: 'temporary'
+                        },
+                        options: {
+                            permission: 'read'
+                        },
                         metadata: {}
                     });
 
@@ -92,6 +98,12 @@ function addOAuthRoutes(config) {
                     scmUserId,
                     scmContext,
                     scope: ['user'],
+                    auth: {
+                        type: 'oauth'
+                    },
+                    options: {
+                        permission: 'all'
+                    },
                     metadata: {}
                 });
                 const scmDisplayName = await userFactory.scm.getDisplayName({ scmContext });

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -45,7 +45,10 @@ module.exports = () => ({
                 profile = request.server.plugins.auth.generateProfile({
                     username: request.params.buildId,
                     scmContext: pipeline.scmContext,
-                    scope: ['build', 'impersonated']
+                    scope: ['build', 'impersonated'],
+                    auth: {
+                        type: 'temporary'
+                    }
                 });
                 profile.token = request.server.plugins.auth.generateToken(profile);
 

--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -58,6 +58,9 @@ module.exports = () => ({
                             username: profile.username,
                             scmContext: profile.scmContext,
                             scope: ['build'],
+                            auth: {
+                                type: 'temporary'
+                            },
                             metadata: jwtInfo
                         }),
                         parseInt(buildTimeout, 10)

--- a/plugins/pipelines/admins/get.js
+++ b/plugins/pipelines/admins/get.js
@@ -44,7 +44,13 @@ module.exports = () => ({
                     const profile = request.server.plugins.auth.generateProfile({
                         username: admin.username,
                         scmContext: admin.scmContext,
-                        scope: ['user']
+                        scope: ['user'],
+                        auth: {
+                            type: 'temporary'
+                        },
+                        options: {
+                            permission: 'all'
+                        }
                     });
 
                     admin.userToken = request.server.plugins.auth.generateToken(profile);

--- a/plugins/pipelines/caches/request.js
+++ b/plugins/pipelines/caches/request.js
@@ -40,7 +40,10 @@ async function invoke(request) {
             username,
             scmContext,
             scope: ['sdapi'],
-            metadata: { pipelineId }
+            metadata: { pipelineId },
+            auth: {
+                type: 'temporary'
+            }
         })
     );
 

--- a/plugins/pipelines/get.js
+++ b/plugins/pipelines/get.js
@@ -19,7 +19,7 @@ module.exports = () => ({
         },
         plugins: {
             authorization: {
-                permission: 'read',
+                permission: 'read'
             }
         },
 

--- a/plugins/pipelines/get.js
+++ b/plugins/pipelines/get.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read',
+            }
+        },
 
         handler: async (request, h) => {
             const { canAccessPipeline } = request.server.plugins.pipelines;

--- a/plugins/users/get.js
+++ b/plugins/users/get.js
@@ -42,7 +42,13 @@ module.exports = () => ({
                 const profile = request.server.plugins.auth.generateProfile({
                     username: user.username,
                     scmContext: user.scmContext,
-                    scope: ['user']
+                    scope: ['user'],
+                    auth: {
+                        type: 'temporary'
+                    },
+                    options: {
+                        permission: 'all'
+                    }
                 });
 
                 user.userToken = request.server.plugins.auth.generateToken(profile);

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -113,6 +113,10 @@ describe('server case', () => {
         });
 
         it('populates server.app values', () => {
+            const buildMetadata = { buildId: 123 };
+            const jobMetadata = { jobId: 456 };
+            const scmContext = 'github:github.com';
+
             Assert.isObject(server.app);
             Assert.strictEqual(server.app.triggerFactory, 'trigger');
             Assert.strictEqual(server.app.pipelineFactory, 'pipeline');
@@ -121,14 +125,30 @@ describe('server case', () => {
             Assert.match(server.app.buildFactory.apiUri, /^http(s)?:\/\/[^:]+:12347$/);
             Assert.match(server.app.jobFactory.apiUri, /^http(s)?:\/\/[^:]+:12347$/);
             Assert.isFunction(server.app.buildFactory.tokenGen);
-            Assert.strictEqual(server.app.buildFactory.tokenGen('bar'), 'foo');
+            Assert.strictEqual(server.app.buildFactory.tokenGen('123', buildMetadata, scmContext, 60), 'foo');
+            sinon.assert.calledWithExactly(server.plugins.auth.generateProfile, {
+                username: '123',
+                scmContext,
+                scope: ['temporal'],
+                auth: { type: 'temporary' },
+                metadata: buildMetadata
+            });
+            sinon.assert.calledWithExactly(server.plugins.auth.generateToken, 'bar', 60);
             Assert.isObject(server.app.jobFactory);
             Assert.isFunction(server.app.jobFactory.tokenGen);
-            Assert.strictEqual(server.app.jobFactory.tokenGen('bar'), 'foo');
+            Assert.strictEqual(server.app.jobFactory.tokenGen('batman', jobMetadata, scmContext), 'foo');
+            sinon.assert.calledWithExactly(server.plugins.auth.generateProfile, {
+                username: 'batman',
+                scmContext,
+                scope: ['user'],
+                auth: { type: 'temporary' },
+                metadata: jobMetadata
+            });
+            sinon.assert.calledWithExactly(server.plugins.auth.generateToken, 'bar');
             Assert.isFunction(server.app.buildFactory.executor.tokenGen);
-            Assert.strictEqual(server.app.buildFactory.executor.tokenGen('bar'), 'foo');
+            Assert.strictEqual(server.app.buildFactory.executor.tokenGen, server.app.buildFactory.tokenGen);
             Assert.isFunction(server.app.jobFactory.executor.userTokenGen);
-            Assert.strictEqual(server.app.jobFactory.executor.userTokenGen('bar'), 'foo');
+            Assert.strictEqual(server.app.jobFactory.executor.userTokenGen, server.app.jobFactory.tokenGen);
         });
     });
 

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -783,9 +783,7 @@ describe('auth plugin test', () => {
                     type: 'api_token',
                     apiTokenType: 'user'
                 },
-                options: {
-                    permission: 'all',
-                }
+                permission: 'all'
             });
             const reply = await injectJwt('/test/authorization/read', token);
 
@@ -805,9 +803,7 @@ describe('auth plugin test', () => {
                     apiTokenId: missingTokenId,
                     apiTokenType: 'user'
                 },
-                options: {
-                    permission: 'all',
-                }
+                permission: 'all'
             });
 
             tokenFactoryMock.get.withArgs({ id: missingTokenId }).resolves(null);
@@ -829,9 +825,7 @@ describe('auth plugin test', () => {
                     apiTokenId,
                     apiTokenType: 'user'
                 },
-                options: {
-                    permission: 'invalid',
-                }
+                permission: 'invalid'
             });
 
             tokenFactoryMock.get.withArgs({ id: apiTokenId }).resolves({ id: apiTokenId });

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -852,6 +852,25 @@ describe('auth plugin test', () => {
                     assert.isOk(reply.headers.location.match(/auth\/token/), 'Redirects to token');
                 }));
 
+            it('issues a temporary JWT with read permission', async () => {
+                const loginReply = await server.inject('/auth/login/guest');
+                const sessionCookie = loginReply.headers['set-cookie']
+                    .find(cookie => cookie.startsWith('sid='))
+                    .split(';')[0];
+                const tokenReply = await server.inject({
+                    url: '/auth/token',
+                    headers: {
+                        cookie: sessionCookie
+                    }
+                });
+                const decoded = jwt.decode(tokenReply.result.token);
+
+                assert.equal(tokenReply.statusCode, 200);
+                assert.match(decoded.username, /^guest\//);
+                assert.deepEqual(decoded.auth, { type: 'temporary' });
+                assert.equal(decoded.permission, 'read');
+            });
+
             it('creates a user tries to close a window', () => {
                 const webOptions = hoek.clone(options);
 
@@ -1081,6 +1100,27 @@ describe('auth plugin test', () => {
                     assert.calledOnce(userMock.update);
                     assert.notCalled(userFactoryMock.create);
                 }));
+
+            it('issues an OAuth JWT with all permission', async () => {
+                const loginReply = await server.inject(options);
+                const sessionCookie = loginReply.headers['set-cookie']
+                    .find(cookie => cookie.startsWith('sid='))
+                    .split(';')[0];
+                const tokenReply = await server.inject({
+                    url: '/auth/token',
+                    headers: {
+                        cookie: sessionCookie
+                    }
+                });
+                const decoded = jwt.decode(tokenReply.result.token);
+
+                assert.equal(tokenReply.statusCode, 200);
+                assert.equal(decoded.username, username);
+                assert.equal(decoded.scmUserId, scmUserId);
+                assert.equal(decoded.scmContext, scmContext);
+                assert.deepEqual(decoded.auth, { type: 'oauth' });
+                assert.equal(decoded.permission, 'all');
+            });
 
             describe('ghe cloud', () => {
                 beforeEach(async () => {

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -514,6 +514,332 @@ describe('auth plugin test', () => {
         });
     });
 
+    describe('onPostAuth authorization', () => {
+        const apiTokenId = 123;
+        const apiTokenValue = 'aUserApiToken';
+        const user = {
+            id: 456,
+            username: 'batman',
+            scmContext: 'github:github.com',
+            token: 'oauthToken'
+        };
+
+        beforeEach(() => {
+            server.route([
+                {
+                    method: 'GET',
+                    path: '/test/no-authorization',
+                    options: {
+                        auth: false,
+                        handler: () => ({ ok: true })
+                    }
+                },
+                {
+                    method: 'GET',
+                    path: '/test/authorization/unauthenticated',
+                    options: {
+                        auth: false,
+                        plugins: {
+                            authorization: {
+                                permission: 'read'
+                            }
+                        },
+                        handler: () => ({ ok: true })
+                    }
+                },
+                {
+                    method: 'GET',
+                    path: '/test/authorization/read',
+                    options: {
+                        auth: {
+                            strategies: ['token'],
+                            scope: ['user']
+                        },
+                        plugins: {
+                            authorization: {
+                                permission: 'read'
+                            }
+                        },
+                        handler: () => ({ ok: true })
+                    }
+                },
+                {
+                    method: 'GET',
+                    path: '/test/authorization/write',
+                    options: {
+                        auth: {
+                            strategies: ['token'],
+                            scope: ['user']
+                        },
+                        plugins: {
+                            authorization: {
+                                permission: 'write'
+                            }
+                        },
+                        handler: () => ({ ok: true })
+                    }
+                },
+                {
+                    method: 'GET',
+                    path: '/test/authorization/invalid',
+                    options: {
+                        auth: {
+                            strategies: ['token'],
+                            scope: ['user']
+                        },
+                        plugins: {
+                            authorization: {
+                                permission: 'invalid'
+                            }
+                        },
+                        handler: () => ({ ok: true })
+                    }
+                }
+            ]);
+        });
+
+        const issueApiTokenJwt = async (permission, expiresAt) => {
+            const tokenMock = {
+                id: apiTokenId,
+                userId: user.id,
+                options: null
+            };
+
+            if (permission) {
+                tokenMock.options = { permission };
+            }
+
+            if (expiresAt) {
+                tokenMock.expiresAt = expiresAt;
+            }
+
+            const userMock = getUserMock(user);
+
+            userFactoryMock.get.resolves(userMock);
+            tokenFactoryMock.get.withArgs({ value: apiTokenValue }).resolves(tokenMock);
+            tokenFactoryMock.get.withArgs({ id: apiTokenId }).resolves(tokenMock);
+            collectionFactoryMock.list.resolves([{}]);
+            scm.decorateAuthor.resolves({ id: 1315 });
+
+            const reply = await server.inject({
+                url: `/auth/token?api_token=${apiTokenValue}`
+            });
+
+            assert.equal(reply.statusCode, 200);
+            assert.ok(reply.result.token);
+
+            const decoded = jwt.decode(reply.result.token);
+
+            assert.deepEqual(decoded.auth, {
+                type: 'api_token',
+                apiTokenId,
+                apiTokenType: 'user'
+            });
+
+            if (permission) {
+                assert.equal(decoded.permission, permission);
+            } else {
+                assert.notProperty(decoded, 'permission');
+            }
+
+            return reply.result.token;
+        };
+
+        const injectJwt = (url, token) =>
+            server.inject({
+                url,
+                headers: {
+                    authorization: `Bearer ${token}`
+                }
+            });
+
+        it('allows an unauthenticated endpoint without authorization settings', async () => {
+            const reply = await server.inject('/test/no-authorization');
+
+            assert.equal(reply.statusCode, 200);
+            assert.notCalled(tokenFactoryMock.get);
+        });
+
+        it('rejects an unauthenticated request when authorization settings exist', async () => {
+            const reply = await server.inject('/test/authorization/unauthenticated');
+
+            assert.equal(reply.statusCode, 401);
+            assert.notCalled(tokenFactoryMock.get);
+        });
+
+        it('allows an OAuth JWT without applying API Token permission checks', async () => {
+            const profile = server.plugins.auth.generateProfile({
+                username: 'robin',
+                scmUserId: 1357,
+                scmContext: 'github:github.com',
+                scope: ['user'],
+                auth: {
+                    type: 'oauth'
+                },
+                options: {
+                    permission: 'all'
+                },
+                metadata: {}
+            });
+            const oauthJwt = server.plugins.auth.generateToken(profile);
+            const reply = await injectJwt('/test/authorization/write', oauthJwt);
+
+            assert.equal(reply.statusCode, 200);
+            assert.notCalled(tokenFactoryMock.get);
+        });
+
+        it('allows a temporary guest JWT without applying API Token permission checks', async () => {
+            const profile = server.plugins.auth.generateProfile({
+                username: 'guest/123',
+                scope: ['user', 'guest'],
+                auth: {
+                    type: 'temporary'
+                },
+                options: {
+                    permission: 'read'
+                },
+                metadata: {}
+            });
+            const guestJwt = server.plugins.auth.generateToken(profile);
+            const reply = await injectJwt('/test/authorization/write', guestJwt);
+
+            assert.equal(reply.statusCode, 200);
+            assert.notCalled(tokenFactoryMock.get);
+        });
+
+        it('allows a JWT issued before the auth claim was added', async () => {
+            const oldJwt = server.plugins.auth.generateToken({
+                username: 'batman',
+                scmContext: 'github:github.com',
+                scope: ['user']
+            });
+            const reply = await injectJwt('/test/authorization/write', oldJwt);
+
+            assert.equal(reply.statusCode, 200);
+            assert.notCalled(tokenFactoryMock.get);
+        });
+
+        it('allows a read API Token JWT on an endpoint requiring read', async () => {
+            const token = await issueApiTokenJwt('read');
+            const reply = await injectJwt('/test/authorization/read', token);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('allows an all API Token JWT on an endpoint requiring read', async () => {
+            const token = await issueApiTokenJwt('all');
+            const reply = await injectJwt('/test/authorization/read', token);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('treats a legacy API Token JWT without permission as all on an endpoint requiring read', async () => {
+            const token = await issueApiTokenJwt();
+            const reply = await injectJwt('/test/authorization/read', token);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('rejects an expired API Token JWT', async () => {
+            const token = await issueApiTokenJwt('read', '2000-01-01T00:00:00.000Z');
+            const reply = await injectJwt('/test/authorization/read', token);
+
+            assert.equal(reply.statusCode, 403);
+            assert.equal(reply.result.message, `Your token is expired: token id ${apiTokenId}`);
+        });
+
+        it('rejects a read API Token JWT on an endpoint requiring write', async () => {
+            const token = await issueApiTokenJwt('read');
+            const reply = await injectJwt('/test/authorization/write', token);
+
+            assert.equal(reply.statusCode, 403);
+            assert.equal(reply.result.message, 'This endpoint requires "write" permission');
+        });
+
+        it('allows an all API Token JWT on an endpoint requiring write', async () => {
+            const token = await issueApiTokenJwt('all', '2999-01-01T00:00:00.000Z');
+            const reply = await injectJwt('/test/authorization/write', token);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('treats a legacy API Token JWT without permission as all on an endpoint requiring write', async () => {
+            const token = await issueApiTokenJwt();
+            const reply = await injectJwt('/test/authorization/write', token);
+
+            assert.equal(reply.statusCode, 200);
+        });
+
+        it('returns an internal error for an invalid required permission', async () => {
+            const token = await issueApiTokenJwt('all');
+            const reply = await injectJwt('/test/authorization/invalid', token);
+
+            assert.equal(reply.statusCode, 500);
+        });
+
+        it('rejects an API Token JWT without an API Token ID', async () => {
+            const token = server.plugins.auth.generateToken({
+                username: 'batman',
+                scmContext: 'github:github.com',
+                scope: ['user'],
+                auth: {
+                    type: 'api_token',
+                    apiTokenType: 'user'
+                },
+                permission: 'all'
+            });
+            const reply = await injectJwt('/test/authorization/read', token);
+
+            assert.equal(reply.statusCode, 403);
+            assert.equal(reply.result.message, 'Your token is invalid');
+            assert.notCalled(tokenFactoryMock.get);
+        });
+
+        it('rejects an API Token JWT when its API Token no longer exists', async () => {
+            const missingTokenId = 999;
+            const token = server.plugins.auth.generateToken({
+                username: 'batman',
+                scmContext: 'github:github.com',
+                scope: ['user'],
+                auth: {
+                    type: 'api_token',
+                    apiTokenId: missingTokenId,
+                    apiTokenType: 'user'
+                },
+                permission: 'all'
+            });
+
+            tokenFactoryMock.get.withArgs({ id: missingTokenId }).resolves(null);
+
+            const reply = await injectJwt('/test/authorization/read', token);
+
+            assert.equal(reply.statusCode, 403);
+            assert.equal(reply.result.message, 'Your token is invalid');
+            assert.calledWith(tokenFactoryMock.get, { id: missingTokenId });
+        });
+
+        it('rejects an API Token JWT with an invalid actual permission', async () => {
+            const token = server.plugins.auth.generateToken({
+                username: 'batman',
+                scmContext: 'github:github.com',
+                scope: ['user'],
+                auth: {
+                    type: 'api_token',
+                    apiTokenId,
+                    apiTokenType: 'user'
+                },
+                permission: 'invalid'
+            });
+
+            tokenFactoryMock.get.withArgs({ id: apiTokenId }).resolves({ id: apiTokenId });
+
+            const reply = await injectJwt('/test/authorization/read', token);
+
+            assert.equal(reply.statusCode, 403);
+            assert.equal(reply.result.message, 'This endpoint requires "read" permission');
+        });
+    });
+
     describe('GET /auth/login/guest', () => {
         const options = {
             url: '/auth/login/guest'

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -676,9 +676,6 @@ describe('auth plugin test', () => {
                 auth: {
                     type: 'oauth'
                 },
-                options: {
-                    permission: 'all'
-                },
                 metadata: {}
             });
             const oauthJwt = server.plugins.auth.generateToken(profile);
@@ -786,7 +783,9 @@ describe('auth plugin test', () => {
                     type: 'api_token',
                     apiTokenType: 'user'
                 },
-                permission: 'all'
+                options: {
+                    permission: 'all',
+                }
             });
             const reply = await injectJwt('/test/authorization/read', token);
 
@@ -806,7 +805,9 @@ describe('auth plugin test', () => {
                     apiTokenId: missingTokenId,
                     apiTokenType: 'user'
                 },
-                permission: 'all'
+                options: {
+                    permission: 'all',
+                }
             });
 
             tokenFactoryMock.get.withArgs({ id: missingTokenId }).resolves(null);
@@ -828,7 +829,9 @@ describe('auth plugin test', () => {
                     apiTokenId,
                     apiTokenType: 'user'
                 },
-                permission: 'invalid'
+                options: {
+                    permission: 'invalid',
+                }
             });
 
             tokenFactoryMock.get.withArgs({ id: apiTokenId }).resolves({ id: apiTokenId });

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -1594,7 +1594,12 @@ describe('auth plugin test', () => {
                 expect(reply.result.token).to.be.a.jwt.and.deep.include({
                     username: 'batman',
                     scope: ['pipeline'],
-                    pipelineId: 12345
+                    pipelineId: 12345,
+                    auth: {
+                        type: 'api_token',
+                        apiTokenId: tokenId,
+                        apiTokenType: 'pipeline'
+                    }
                 });
             });
         });
@@ -1716,7 +1721,10 @@ describe('auth plugin test', () => {
 
                         expect(reply.result.token).to.be.a.jwt.and.deep.include({
                             username: '474ee9ee179b0ecf0bc27408079a0b15eda4c99d',
-                            scope: ['build', 'impersonated']
+                            scope: ['build', 'impersonated'],
+                            auth: {
+                                type: 'temporary'
+                            }
                         });
                     }));
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -8738,6 +8738,9 @@ describe('build plugin test', () => {
                     username: '12345',
                     scmContext: 'github:github.com',
                     scope: ['build'],
+                    auth: {
+                        type: 'temporary'
+                    },
                     metadata: {
                         isPR: false,
                         jobId: 1234,
@@ -8773,6 +8776,9 @@ describe('build plugin test', () => {
                     username: '12345',
                     scmContext: 'github:github.com',
                     scope: ['build'],
+                    auth: {
+                        type: 'temporary'
+                    },
                     metadata: {
                         isPR: false,
                         jobId: 1234,

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -182,11 +182,22 @@ describe('DELETE /pipelines/1234/caches', () => {
 
     describe('with cache strategy s3', () => {
         it('successfully deleting cache by id and scope', () => {
+            const profile = { username, scmContext };
+
+            generateProfileMock.returns(profile);
             mockRequestRetry.resolves({ statusCode: 204 });
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 204);
                 assert.calledOnce(mockRequestRetry);
+                assert.calledOnceWithExactly(generateProfileMock, {
+                    username,
+                    scmContext,
+                    scope: ['sdapi'],
+                    metadata: { pipelineId: id },
+                    auth: { type: 'temporary' }
+                });
+                assert.calledOnceWithExactly(generateTokenMock, profile);
             });
         });
 

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -848,6 +848,12 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('requires read permission', () => {
+            const route = server.table().find(r => r.path === '/pipelines/{id}' && r.method === 'get');
+
+            assert.equal(route.settings.plugins.authorization.permission, 'read');
+        });
+
         it('throws error not found when pipeline does not exist', () => {
             const error = {
                 statusCode: 404,

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -3758,7 +3758,13 @@ describe('pipeline plugin test', () => {
                 assert.calledWith(generateProfileMock, {
                     username: adminUser.username,
                     scmContext: adminUser.scmContext,
-                    scope: ['user']
+                    scope: ['user'],
+                    auth: {
+                        type: 'temporary'
+                    },
+                    options: {
+                        permission: 'all'
+                    }
                 });
                 assert.calledWith(generateTokenMock, profile);
             });

--- a/test/plugins/user.test.js
+++ b/test/plugins/user.test.js
@@ -381,7 +381,13 @@ describe('user plugin test', () => {
                 assert.calledWith(generateProfileMock, {
                     username: userGithubSam.username,
                     scmContext: userGithubSam.scmContext,
-                    scope: ['user']
+                    scope: ['user'],
+                    auth: {
+                        type: 'temporary'
+                    },
+                    options: {
+                        permission: 'all'
+                    }
                 });
                 assert.calledWith(generateTokenMock, profile);
 


### PR DESCRIPTION
## Context
API Tokens can define expiration and permission settings, but these were not enforced when accessing API endpoints. JWTs also lacked authentication-source metadata needed to distinguish API Token, OAuth, and temporary authentication.

## Objective

- Add auth metadata to generated JWTs to identify their authentication source.
- Add API Token IDs, types, and permissions to API Token JWTs.
- Mark OAuth and temporary JWTs appropriately.
- Add an onPostAuth authorization check that:Confirms the underlying API 
  - Token still exists.
  - Rejects expired API Tokens.
  - Enforces the read < execute < write < all permission hierarchy.
  - Rejects invalid Token or route permission values.
- Require read permission for GET /pipelines/{id}.
  - Permission checks for other endpoints are scheduled to be added separately in a different PR.
- Preserve backward compatibility:
  - API Tokens without permission are treated as all.
  - OAuth, temporary, and JWTs issued before the auth claim was introduced retain their existing behavior.
  - Routes without authorization settings remain unaffected.
- Add coverage for authorization, backward compatibility, JWT generation paths, and invalid Token states.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3508

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
