### PR TITLE
fix: Add exclusive control for stageBuild status

### DIFF
--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -421,7 +421,11 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     const eventResource = `event:${event.id}`;
 
     if (isEndBuildStatus) {
-        eventLock = await locker.lock(eventResource);
+        try {
+            eventLock = await locker.lock(eventResource);
+        } catch (err) {
+            eventLock = null;
+        }
 
         const latestEvent = await eventFactory.get(build.eventId);
 
@@ -431,7 +435,11 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     const [newBuild, newEvent] = await Promise.all([build.update(), event.update(), stopFrozen]);
 
     if (isEndBuildStatus) {
-        await locker.unlock(eventLock, eventResource);
+        try {
+            await locker.unlock(eventLock, eventResource);
+        } catch (err) {
+            // ignore unlock errors for parity with lock helper behavior
+        }
     }
 
     if (desiredStatus) {
@@ -456,7 +464,11 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
 
     if (stage) {
         stageResource = `event:${event.id}:stage:${stage.id}`;
-        stageLock = await locker.lock(stageResource);
+        try {
+            stageLock = await locker.lock(stageResource);
+        } catch (err) {
+            stageLock = null;
+        }
         stageBuild = await stageBuildFactory.get({
             stageId: stage.id,
             eventId: newEvent.id
@@ -531,7 +543,11 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
         }
     }
     if (stageResource) {
-        await locker.unlock(stageLock, stageResource);
+        try {
+            await locker.unlock(stageLock, stageResource);
+        } catch (err) {
+            // ignore unlock errors for parity with lock helper behavior
+        }
     }
 
     // update event status

--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -6,7 +6,7 @@ const merge = require('lodash.mergewith');
 const isEmpty = require('lodash.isempty');
 const { PR_JOB_NAME, PR_STAGE_NAME, STAGE_TEARDOWN_PATTERN } = require('screwdriver-data-schema').config.regex;
 const { getFullStageJobName } = require('../../helper');
-const { locker } = require('../../lock');
+const locker = require('../../lock');
 const { updateVirtualBuildSuccess, emitBuildStatusEvent, isFixedBuild } = require('../triggers/helpers');
 const TERMINAL_STATUSES = ['FAILURE', 'ABORTED', 'UNSTABLE', 'COLLAPSED'];
 const FINISHED_STATUSES = ['SUCCESS', ...TERMINAL_STATUSES];
@@ -421,11 +421,7 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     const eventResource = `event:${event.id}`;
 
     if (isEndBuildStatus) {
-        try {
-            eventLock = await locker.lock(eventResource);
-        } catch (err) {
-            eventLock = null;
-        }
+        eventLock = await locker.lock(eventResource);
 
         const latestEvent = await eventFactory.get(build.eventId);
 
@@ -435,11 +431,7 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     const [newBuild, newEvent] = await Promise.all([build.update(), event.update(), stopFrozen]);
 
     if (isEndBuildStatus) {
-        try {
-            await locker.unlock(eventLock, eventResource);
-        } catch (err) {
-            // ignore unlock errors for parity with lock helper behavior
-        }
+        await locker.unlock(eventLock, eventResource);
     }
 
     if (desiredStatus) {
@@ -459,8 +451,12 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     let stageBuild;
     const isStageTeardown = STAGE_TEARDOWN_PATTERN.test(job.name);
     let stageBuildHasFailure = false;
+    let stageLock;
+    let stageResource;
 
     if (stage) {
+        stageResource = `event:${event.id}:stage:${stage.id}`;
+        stageLock = await locker.lock(stageResource);
         stageBuild = await stageBuildFactory.get({
             stageId: stage.id,
             eventId: newEvent.id
@@ -533,6 +529,9 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
                 }
             }
         }
+    }
+    if (stageResource) {
+        await locker.unlock(stageLock, stageResource);
     }
 
     // update event status

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -3450,8 +3450,8 @@ describe('build plugin test', () => {
                         return server.inject(options).then(() => {
                             const { lock, unlock } = lockMock;
 
-                            assert.calledOnce(lock);
-                            assert.calledOnce(unlock);
+                            assert.calledTwice(lock);
+                            assert.calledTwice(unlock);
                         });
                     });
 
@@ -3462,8 +3462,8 @@ describe('build plugin test', () => {
                         return server.inject(options).then(() => {
                             const { lock, unlock } = lockMock;
 
-                            assert.calledOnce(lock);
-                            assert.calledOnce(unlock);
+                            assert.calledTwice(lock);
+                            assert.calledTwice(unlock);
                         });
                     });
                 });
@@ -6653,7 +6653,7 @@ describe('build plugin test', () => {
                         return newServer.inject(options).then(() => {
                             const { lock, unlock } = lockMock;
 
-                            assert.calledTwice(lock);
+                            assert.calledThrice(lock);
                             assert.called(unlock);
                         });
                     });
@@ -6665,7 +6665,7 @@ describe('build plugin test', () => {
                         return newServer.inject(options).then(() => {
                             const { lock, unlock } = lockMock;
 
-                            assert.calledTwice(lock);
+                            assert.calledThrice(lock);
                             assert.called(unlock);
                         });
                     });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -6453,6 +6453,116 @@ describe('build plugin test', () => {
                     });
                 });
 
