### PR TITLE
build: bump screwdriver-coverage-sonar to ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "screwdriver-command-validator": "^5.0.0",
     "screwdriver-config-parser": "^12.2.3",
     "screwdriver-coverage-bookend": "^3.0.0",
-    "screwdriver-coverage-sonar": "^5.0.0",
+    "screwdriver-coverage-sonar": "^6.0.0",
     "screwdriver-data-schema": "^26.1.0",
     "screwdriver-datastore-sequelize": "^10.1.0",
     "screwdriver-executor-base": "^11.0.0",


### PR DESCRIPTION
## Context
Follow-up to #3518 and [coverage-sonar#80](https://github.com/screwdriver-cd/coverage-sonar/pull/80), which fix PSECBUGS-115276 (an IDOR letting a build request a Sonar coverage token for another pipeline's project). coverage-sonar#80 publishes as a major version (6.0.0) specifically so this dependency's `^5.0.0` range can't auto-pull it early.

## Objective
Bump `screwdriver-coverage-sonar` from `^5.0.0` to `^6.0.0`.

## Do not merge yet
This PR is expected to fail CI right now — `screwdriver-coverage-sonar@6.0.0` doesn't exist on the registry yet, since coverage-sonar#80 hasn't published. Opened early so #3518's review thread has a live link instead of prose describing an unopened PR.

Merge only after:
1. #3518 is deployed.
2. coverage-sonar#80 is merged and has actually published `6.0.0`.

## Changes
- `package.json`: `"screwdriver-coverage-sonar": "^5.0.0"` → `"^6.0.0"`. No lockfile changes — intentionally not installed yet.

## References
- #3518
- https://github.com/screwdriver-cd/coverage-sonar/pull/80