### PR TITLE
Fix: coverage git app binding

### DIFF
--- a/plugins/coverage/README.md
+++ b/plugins/coverage/README.md
@@ -27,7 +27,12 @@ server.register({
 ### Routes
 
 #### Returns an access token to talk to coverage server
-`GET /coverage/token?scope=job&projectKey=job:123&projectName=d2lam/mytest&username=user-job-123`
+`GET /coverage/token?projectKey=job:123`
+
+`scope`, `projectName`, and `username` are not accepted as query parameters — all three are always resolved
+server-side from the build's own JWT-verified identity. `projectKey` is accepted only if it names a project
+the calling build is authorized for (its own pipeline, its own job, or its PR parent job); anything else is
+rejected with a `403`.
 
 #### Get an object with coverage info
 

--- a/plugins/coverage/README.md
+++ b/plugins/coverage/README.md
@@ -30,9 +30,13 @@ server.register({
 `GET /coverage/token?projectKey=job:123`
 
 `scope`, `projectName`, and `username` are not accepted as query parameters — all three are always resolved
-server-side from the build's own JWT-verified identity. `projectKey` is accepted only if it names a project
-the calling build is authorized for (its own pipeline, its own job, or its PR parent job); anything else is
-rejected with a `403`.
+server-side from the build's own JWT-verified identity. `projectKey` is rejected with a `403` unless it
+names a project the calling build is authorized for (its own pipeline, its own job, or its PR parent job)
+**and** matches the build's own resolved coverage scope.
+
+> **Deployment order:** requires `screwdriver-coverage-sonar` ≥6.0.0
+> ([coverage-sonar#80](https://github.com/screwdriver-cd/coverage-sonar/pull/80)). This API change must be
+> deployed *before* that dependency is bumped — see that PR's README for why.
 
 #### Get an object with coverage info
 

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -22,7 +22,10 @@ module.exports = config => ({
             const { jobFactory, pipelineFactory } = request.server.app;
             const buildCredentials = request.auth.credentials;
             const { jobId, pipelineId } = buildCredentials;
-            const { scope, projectKey, projectName, username, selfSonarHost, selfSonarAdminToken } = request.query;
+            const { scope, projectKey, selfSonarHost, selfSonarAdminToken } = request.query;
+            // `projectName` and `username` are deliberately not read from the query. The coverage plugin
+            // derives both from the pipeline name resolved below, so a build cannot point its Sonar
+            // project's Git App binding at another organization's repository. See PSECBUGS-115276.
             const tokenConfig = {
                 buildCredentials,
                 scope
@@ -30,14 +33,6 @@ module.exports = config => ({
 
             if (projectKey) {
                 tokenConfig.projectKey = projectKey;
-            }
-
-            if (projectName) {
-                tokenConfig.projectName = projectName;
-            }
-
-            if (username) {
-                tokenConfig.username = username;
             }
 
             // Get scope and job name
@@ -56,8 +51,8 @@ module.exports = config => ({
             }
             let pipeline;
 
-            // Get pipeline name
-            if (pipelineId && (!projectName || projectName.includes('undefined'))) {
+            // Get pipeline name; always resolved here so it can never be supplied by the caller
+            if (pipelineId) {
                 pipeline = await pipelineFactory.get(pipelineId);
 
                 if (!pipeline) {
@@ -90,12 +85,6 @@ module.exports = config => ({
 
             const data = await config.coveragePlugin.getAccessToken(tokenConfig);
             const { projectUrl } = config.coveragePlugin.getProjectData(tokenConfig);
-
-            if (!pipeline && pipelineId) {
-                pipeline = await pipelineFactory.get(pipelineId);
-
-                logger.info(`looking up again, pipeline:${pipelineId}, and found pipeline: ${pipeline}`);
-            }
 
             if (pipeline && projectUrl) {
                 try {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -21,7 +21,7 @@ module.exports = config => ({
         handler: async (request, h) => {
             const { jobFactory, pipelineFactory } = request.server.app;
             const buildCredentials = request.auth.credentials;
-            const { jobId, pipelineId, prParentJobId } = buildCredentials;
+            const { jobId, pipelineId } = buildCredentials;
             const { projectKey, selfSonarHost, selfSonarAdminToken } = request.query;
             // `scope`, `projectName`, and `username` are deliberately not read from the query. The coverage
             // plugin derives all three from records resolved below via the build's own JWT-verified ids, so
@@ -83,19 +83,7 @@ module.exports = config => ({
             }
 
             const data = await config.coveragePlugin.getAccessToken(tokenConfig);
-            // projectKey is deliberately not forwarded here: getAccessToken above only actually uses a
-            // caller-supplied projectKey when it's both authorized and scope-consistent, silently ignoring
-            // it otherwise, so re-deriving from the same scope/jobName/pipelineName inputs is what keeps
-            // this badge URL consistent with the project the minted token is actually scoped to.
-            const { projectUrl } = config.coveragePlugin.getProjectData({
-                enterpriseEnabled: config.coveragePlugin.config.sonarEnterprise,
-                jobId,
-                jobName: tokenConfig.jobName,
-                pipelineId,
-                pipelineName: tokenConfig.pipelineName,
-                prParentJobId,
-                scope: tokenConfig.scope
-            });
+            const { projectUrl } = config.coveragePlugin.getProjectData(tokenConfig);
 
             if (pipeline && projectUrl) {
                 try {

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -43,6 +43,13 @@ module.exports = config => ({
                 }
 
                 tokenConfig.jobName = job.name;
+                // Invariant this rejection below relies on: screwdriver-cd/launcher's coverage/info call
+                // (launch.go, GetCoverageInfo) reads this exact field/index -
+                // job.Permutations[0].Annotations.CoverageScope - and always sends it as `scope`, empty
+                // string when absent, never omitted (screwdriver.go's CoverageURL has no projectKey param
+                // at all). So the scope screwdriver-coverage-sonar resolved when it minted
+                // SD_SONAR_PROJECT_KEY and the annotation re-read here cannot disagree for a real build,
+                // short of a pipeline sync rewriting this annotation between build start and this request.
                 tokenConfig.scope =
                     job.permutations[0] && job.permutations[0].annotations
                         ? job.permutations[0].annotations[COVERAGE_SCOPE_ANNOTATION]

--- a/plugins/coverage/token.js
+++ b/plugins/coverage/token.js
@@ -21,22 +21,21 @@ module.exports = config => ({
         handler: async (request, h) => {
             const { jobFactory, pipelineFactory } = request.server.app;
             const buildCredentials = request.auth.credentials;
-            const { jobId, pipelineId } = buildCredentials;
-            const { scope, projectKey, selfSonarHost, selfSonarAdminToken } = request.query;
-            // `projectName` and `username` are deliberately not read from the query. The coverage plugin
-            // derives both from the pipeline name resolved below, so a build cannot point its Sonar
-            // project's Git App binding at another organization's repository. See PSECBUGS-115276.
+            const { jobId, pipelineId, prParentJobId } = buildCredentials;
+            const { projectKey, selfSonarHost, selfSonarAdminToken } = request.query;
+            // `scope`, `projectName`, and `username` are deliberately not read from the query. The coverage
+            // plugin derives all three from records resolved below via the build's own JWT-verified ids, so
+            // a build cannot override which Sonar project or scope its token/Git App binding applies to.
             const tokenConfig = {
-                buildCredentials,
-                scope
+                buildCredentials
             };
 
             if (projectKey) {
                 tokenConfig.projectKey = projectKey;
             }
 
-            // Get scope and job name
-            if (jobId && !scope) {
+            // Get scope and job name; always resolved here so neither can be supplied by the caller
+            if (jobId) {
                 const job = await jobFactory.get(jobId);
 
                 if (!job) {
@@ -84,7 +83,19 @@ module.exports = config => ({
             }
 
             const data = await config.coveragePlugin.getAccessToken(tokenConfig);
-            const { projectUrl } = config.coveragePlugin.getProjectData(tokenConfig);
+            // projectKey is deliberately not forwarded here: getAccessToken above only actually uses a
+            // caller-supplied projectKey when it's both authorized and scope-consistent, silently ignoring
+            // it otherwise, so re-deriving from the same scope/jobName/pipelineName inputs is what keeps
+            // this badge URL consistent with the project the minted token is actually scoped to.
+            const { projectUrl } = config.coveragePlugin.getProjectData({
+                enterpriseEnabled: config.coveragePlugin.config.sonarEnterprise,
+                jobId,
+                jobName: tokenConfig.jobName,
+                pipelineId,
+                pipelineName: tokenConfig.pipelineName,
+                prParentJobId,
+                scope: tokenConfig.scope
+            });
 
             if (pipeline && projectUrl) {
                 try {

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -135,7 +135,7 @@ describe('coverage plugin test', () => {
             });
         });
 
-        it('ignores caller-supplied username and projectName, forwarding the resolved pipeline name', () => {
+        it('ignores caller-supplied username, projectName, and scope, forwarding the resolved pipeline name and annotation-derived scope', () => {
             options.url =
                 '/coverage/token?projectKey=job:123&username=user-job-123&scope=job&projectName=d2lam/test:main';
 
@@ -143,7 +143,8 @@ describe('coverage plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, 'faketoken');
                 assert.calledWith(mockCoveragePlugin.getAccessToken, {
-                    scope: 'job',
+                    scope: 'pipeline',
+                    jobName: 'main',
                     buildCredentials: credentials,
                     projectKey: 'job:123',
                     pipelineName: 'd2lam/test'
@@ -151,7 +152,7 @@ describe('coverage plugin test', () => {
             });
         });
 
-        it('ignores caller-supplied username and projectName on the selfSonar path too', () => {
+        it('ignores caller-supplied username, projectName, and scope on the selfSonar path too', () => {
             options.url =
                 '/coverage/token?projectKey=job:123&username=user-job-123&scope=job&projectName=d2lam/test:main&selfSonarHost=http://mySonar&selfSonarAdminToken=faketoken';
 
@@ -159,7 +160,8 @@ describe('coverage plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, 'faketoken');
                 assert.calledWith(mockCoveragePlugin.getAccessToken, {
-                    scope: 'job',
+                    scope: 'pipeline',
+                    jobName: 'main',
                     buildCredentials: credentials,
                     projectKey: 'job:123',
                     pipelineName: 'd2lam/test'
@@ -210,14 +212,15 @@ describe('coverage plugin test', () => {
             });
         });
 
-        it('returns 200 with coverage scope query param', () => {
+        it("ignores a scope query param and uses the job's own annotation instead", () => {
             options.url = '/coverage/token?scope=job';
 
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, 'faketoken');
                 assert.calledWith(mockCoveragePlugin.getAccessToken, {
-                    scope: 'job',
+                    scope: 'pipeline',
+                    jobName: 'main',
                     pipelineName: 'd2lam/test',
                     buildCredentials: credentials
                 });
@@ -241,7 +244,7 @@ describe('coverage plugin test', () => {
             });
         });
 
-        it('returns 200 with coverage scope query param for PR', () => {
+        it("ignores a scope query param for a PR job, using the job's own (unset) annotation instead", () => {
             jobFactoryMock.get.resolves({
                 permutations: [{}],
                 name: 'PR-234:main',
@@ -256,7 +259,8 @@ describe('coverage plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.deepEqual(reply.result, 'faketoken');
                 assert.calledWith(mockCoveragePlugin.getAccessToken, {
-                    scope: 'job',
+                    scope: null,
+                    jobName: 'PR-234:main',
                     pipelineName: 'd2lam/test',
                     buildCredentials: {
                         jobId: 555,

--- a/test/plugins/coverage.test.js
+++ b/test/plugins/coverage.test.js
@@ -135,7 +135,7 @@ describe('coverage plugin test', () => {
             });
         });
 
-        it('returns 200 with projectKey and username and projectName', () => {
+        it('ignores caller-supplied username and projectName, forwarding the resolved pipeline name', () => {
             options.url =
                 '/coverage/token?projectKey=job:123&username=user-job-123&scope=job&projectName=d2lam/test:main';
 
@@ -146,13 +146,12 @@ describe('coverage plugin test', () => {
                     scope: 'job',
                     buildCredentials: credentials,
                     projectKey: 'job:123',
-                    projectName: 'd2lam/test:main',
-                    username: 'user-job-123'
+                    pipelineName: 'd2lam/test'
                 });
             });
         });
 
-        it('returns 200 with projectKey and username and projectName and selfSonarHost and selfSonarAdminToken', () => {
+        it('ignores caller-supplied username and projectName on the selfSonar path too', () => {
             options.url =
                 '/coverage/token?projectKey=job:123&username=user-job-123&scope=job&projectName=d2lam/test:main&selfSonarHost=http://mySonar&selfSonarAdminToken=faketoken';
 
@@ -163,9 +162,32 @@ describe('coverage plugin test', () => {
                     scope: 'job',
                     buildCredentials: credentials,
                     projectKey: 'job:123',
-                    projectName: 'd2lam/test:main',
-                    username: 'user-job-123'
+                    pipelineName: 'd2lam/test'
                 });
+            });
+        });
+
+        it('does not let a caller redirect the Git App binding to another repository', () => {
+            options.url = '/coverage/token?projectKey=job:123&scope=job&projectName=victim-org/victim-repo';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+
+                const [tokenConfig] = mockCoveragePlugin.getAccessToken.firstCall.args;
+
+                assert.notProperty(tokenConfig, 'projectName');
+                assert.notProperty(tokenConfig, 'username');
+                assert.strictEqual(tokenConfig.pipelineName, 'd2lam/test');
+            });
+        });
+
+        it('resolves the pipeline name even when the caller supplies a usable projectName', () => {
+            options.url = '/coverage/token?scope=job&projectName=d2lam/test:main';
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.calledWith(pipelineFactoryMock.get, 333);
+                assert.calledWithMatch(mockCoveragePlugin.getAccessToken, { pipelineName: 'd2lam/test' });
             });
         });
 


### PR DESCRIPTION
## Context
Second half of the work needed to bind the Sonar tokens to the project.  https://github.com/screwdriver-cd/coverage-sonar/pull/80 contains the main work for managing and validating the sonar project to pipeline/job.

## Objective
Updates the API for getting Sonar project tokens to require just the projectKey parameter

## References
https://github.com/screwdriver-cd/coverage-sonar/pull/80

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
