### PR TITLE
feat(3508): add API Token access audit logging

### DIFF
--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -10,6 +10,7 @@ const keyRoute = require('./key');
 const loginRoute = require('./login');
 const logoutRoute = require('./logout');
 const tokenRoute = require('./token');
+const logger = require('screwdriver-logger');
 
 const DEFAULT_TIMEOUT = 2 * 60; // 2h in minutes
 const ALGORITHM = 'RS256';
@@ -124,16 +125,19 @@ const authPlugin = {
             const { apiTokenId } = credentials.auth;
 
             if (!apiTokenId) {
+                logger.info(`[API Token Access] Invalid API Token.`);
                 throw boom.forbidden(`Your token is invalid`);
             }
 
             const token = await tokenFactory.get({ id: apiTokenId });
 
             if (!token) {
+                logger.info(`[API Token Access] Invalid API Token.`);
                 throw boom.forbidden(`Your token is invalid`);
             }
 
             if (token.expiresAt && new Date(token.expiresAt) < new Date()) {
+                logger.info(`[API Token Access][TokenId:${apiTokenId}] Expired Token Access.`);
                 throw boom.forbidden(`Your token is expired: token id ${apiTokenId}`);
             }
 
@@ -146,9 +150,14 @@ const authPlugin = {
                 throw boom.badImplementation(`Invalid required permission: "${requiredPermission}"`);
             }
 
+            const endpoint = request.route.path;
+
             if (!actualPermissionLevel || actualPermissionLevel < requiredPermissionLevel) {
+                logger.info(`[API Token Access][TokenId:${apiTokenId}][${endpoint}] Invalid permission Token Access. This endpoint requires "${requiredPermission}" permission. This token has "${actualPermission}"`);
                 throw boom.forbidden(`This endpoint requires "${requiredPermission}" permission`);
             }
+
+            logger.info(`[API Token Access][TokenId:${apiTokenId}][${endpoint}] Success API Token access.`);
 
             return h.continue;
         });

--- a/plugins/auth/index.js
+++ b/plugins/auth/index.js
@@ -4,13 +4,13 @@ const boom = require('@hapi/boom');
 const joi = require('joi');
 const jwt = require('jsonwebtoken');
 const { v4: uuidv4 } = require('uuid');
+const logger = require('screwdriver-logger');
 const contextsRoute = require('./contexts');
 const crumbRoute = require('./crumb');
 const keyRoute = require('./key');
 const loginRoute = require('./login');
 const logoutRoute = require('./logout');
 const tokenRoute = require('./token');
-const logger = require('screwdriver-logger');
 
 const DEFAULT_TIMEOUT = 2 * 60; // 2h in minutes
 const ALGORITHM = 'RS256';
@@ -153,7 +153,9 @@ const authPlugin = {
             const endpoint = request.route.path;
 
             if (!actualPermissionLevel || actualPermissionLevel < requiredPermissionLevel) {
-                logger.info(`[API Token Access][TokenId:${apiTokenId}][${endpoint}] Invalid permission Token Access. This endpoint requires "${requiredPermission}" permission. This token has "${actualPermission}"`);
+                logger.info(
+                    `[API Token Access][TokenId:${apiTokenId}][${endpoint}] Invalid permission Token Access. This endpoint requires "${requiredPermission}" permission. This token has "${actualPermission}"`
+                );
                 throw boom.forbidden(`This endpoint requires "${requiredPermission}" permission`);
             }
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
There was no way to track which API Token accessed which endpoint or to determine the cause of authentication and authorization failures. To facilitate security auditing and access troubleshooting, this PR enhances the audit logging for API Token access.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Use screwdriver-logger to record the following information for API Token access:
 - Token ID
 - Access endpoint
 - error reason or success message

Token secrets and JWTs will not be included in the logs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#3508 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
