### PR TITLE
fix: show pipeline badge when the pipeline has no events

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -115,13 +115,13 @@ const authPlugin = {
                 throw boom.unauthorized();
             }
 
-            const credentials = request.auth.credentials;
+            const { credentials } = request.auth;
 
             if (!credentials.auth || credentials.auth.type !== 'api_token') {
                 return h.continue;
             }
 
-            const apiTokenId = credentials.auth.apiTokenId;
+            const { apiTokenId } = credentials.auth;
 
             if (!apiTokenId) {
                 throw boom.forbidden(`Your token is invalid`);

--- a/plugins/pipelines/badge.js
+++ b/plugins/pipelines/badge.js
@@ -22,24 +22,24 @@ module.exports = config => ({
             const { pipelineFactory, eventFactory } = request.server.app;
             const pipelineId = request.params.id;
             const { statusColor } = config;
-            const badgeConfig = {
-                statusColor
-            };
             const contentType = 'image/svg+xml;charset=utf-8';
+            let label;
 
             try {
                 // Get pipeline
                 const pipeline = await pipelineFactory.get(pipelineId);
 
                 if (!pipeline) {
-                    return h.response(getPipelineBadge(badgeConfig)).header('Content-Type', contentType);
+                    return h.response(getPipelineBadge({ statusColor })).header('Content-Type', contentType);
                 }
+
+                label = pipeline.name;
 
                 // Get latest pipeline events
                 const latestEvents = await eventFactory.getPipelineTypeBuildEvents(pipelineId);
 
                 if (!latestEvents || Object.keys(latestEvents).length === 0) {
-                    return h.response(getPipelineBadge(badgeConfig)).header('Content-Type', contentType);
+                    return h.response(getPipelineBadge({ statusColor, label })).header('Content-Type', contentType);
                 }
 
                 // Only care about latest
@@ -47,26 +47,19 @@ module.exports = config => ({
                 const builds = await lastEvent.getBuilds({ readOnly: true, sortBy: 'id', sort: 'descending' });
 
                 if (!builds || builds.length < 1) {
-                    return h.response(getPipelineBadge(badgeConfig)).header('Content-Type', contentType);
+                    return h.response(getPipelineBadge({ statusColor, label })).header('Content-Type', contentType);
                 }
 
                 // Convert build statuses
                 const buildsStatus = builds.map(build => build.status.toLowerCase());
 
                 return h
-                    .response(
-                        getPipelineBadge(
-                            Object.assign(badgeConfig, {
-                                buildsStatus,
-                                label: pipeline.name
-                            })
-                        )
-                    )
+                    .response(getPipelineBadge({ statusColor, label, buildsStatus }))
                     .header('Content-Type', contentType);
             } catch (err) {
                 logger.error(`Failed to get badge for pipeline:${pipelineId}: ${err.message}`);
 
-                return h.response(getPipelineBadge(badgeConfig));
+                return h.response(getPipelineBadge({ statusColor, label }));
             }
         },
         validate: {

--- a/plugins/pipelines/jobBadge.js
+++ b/plugins/pipelines/jobBadge.js
@@ -3,6 +3,7 @@
 const joi = require('joi');
 const schema = require('screwdriver-data-schema');
 const idSchema = schema.models.pipeline.base.extract('id');
+const logger = require('screwdriver-logger');
 const { getJobBadge } = require('./helper');
 
 module.exports = config => ({
@@ -22,61 +23,55 @@ module.exports = config => ({
             const { pipelineFactory } = request.server.app;
             const { id, jobName } = request.params;
             const { statusColor } = config;
-            const badgeConfig = {
-                statusColor
-            };
             const contentType = 'image/svg+xml;charset=utf-8';
+            let label;
 
-            return Promise.all([
-                jobFactory.get({
-                    pipelineId: id,
-                    name: jobName
-                }),
-                pipelineFactory.get(id)
-            ])
-                .then(([job, pipeline]) => {
-                    if (!job) {
-                        return h.response(getJobBadge(badgeConfig)).header('Content-Type', contentType);
+            try {
+                const [job, pipeline] = await Promise.all([
+                    jobFactory.get({
+                        pipelineId: id,
+                        name: jobName
+                    }),
+                    pipelineFactory.get(id)
+                ]);
+
+                if (!pipeline) {
+                    return h.response(getJobBadge({ statusColor })).header('Content-Type', contentType);
+                }
+
+                label = pipeline.name;
+
+                if (!job) {
+                    return h.response(getJobBadge({ statusColor, label })).header('Content-Type', contentType);
+                }
+
+                label = `${pipeline.name}:${jobName}`;
+
+                if (job.state === 'DISABLED') {
+                    return h
+                        .response(
+                            getJobBadge({
+                                statusColor,
+                                label,
+                                builds: [{ status: 'DISABLED' }]
+                            })
+                        )
+                        .header('Content-Type', contentType);
+                }
+
+                const builds = await job.getBuilds({
+                    paginate: {
+                        page: 1,
+                        count: 1
                     }
+                });
 
-                    if (job.state === 'DISABLED') {
-                        return h
-                            .response(
-                                getJobBadge(
-                                    Object.assign(badgeConfig, {
-                                        builds: [
-                                            {
-                                                status: 'DISABLED'
-                                            }
-                                        ],
-                                        label: `${pipeline.name}:${jobName}`
-                                    })
-                                )
-                            )
-                            .header('Content-Type', contentType);
-                    }
+                return h.response(getJobBadge({ statusColor, label, builds })).header('Content-Type', contentType);
+            } catch (err) {
+                logger.error(`Failed to get job badge for pipeline:${id}, job:${jobName}: ${err.message}`);
 
-                    const listConfig = {
-                        paginate: {
-                            page: 1,
-                            count: 1
-                        }
-                    };
-
-                    return job.getBuilds(listConfig).then(builds => {
-                        return h
-                            .response(
-                                getJobBadge(
-                                    Object.assign(badgeConfig, {
-                                        builds,
-                                        label: `${pipeline.name}:${jobName}`
-                                    })
-                                )
-                            )
-                            .header('Content-Type', contentType);
-                    });
-                })
-                .catch(() => h.response(getJobBadge(badgeConfig)));
+                return h.response(getJobBadge({ statusColor, label })).header('Content-Type', contentType);
+            }
         },
         validate: {
             params: joi.object({

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -1624,21 +1624,21 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 200 to unknown for an event that does not exist', () => {
+        it('returns 200 to only pipeline name for an event that does not exist', () => {
             eventFactoryMock.getPipelineTypeBuildEvents.resolves([]);
 
             return server.inject(`/pipelines/${id}/badge`).then(reply => {
                 assert.equal(reply.statusCode, 200);
-                assert.include(reply.payload, 'pipeline: unknown');
+                assert.include(reply.payload, 'foo/bar: unknown');
             });
         });
 
-        it('returns 200 to unknown for a build that does not exist', () => {
+        it('returns 200 to only pipeline name for a build that does not exist', () => {
             eventsMock[0].getBuilds.resolves([]);
 
             return server.inject(`/pipelines/${id}/badge`).then(reply => {
                 assert.equal(reply.statusCode, 200);
-                assert.include(reply.payload, 'pipeline: unknown');
+                assert.include(reply.payload, 'foo/bar: unknown');
             });
         });
 
@@ -1682,8 +1682,8 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 200 to unknown for a job that does not exist', () => {
-            jobFactoryMock.get.resolves(null);
+        it('returns 200 to unknown for a pipeline that does not exist', () => {
+            pipelineFactoryMock.get.resolves(null);
 
             return server.inject(`/pipelines/${id}/${jobName}/badge`).then(reply => {
                 assert.equal(reply.statusCode, 200);
@@ -1691,7 +1691,26 @@ describe('pipeline plugin test', () => {
             });
         });
 
-        it('returns 200 to unknown when the datastore returns an error', () => {
+        it('returns 200 to only pipeline name for a job that does not exist', () => {
+            jobFactoryMock.get.resolves(null);
+
+            return server.inject(`/pipelines/${id}/${jobName}/badge`).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.include(reply.payload, 'foo/bar-test: unknown');
+            });
+        });
+
+        it('returns 200 to unknown name when the datastore returns an error', () => {
+            server.app.ecosystem.badges = '{{subject}}*{{status}}*{{color}}';
+            pipelineFactoryMock.get.rejects(new Error('icantdothatdave'));
+
+            return server.inject(`/pipelines/${id}/${jobName}/badge`).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.include(reply.payload, 'job: unknown');
+            });
+        });
+
+        it('returns 200 to unknown name when the datastore returns an error', () => {
             server.app.ecosystem.badges = '{{subject}}*{{status}}*{{color}}';
             jobFactoryMock.get.rejects(new Error('icantdothatdave'));
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When the pipeline has no events, then the pipeline badge will be `pipeline: unknown`.

https://api.screwdriver.cd/v4/pipelines/16115/badge

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Show the pipeline name when the pipeline does not have any events.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