+                it('update stageBuild statuses at the same time', async () => {
+                    const failureOptions = hoek.clone(options);
+                    const successOptions = hoek.clone(options);
+                    const stageResource = 'event:8888:stage:1';
+                    const stageBuildStore = { status: 'RUNNING' };
+                    const stageBuildUpdate = sinon.stub().callsFake(function updateStageBuild() {
+                        stageBuildStore.status = this.status;
+
+                        return Promise.resolve(this);
+                    });
+                    const waitingStageLocks = [];
+                    let stageLockHeld = false;
+
+                    failureOptions.payload.status = 'FAILURE';
+                    successOptions.payload.status = 'SUCCESS';
+                    successOptions.url = '/builds/12346';
+                    successOptions.auth.credentials.username = 12346;
+
+                    lockMock.lock = sinon.stub().callsFake(resource => {
+                        if (resource !== stageResource) {
+                            return Promise.resolve(`${resource}:lock`);
+                        }
+
+                        if (!stageLockHeld) {
+                            stageLockHeld = true;
+
+                            return Promise.resolve('stage-lock');
+                        }
+
+                        return new Promise(resolve => {
+                            waitingStageLocks.push(() => {
+                                stageLockHeld = true;
+                                resolve('stage-lock-waiter');
+                            });
+                        });
+                    });
+                    lockMock.unlock = sinon.stub().callsFake((lock, resource) => {
+                        if (resource === stageResource) {
+                            stageLockHeld = false;
+
+                            const nextWaiter = waitingStageLocks.shift();
+
+                            if (nextWaiter) {
+                                nextWaiter();
+                            }
+                        }
+
+                        return Promise.resolve(lock);
+                    });
+
+                    eventMock.workflowGraph = testWorkflowGraphWithStages;
+                    eventFactoryMock.get.resolves(eventMock);
+                    stageFactoryMock.get.resolves(stageAlphaMock);
+                    stageBuildFactoryMock.get.callsFake(async () => ({
+                        id: 1,
+                        stageId: 1,
+                        status: stageBuildStore.status,
+                        update: stageBuildUpdate
+                    }));
+
+                    const makeBuild = ({ buildId, jobName }) => {
+                        const build = getBuildMock({
+                            ...testBuild,
+                            id: buildId,
+                            eventId: '8888',
+                            status: 'RUNNING'
+                        });
+                        const buildJob = {
+                            id: buildId,
+                            name: jobName,
+                            pipelineId,
+                            permutations: [
+                                {
+                                    settings: {
+                                        email: 'foo@bar.com'
+                                    }
+                                }
+                            ],
+                            state: 'ENABLED',
+                            pipeline: sinon.stub().resolves(pipelineMock)(),
+                            getLatestBuild: sinon.stub().resolves(build)
+                        };
+
+                        build.update.resolves(build);
+                        build.job = sinon.stub().resolves(buildJob)();
+
+                        return build;
+                    };
+
+                    const failureBuild = makeBuild({ buildId: 12345, jobName: 'alpha-deploy' });
+                    const successBuild = makeBuild({ buildId: 12346, jobName: 'alpha-test' });
+
+                    buildFactoryMock.get.withArgs(12345).resolves(failureBuild);
+                    buildFactoryMock.get.withArgs(12346).resolves(successBuild);
+
+                    const [failureReply, successReply] = await Promise.all([
+                        newServer.inject(failureOptions),
+                        newServer.inject(successOptions)
+                    ]);
+                    const stageLockCalls = lockMock.lock.getCalls().filter(call => call.args[0] === stageResource);
+
+                    assert.equal(failureReply.statusCode, 200);
+                    assert.equal(successReply.statusCode, 200);
+                    assert.lengthOf(stageLockCalls, 2);
+                    assert.calledTwice(stageBuildFactoryMock.get);
+                    assert.calledOnce(stageBuildUpdate);
+                    assert.equal(stageBuildStore.status, 'FAILURE');
+                    assert.calledWith(lockMock.unlock, sinon.match.string, stageResource);
+                });
+
                 it('update stageBuild status if next job is stage teardown and parent has some failures', () => {
                     const localOptions = hoek.clone(options);
                     const stageBuildMock = {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When status updates for SUCCESS and FAILURE builds within a stage run in parallel, the stage status can sometimes be marked as SUCCESS even if there is a failed build.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Implement proper exclusive control for updating build statuses within the stage.

The existing lock process was not working because of an incorrect locker import statement.
Moving forward, concurrency control will be applied when overwriting event metadata.
- https://github.com/screwdriver-cd/screwdriver/pull/3493


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
