### PR TITLE
feat(3508): configure API token permissions for runtime endpoints

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -115,13 +115,13 @@ const authPlugin = {
                 throw boom.unauthorized();
             }
 
-            const credentials = request.auth.credentials;
+            const { credentials } = request.auth;
 
             if (!credentials.auth || credentials.auth.type !== 'api_token') {
                 return h.continue;
             }
 
-            const apiTokenId = credentials.auth.apiTokenId;
+            const { apiTokenId } = credentials.auth;
 
             if (!apiTokenId) {
                 throw boom.forbidden(`Your token is invalid`);

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -35,9 +35,7 @@ module.exports = () => ({
             // Check Build ID impersonate
             if (request.params.buildId) {
                 if (!scope.includes('admin') || permission !== 'all') {
-                    return boom.forbidden(
-                        `User ${username} must be an admin with all permission to impersonate`
-                    );
+                    return boom.forbidden(`User ${username} must be an admin with all permission to impersonate`);
                 }
 
                 const build = await buildFactory.get(request.params.buildId);

--- a/plugins/auth/token.js
+++ b/plugins/auth/token.js
@@ -29,13 +29,15 @@ module.exports = () => ({
         },
         handler: async (request, h) => {
             let profile = request.auth.credentials;
-            const { scope, token, username } = profile;
+            const { scope, token, username, permission = 'all' } = profile;
             const { buildFactory, jobFactory, pipelineFactory } = request.server.app;
 
             // Check Build ID impersonate
             if (request.params.buildId) {
-                if (!scope.includes('admin')) {
-                    return boom.forbidden(`User ${username} is not an admin and cannot impersonate`);
+                if (!scope.includes('admin') || permission !== 'all') {
+                    return boom.forbidden(
+                        `User ${username} must be an admin with all permission to impersonate`
+                    );
                 }
 
                 const build = await buildFactory.get(request.params.buildId);

--- a/plugins/buildClusters/create.js
+++ b/plugins/buildClusters/create.js
@@ -15,6 +15,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildClusterFactory, bannerFactory } = request.server.app;

--- a/plugins/buildClusters/get.js
+++ b/plugins/buildClusters/get.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { name } = request.params;

--- a/plugins/buildClusters/list.js
+++ b/plugins/buildClusters/list.js
@@ -15,6 +15,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildClusterFactory } = request.server.app;

--- a/plugins/buildClusters/remove.js
+++ b/plugins/buildClusters/remove.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildClusterFactory, userFactory, bannerFactory } = request.server.app;

--- a/plugins/buildClusters/update.js
+++ b/plugins/buildClusters/update.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildClusterFactory, bannerFactory } = request.server.app;

--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -29,6 +29,11 @@ module.exports = config => ({
             strategies: ['session', 'token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (req, h) => {
             const artifact = req.params.name;

--- a/plugins/builds/artifacts/getAll.js
+++ b/plugins/builds/artifacts/getAll.js
@@ -28,6 +28,11 @@ module.exports = config => ({
             strategies: ['session', 'token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (req, h) => {
             const { name: artifact, id: buildId } = req.params;

--- a/plugins/builds/artifacts/unzip.js
+++ b/plugins/builds/artifacts/unzip.js
@@ -16,6 +16,11 @@ module.exports = config => ({
             strategies: ['token'],
             scope: ['user', 'build']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (req, h) => {
             if (!req.server.app.unzipArtifacts) {

--- a/plugins/builds/create.js
+++ b/plugins/builds/create.js
@@ -19,6 +19,9 @@ module.exports = () => ({
             'hapi-swagger': {
                 security: [{ token: [] }],
                 deprecated: true
+            },
+            authorization: {
+                permission: 'execute'
             }
         },
         handler: async (request, h) => {

--- a/plugins/builds/get.js
+++ b/plugins/builds/get.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildFactory } = request.server.app;

--- a/plugins/builds/getBuildStatuses.js
+++ b/plugins/builds/getBuildStatuses.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildFactory } = request.server.app;

--- a/plugins/builds/listSecrets.js
+++ b/plugins/builds/listSecrets.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.buildFactory;

--- a/plugins/builds/metrics.js
+++ b/plugins/builds/metrics.js
@@ -19,6 +19,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'build']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.buildFactory;

--- a/plugins/builds/steps/get.js
+++ b/plugins/builds/steps/get.js
@@ -15,6 +15,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { stepFactory } = request.server.app;

--- a/plugins/builds/steps/list.js
+++ b/plugins/builds/steps/list.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline', '!guest', 'temporal']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { stepFactory } = request.server.app;

--- a/plugins/builds/steps/logs.js
+++ b/plugins/builds/steps/logs.js
@@ -289,6 +289,11 @@ module.exports = config => ({
             strategies: ['token', 'session'],
             scope: ['user', 'pipeline', 'build']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: (req, h) => {
             const { credentials } = req.auth;

--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -14,11 +14,6 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['build', 'temporal']
         },
-        plugins: {
-            authorization: {
-                permission: 'all'
-            }
-        },
 
         handler: async (request, h) => {
             const { stepFactory } = request.server.app;

--- a/plugins/builds/steps/update.js
+++ b/plugins/builds/steps/update.js
@@ -14,6 +14,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['build', 'temporal']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { stepFactory } = request.server.app;

--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['temporal']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const profile = request.auth.credentials;

--- a/plugins/builds/token.js
+++ b/plugins/builds/token.js
@@ -17,11 +17,6 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['temporal']
         },
-        plugins: {
-            authorization: {
-                permission: 'all'
-            }
-        },
 
         handler: async (request, h) => {
             const profile = request.auth.credentials;

--- a/plugins/builds/update.js
+++ b/plugins/builds/update.js
@@ -90,6 +90,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['build', 'pipeline', 'user', '!guest', 'temporal']
         },
+        plugins: {
+            authorization: {
+                permission: 'execute'
+            }
+        },
 
         handler: async (request, h) => {
             const { buildFactory } = request.server.app;

--- a/plugins/coverage/info.js
+++ b/plugins/coverage/info.js
@@ -11,6 +11,11 @@ module.exports = config => ({
             strategies: ['token'],
             scope: ['user', 'build']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const data = await config.coveragePlugin.getInfo(request.query);

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -17,11 +17,6 @@ module.exports = config => ({
             strategies: ['token'],
             scope: ['build']
         },
-        plugins: {
-            authorization: {
-                permission: 'all'
-            }
-        },
 
         handler: async (request, h) => {
             const { jobFactory, pipelineFactory } = request.server.app;

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -17,6 +17,11 @@ module.exports = config => ({
             strategies: ['token'],
             scope: ['build']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { jobFactory, pipelineFactory } = request.server.app;

--- a/plugins/isAdmin.js
+++ b/plugins/isAdmin.js
@@ -21,6 +21,9 @@ const isAdminPlugin = {
                 plugins: {
                     'hapi-swagger': {
                         security: [{ token: [] }]
+                    },
+                    authorization: {
+                        permission: 'read'
                     }
                 },
                 handler: async (request, h) =>

--- a/plugins/jobs/buildCluster/remove.js
+++ b/plugins/jobs/buildCluster/remove.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { jobFactory, bannerFactory, userFactory, pipelineFactory } = request.server.app;

--- a/plugins/jobs/buildCluster/update.js
+++ b/plugins/jobs/buildCluster/update.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
         handler: async (request, h) => {
             const adminAnnotation = 'screwdriver.cd/sdAdminBuildClusterOverride';
             const { payload } = request;

--- a/plugins/jobs/get.js
+++ b/plugins/jobs/get.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.jobFactory;

--- a/plugins/jobs/lastSuccessfulMeta.js
+++ b/plugins/jobs/lastSuccessfulMeta.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.jobFactory;

--- a/plugins/jobs/latestBuild.js
+++ b/plugins/jobs/latestBuild.js
@@ -18,6 +18,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { jobFactory } = request.server.app;

--- a/plugins/jobs/listBuilds.js
+++ b/plugins/jobs/listBuilds.js
@@ -18,6 +18,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'pipeline', 'build']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.jobFactory;

--- a/plugins/jobs/metrics.js
+++ b/plugins/jobs/metrics.js
@@ -19,6 +19,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.jobFactory;

--- a/plugins/jobs/notify.js
+++ b/plugins/jobs/notify.js
@@ -18,6 +18,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { jobFactory, pipelineFactory } = request.server.app;

--- a/plugins/jobs/update.js
+++ b/plugins/jobs/update.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'write'
+            }
+        },
 
         handler: async (request, h) => {
             const { jobFactory, pipelineFactory, userFactory, bannerFactory } = request.server.app;

--- a/plugins/secrets/create.js
+++ b/plugins/secrets/create.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { pipelineFactory, secretFactory, userFactory } = request.server.app;

--- a/plugins/secrets/get.js
+++ b/plugins/secrets/get.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { secretFactory } = request.server.app;

--- a/plugins/secrets/remove.js
+++ b/plugins/secrets/remove.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { secretFactory } = request.server.app;

--- a/plugins/secrets/update.js
+++ b/plugins/secrets/update.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const factory = request.server.app.secretFactory;

--- a/plugins/stages/get.js
+++ b/plugins/stages/get.js
@@ -17,6 +17,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', 'build', 'pipeline']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { stageFactory } = request.server.app;

--- a/plugins/stages/stageBuilds/list.js
+++ b/plugins/stages/stageBuilds/list.js
@@ -18,6 +18,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { stageFactory, stageBuildFactory } = request.server.app;

--- a/plugins/tokens/create.js
+++ b/plugins/tokens/create.js
@@ -15,6 +15,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { tokenFactory } = request.server.app;

--- a/plugins/tokens/list.js
+++ b/plugins/tokens/list.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'read'
+            }
+        },
 
         handler: async (request, h) => {
             const { userFactory } = request.server.app;

--- a/plugins/tokens/refresh.js
+++ b/plugins/tokens/refresh.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { tokenFactory } = request.server.app;

--- a/plugins/tokens/remove.js
+++ b/plugins/tokens/remove.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { tokenFactory } = request.server.app;

--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -16,6 +16,11 @@ module.exports = () => ({
             strategies: ['token'],
             scope: ['user', '!guest']
         },
+        plugins: {
+            authorization: {
+                permission: 'all'
+            }
+        },
 
         handler: async (request, h) => {
             const { tokenFactory } = request.server.app;

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -1781,7 +1781,7 @@ describe('auth plugin test', () => {
                 });
             });
 
-            it('returns admin impersonated build token', () =>
+            it('returns admin impersonated build token with all permission', () =>
                 server
                     .inject({
                         url: '/auth/token/474ee9ee179b0ecf0bc27408079a0b15eda4c99d',
@@ -1789,7 +1789,8 @@ describe('auth plugin test', () => {
                             credentials: {
                                 username: 'batman',
                                 scmContext,
-                                scope: ['user', 'admin']
+                                scope: ['user', 'admin'],
+                                permission: 'all'
                             },
                             strategy: ['token']
                         }
@@ -1807,6 +1808,43 @@ describe('auth plugin test', () => {
                                 type: 'temporary'
                             }
                         });
+                    }));
+
+            it('returns admin impersonated build token for a legacy JWT without permission', () =>
+                server
+                    .inject({
+                        url: '/auth/token/474ee9ee179b0ecf0bc27408079a0b15eda4c99d',
+                        auth: {
+                            credentials: {
+                                username: 'batman',
+                                scmContext,
+                                scope: ['user', 'admin']
+                            },
+                            strategy: ['token']
+                        }
+                    })
+                    .then(reply => {
+                        assert.equal(reply.statusCode, 200, 'Login route should be available');
+                        assert.ok(reply.result.token, 'Token not returned');
+                    }));
+
+            it('returns forbidden for an admin without all permission attempting to impersonate', () =>
+                server
+                    .inject({
+                        url: '/auth/token/474ee9ee179b0ecf0bc27408079a0b15eda4c99d',
+                        auth: {
+                            credentials: {
+                                username: 'batman',
+                                scmContext,
+                                scope: ['user', 'admin'],
+                                permission: 'read'
+                            },
+                            strategy: ['token']
+                        }
+                    })
+                    .then(reply => {
+                        assert.equal(reply.statusCode, 403, 'Login route should be unavailable');
+                        assert.notOk(reply.result.token, 'Token should not be returned');
                     }));
 
             it('returns forbidden for non-admin attempting to impersonate', () =>

--- a/test/plugins/buildClusters.test.js
+++ b/test/plugins/buildClusters.test.js
@@ -133,6 +133,29 @@ describe('buildCluster plugin test', () => {
         assert.isOk(server.registrations.buildClusters);
     });
 
+    describe('authorization settings for build cluster routes', () => {
+        const routesRequiringAuthorization = [
+            ['get', '/buildclusters', 'read'],
+            ['get', '/buildclusters/{name}', 'read'],
+            ['post', '/buildclusters', 'all'],
+            ['put', '/buildclusters/{name}', 'all'],
+            ['delete', '/buildclusters/{name}', 'all']
+        ];
+
+        it('sets the agreed permission on every authenticated build cluster route', () => {
+            routesRequiringAuthorization.forEach(([method, path, permission]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.equal(
+                    route.settings.plugins.authorization.permission,
+                    permission,
+                    `${method.toUpperCase()} ${path} should require ${permission} permission`
+                );
+            });
+        });
+    });
+
     describe('GET /buildclusters', () => {
         let options;
 

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -310,12 +310,14 @@ describe('build plugin test', () => {
             ['get', '/builds/{id}/artifacts/{name*}', 'read'],
             ['post', '/builds', 'execute'],
             ['put', '/builds/{id}', 'execute'],
-            ['put', '/builds/{id}/steps/{name}', 'all'],
-            ['post', '/builds/{id}/token', 'all'],
             ['post', '/builds/{id}/artifacts/unzip', 'all']
         ];
+        const nonApiTokenRoutes = [
+            ['put', '/builds/{id}/steps/{name}'],
+            ['post', '/builds/{id}/token']
+        ];
 
-        it('sets the agreed permission on every authenticated build route', () => {
+        it('sets the agreed permission on every API Token-accessible build route', () => {
             routesRequiringAuthorization.forEach(([method, path, permission]) => {
                 const route = server.table().find(r => r.method === method && r.path === path);
 
@@ -325,6 +327,15 @@ describe('build plugin test', () => {
                     permission,
                     `${method.toUpperCase()} ${path} should require ${permission} permission`
                 );
+            });
+        });
+
+        it('does not set API Token permissions on Build or Temporal Token-only build routes', () => {
+            nonApiTokenRoutes.forEach(([method, path]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.notProperty(route.settings.plugins, 'authorization');
             });
         });
     });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -297,6 +297,38 @@ describe('build plugin test', () => {
         assert.isOk(server.registrations.builds);
     });
 
+    describe('authorization settings for build routes', () => {
+        const routesRequiringAuthorization = [
+            ['get', '/builds/{id}', 'read'],
+            ['get', '/builds/statuses', 'read'],
+            ['get', '/builds/{id}/steps/{name}/logs', 'read'],
+            ['get', '/builds/{id}/steps/{name}', 'read'],
+            ['get', '/builds/{id}/steps', 'read'],
+            ['get', '/builds/{id}/secrets', 'read'],
+            ['get', '/builds/{id}/metrics', 'read'],
+            ['get', '/builds/{id}/artifacts', 'read'],
+            ['get', '/builds/{id}/artifacts/{name*}', 'read'],
+            ['post', '/builds', 'execute'],
+            ['put', '/builds/{id}', 'execute'],
+            ['put', '/builds/{id}/steps/{name}', 'all'],
+            ['post', '/builds/{id}/token', 'all'],
+            ['post', '/builds/{id}/artifacts/unzip', 'all']
+        ];
+
+        it('sets the agreed permission on every authenticated build route', () => {
+            routesRequiringAuthorization.forEach(([method, path, permission]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.equal(
+                    route.settings.plugins.authorization.permission,
+                    permission,
+                    `${method.toUpperCase()} ${path} should require ${permission} permission`
+                );
+            });
+        });
+    });
+
     describe('GET /builds/{id}', () => {
         const id = 12345;
 

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -90,6 +90,26 @@ describe('coverage plugin test', () => {
         assert.isOk(server.registrations.coverage);
     });
 
+    describe('authorization settings for coverage routes', () => {
+        const routesRequiringAuthorization = [
+            ['get', '/coverage/info', 'read'],
+            ['get', '/coverage/token', 'all']
+        ];
+
+        it('sets the agreed permission on every authenticated coverage route', () => {
+            routesRequiringAuthorization.forEach(([method, path, permission]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.equal(
+                    route.settings.plugins.authorization.permission,
+                    permission,
+                    `${method.toUpperCase()} ${path} should require ${permission} permission`
+                );
+            });
+        });
+    });
+
     describe('GET /coverage/token', () => {
         let options;
         let pipelineMock;

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -91,12 +91,10 @@ describe('coverage plugin test', () => {
     });
 
     describe('authorization settings for coverage routes', () => {
-        const routesRequiringAuthorization = [
-            ['get', '/coverage/info', 'read'],
-            ['get', '/coverage/token', 'all']
-        ];
+        const routesRequiringAuthorization = [['get', '/coverage/info', 'read']];
+        const buildTokenOnlyRoutes = [['get', '/coverage/token']];
 
-        it('sets the agreed permission on every authenticated coverage route', () => {
+        it('sets the agreed permission on every API Token-accessible coverage route', () => {
             routesRequiringAuthorization.forEach(([method, path, permission]) => {
                 const route = server.table().find(r => r.method === method && r.path === path);
 
@@ -106,6 +104,15 @@ describe('coverage plugin test', () => {
                     permission,
                     `${method.toUpperCase()} ${path} should require ${permission} permission`
                 );
+            });
+        });
+
+        it('does not set API Token permissions on Build Token-only coverage routes', () => {
+            buildTokenOnlyRoutes.forEach(([method, path]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.notProperty(route.settings.plugins, 'authorization');
             });
         });
     });

--- a/test/plugins/isAdmin.test.js
+++ b/test/plugins/isAdmin.test.js
@@ -97,6 +97,13 @@ describe('isAdmin plugin test', () => {
         assert.isOk(server.registrations.isAdmin);
     });
 
+    it('requires read permission', () => {
+        const route = server.table().find(r => r.method === 'get' && r.path === '/isAdmin');
+
+        assert.isOk(route);
+        assert.equal(route.settings.plugins.authorization.permission, 'read');
+    });
+
     describe('GET /isAdmin?pipelineId=', () => {
         let options;
 

--- a/test/plugins/jobs.test.js
+++ b/test/plugins/jobs.test.js
@@ -189,6 +189,33 @@ describe('job plugin test', () => {
         assert.isOk(server.registrations.jobs);
     });
 
+    describe('authorization settings for job routes', () => {
+        const routesRequiringAuthorization = [
+            ['get', '/jobs/{id}', 'read'],
+            ['get', '/jobs/{id}/builds', 'read'],
+            ['get', '/jobs/{id}/lastSuccessfulMeta', 'read'],
+            ['get', '/jobs/{id}/metrics', 'read'],
+            ['get', '/jobs/{id}/latestBuild', 'read'],
+            ['put', '/jobs/{id}', 'write'],
+            ['post', '/jobs/{id}/notify', 'all'],
+            ['put', '/jobs/{id}/buildCluster', 'all'],
+            ['delete', '/jobs/{id}/buildCluster', 'all']
+        ];
+
+        it('sets the agreed permission on every authenticated job route', () => {
+            routesRequiringAuthorization.forEach(([method, path, permission]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.equal(
+                    route.settings.plugins.authorization.permission,
+                    permission,
+                    `${method.toUpperCase()} ${path} should require ${permission} permission`
+                );
+            });
+        });
+    });
+
     describe('GET /jobs/{id}', () => {
         const id = 1234;
 

--- a/test/plugins/secrets.test.js
+++ b/test/plugins/secrets.test.js
@@ -119,6 +119,28 @@ describe('secret plugin test', () => {
         assert.isOk(server.registrations.secrets);
     });
 
+    describe('authorization settings for secret routes', () => {
+        const routesRequiringAuthorization = [
+            ['get', '/secrets/{id}', 'read'],
+            ['post', '/secrets', 'all'],
+            ['put', '/secrets/{id}', 'all'],
+            ['delete', '/secrets/{id}', 'all']
+        ];
+
+        it('sets the agreed permission on every authenticated secret route', () => {
+            routesRequiringAuthorization.forEach(([method, path, permission]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.equal(
+                    route.settings.plugins.authorization.permission,
+                    permission,
+                    `${method.toUpperCase()} ${path} should require ${permission} permission`
+                );
+            });
+        });
+    });
+
     describe('POST /secrets', () => {
         let options;
         const scmUri = 'github.com:12345:branchName';

--- a/test/plugins/stages.test.js
+++ b/test/plugins/stages.test.js
@@ -80,6 +80,20 @@ describe('stage plugin test', () => {
         assert.isOk(server.registrations.stages);
     });
 
+    it('requires read permission for every route', () => {
+        const expectedRoutes = [
+            { method: 'get', path: '/stages/{id}' },
+            { method: 'get', path: '/stages/{id}/stageBuilds' }
+        ];
+
+        expectedRoutes.forEach(({ method, path }) => {
+            const route = server.table().find(r => r.method === method && r.path === path);
+
+            assert.isOk(route, `Route not found: ${method.toUpperCase()} ${path}`);
+            assert.equal(route.settings.plugins.authorization.permission, 'read');
+        });
+    });
+
     describe('GET /stages/{id}', () => {
         const id = 123;
         let options;

--- a/test/plugins/tokens.test.js
+++ b/test/plugins/tokens.test.js
@@ -105,6 +105,29 @@ describe('token plugin test', () => {
         assert.isOk(server.registrations.tokens);
     });
 
+    describe('authorization settings for token routes', () => {
+        const routesRequiringAuthorization = [
+            ['get', '/tokens', 'read'],
+            ['post', '/tokens', 'all'],
+            ['put', '/tokens/{id}', 'all'],
+            ['put', '/tokens/{id}/refresh', 'all'],
+            ['delete', '/tokens/{id}', 'all']
+        ];
+
+        it('sets the agreed permission on every authenticated token route', () => {
+            routesRequiringAuthorization.forEach(([method, path, permission]) => {
+                const route = server.table().find(r => r.method === method && r.path === path);
+
+                assert.isOk(route, `${method.toUpperCase()} ${path} should be registered`);
+                assert.equal(
+                    route.settings.plugins.authorization.permission,
+                    permission,
+                    `${method.toUpperCase()} ${path} should require ${permission} permission`
+                );
+            });
+        });
+    });
+
     describe('POST /tokens', () => {
         let options;
         const { name, description, expiresAt, options: tokenOptions } = testToken;


### PR DESCRIPTION
## Context

Authenticated runtime routes must declare their required permission so that limited API tokens cannot perform operations beyond their assigned role.

## Objective

Configure permissions for 42 routes across builds, jobs, stages, build clusters, secrets, tokens, coverage, and the admin check endpoint.

Additionally, require both Screwdriver administrator scope and `all` permission when generating an impersonated build token through `/auth/token/{buildId}`. Legacy JWTs without a permission value remain compatible.

Existing route scopes and resource-specific authorization remain unchanged. Tests are added for the configured permissions and build impersonation checks.

## References

- [https://github.com/screwdriver-cd/screwdriver/issues/3508](https://github.com/screwdriver-cd/screwdriver/issues/3508)

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.