### PR TITLE
feat(3508): configure API token permissions for event endpoints

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -18,6 +18,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'execute'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildFactory, jobFactory, eventFactory, pipelineFactory, userFactory } = request.server.app;

--- a/plugins/events/get.js
+++ b/plugins/events/get.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.eventFactory;

--- a/plugins/events/listBuilds.js
+++ b/plugins/events/listBuilds.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { eventFactory } = request.server.app;

--- a/plugins/events/listStageBuilds.js
+++ b/plugins/events/listStageBuilds.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { eventFactory } = request.server.app;

--- a/plugins/events/metrics.js
+++ b/plugins/events/metrics.js
@@ -19,6 +19,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.eventFactory;

--- a/plugins/events/stopBuilds.js
+++ b/plugins/events/stopBuilds.js
@@ -22,6 +22,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'execute'
+            }
+        },
 
         handler: async (request, h) => {
             const { eventFactory, pipelineFactory, userFactory, bannerFactory } = request.server.app;

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -181,6 +181,30 @@ describe('event plugin test', () => {
         assert.isOk(server.registrations.events);
     });
 
+    describe('authorization settings for event routes', () => {
+        const routesRequiringAuthorization = [
+            ['get', '/events/{id}', 'read'],
+            ['get', '/events/{id}/builds', 'read'],
+            ['get', '/events/{id}/stageBuilds', 'read'],
+            ['get', '/events/{id}/metrics', 'read'],
+            ['post', '/events', 'execute'],
+            ['put', '/events/{id}/stop', 'execute']
+        ];
+
+        it('sets the agreed permission on every authenticated event route', () => {
+            routesRequiringAuthorization.forEach(([method, path, permission]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.equal(
+                    route.settings.plugins.authorization.permission,
+                    permission,
+                    `${method.toUpperCase()} ${path} should require ${permission} permission`
+                );
+            });
+        });
+    });
+
     describe('GET /events/{id}', () => {
         const id = 12345;
 


### PR DESCRIPTION
## Context

Event routes must declare their required permission so that API token permissions are enforced consistently.

## Objective

Configure permissions for six authenticated event routes:

- Require `read` for event details, builds, stage builds, and metrics
- Require `execute` for event creation and build stopping
- Add tests for the route authorization settings

Existing route scopes and event-specific authorization remain unchanged.

## References

- [https://github.com/screwdriver-cd/screwdriver/issues/3508](https://github.com/screwdriver-cd/screwdriver/issues/3508)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.