### PR TITLE
fix(artifacts): encode manifest entries before requesting from store

### DIFF
--- a/plugins/builds/artifacts/get.js
+++ b/plugins/builds/artifacts/get.js
@@ -83,10 +83,18 @@ module.exports = config => ({
                             const directoryArray = manifestArray.filter(f => f.startsWith(`./${artifact}/`));
                             let totalSize = 0;
 
+                            // Manifest entries are build controlled, so encode them the same way
+                            // single file requests are encoded. Appending them verbatim lets
+                            // `..` segments be resolved away when the URL is normalized, which
+                            // would point the request at another build's artifacts.
+                            const fileUrl = file =>
+                                `${baseUrl}/${encodeURIComponent(file.replace(/^\.\//, ''))}`
+                                + `?token=${token}&type=download`;
+
                             // Check file sizes by fetching metadata
                             for (const file of directoryArray) {
                                 if (file) {
-                                    const fileMetaResponse = await request.head(`${baseUrl}/${file}?token=${token}&type=download`);
+                                    const fileMetaResponse = await request.head(fileUrl(file));
                                     const fileSize = parseInt(fileMetaResponse.headers['content-length'], 10);
 
                                     // Accumulate total size
@@ -120,7 +128,7 @@ module.exports = config => ({
                             // Fetch and append the directory files
                             for (const file of directoryArray) {
                                 if (file) {
-                                    const fileStream = request.stream(`${baseUrl}/${file}?token=${token}&type=download`);
+                                    const fileStream = request.stream(fileUrl(file));
 
                                     // Handle errors from file streaming
                                     fileStream.on('error', (err) => {

--- a/plugins/builds/artifacts/getAll.js
+++ b/plugins/builds/artifacts/getAll.js
@@ -92,7 +92,12 @@ module.exports = config => ({
                     try {
                         for (const file of manifestArray) {
                             if (file) {
-                                const fileStream = request.stream(`${baseUrl}/${file}?token=${token}&type=download`);
+                                // Manifest entries are build controlled, so encode them before
+                                // appending. Verbatim entries let `..` segments be resolved away
+                                // when the URL is normalized, which would point the request at
+                                // another build's artifacts.
+                                const encodedFile = encodeURIComponent(file.replace(/^\.\//, ''));
+                                const fileStream = request.stream(`${baseUrl}/${encodedFile}?token=${token}&type=download`);
 
                                 fileStream.on('error', (err) => {
                                     logger.error(`Error downloading file: ${file}`, err);

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -8303,6 +8303,31 @@ describe('build plugin test', () => {
                 assert.equal(reply.result.message, 'An internal server error occurred');
             });
         });
+
+        it('does not fetch another build artifact', () => {
+            const traversalManifest = './../../../builds/99999/ARTIFACTS/secret.txt';
+            const encodedPath = '/v1/builds/12345/ARTIFACTS/..%2F..%2F..%2Fbuilds%2F99999%2FARTIFACTS%2Fsecret.txt';
+
+            nock.disableNetConnect();
+            nock.cleanAll();
+            nock.enableNetConnect();
+            // Would only be reached if the manifest entry escaped this build's artifact space
+            const otherBuildScope = nock(logBaseUrl)
+                .persist()
+                .get(/\/v1\/builds\/99999\//)
+                .reply(200, 'TOP-SECRET');
+
+            nock(logBaseUrl).get('/v1/builds/12345/ARTIFACTS/manifest.txt?token=sign').reply(200, traversalManifest);
+            const sameBuildScope = nock(logBaseUrl)
+                .defaultReplyHeaders(expectedHeaders)
+                .get(`${encodedPath}?token=sign&type=download`)
+                .reply(200, 'not-a-secret');
+
+            return server.inject(options).then(() => {
+                assert.isTrue(sameBuildScope.isDone(), 'request stayed within the requested build');
+                assert.isNotEmpty(otherBuildScope.pendingMocks(), 'another build was requested');
+            });
+        });
     });
 
     describe('GET /builds/{id}/artifacts/{artifact}', () => {
@@ -8426,6 +8451,43 @@ describe('build plugin test', () => {
             });
         });
 
+        it('does not fetch another build artifact for a directory download', () => {
+            const traversalManifest = './artifacts/../../../../builds/99999/ARTIFACTS/secret.txt';
+            const encodedPath =
+                '/v1/builds/12345/ARTIFACTS/artifacts%2F..%2F..%2F..%2F..%2Fbuilds%2F99999%2FARTIFACTS%2Fsecret.txt';
+
+            nock.disableNetConnect();
+            nock.cleanAll();
+            nock.enableNetConnect();
+            // Would only be reached if the manifest entry escaped this build's artifact space
+            const otherBuildScope = nock(logBaseUrl)
+                .persist()
+                .defaultReplyHeaders({
+                    'content-length': 10
+                })
+                .head(/\/v1\/builds\/99999\//)
+                .reply(200)
+                .get(/\/v1\/builds\/99999\//)
+                .reply(200, 'TOP-SECRET');
+
+            nock(logBaseUrl).get('/v1/builds/12345/ARTIFACTS/manifest.txt?token=sign').reply(200, traversalManifest);
+            const sameBuildScope = nock(logBaseUrl)
+                .defaultReplyHeaders({
+                    'content-length': 10
+                })
+                .head(`${encodedPath}?token=sign&type=download`)
+                .reply(200)
+                .get(`${encodedPath}?token=sign&type=download`)
+                .reply(200, 'not-a-secret');
+
+            options.url = `/builds/${id}/artifacts/./artifacts?type=download&dir=true`;
+
+            return server.inject(options).then(() => {
+                assert.isTrue(sameBuildScope.isDone(), 'request stayed within the requested build');
+                assert.isNotEmpty(otherBuildScope.pendingMocks(), 'another build was requested');
+            });
+        });
+
         it('returns 200 for a large artifact download request for directory', async () => {
             const expectedHeaders = {
                 'content-type': 'application/zip',
@@ -8450,7 +8512,7 @@ describe('build plugin test', () => {
                 .reply(200, './artifacts/sample-mp4-file.mp4');
             // Nock intercept to simulate large file download
             nock(logBaseUrl)
-                .get('/v1/builds/12345/ARTIFACTS/./artifacts/sample-mp4-file.mp4?token=sign&type=download')
+                .get('/v1/builds/12345/ARTIFACTS/artifacts%2Fsample-mp4-file.mp4?token=sign&type=download')
                 .delay(5000)
                 .reply(200, largeFileContent, {
                     'Content-Type': 'application/octet-stream',
@@ -8522,7 +8584,7 @@ describe('build plugin test', () => {
                 .get('/v1/builds/12345/ARTIFACTS/manifest.txt?token=sign')
                 .reply(200, './artifacts/sample-mp4-file.mp4');
             nock(logBaseUrl)
-                .get('/v1/builds/12345/ARTIFACTS/./artifacts/sample-mp4-file.mp4?token=sign&type=download')
+                .get('/v1/builds/12345/ARTIFACTS/artifacts%2Fsample-mp4-file.mp4?token=sign&type=download')
                 .reply(500);
 
             options.url = `/builds/${id}/artifacts/./artifacts?type=download&dir=true`;


### PR DESCRIPTION
## Context

`manifest.txt` is written by the build that produced the artifacts, so its
contents are build controlled. Both the directory download handler
(`plugins/builds/artifacts/get.js`) and the download all handler
(`plugins/builds/artifacts/getAll.js`) appended each manifest entry to the store
base URL verbatim:

```js
request.stream(`${baseUrl}/${file}?token=${token}&type=download`)
```

`..` segments in an entry are resolved away when the URL is normalized, so a
crafted entry could move the request out of the requested build's artifact space
and into another build's:

/v1/builds/12345/ARTIFACTS/./artifacts/../../../../builds/99999/ARTIFACTS/secret.txt
  -> /v1/builds/99999/ARTIFACTS/secret.txt

The single file branch in the same file already handles this correctly with
encodeURIComponent; the two zip paths did not.

##Objective

Encode each manifest entry the same way single file requests are already
encoded, so an entry can no longer act as path segments and every request stays
under the requested build.

Both call sites in get.js (the size check loop and the streaming loop) go
through one helper, so the two cannot drift apart.

getAll.js had the same defect and is fixed the same way. It iterates the whole
manifest with no filter, so it was the more direct of the two.

## Behavior change

Legitimate manifest entries resolve to exactly the same store path as before. I
replayed every entry of the existing manifest fixture through a route matching
the store's, and all 19 produce an identical (build, artifact) pair before and
after; only a traversal entry changes.

One visible difference: a manifest containing a traversal entry now fails that
build's own directory download rather than silently including another build's
file. This only affects a build that poisoned its own manifest, and it fails
closed.

## Testing

- Added a regression test to each of the two handlers asserting the request stays
  within the requested build and never reaches another one. Both fail without the
  fix.
- Updated two existing tests that pinned the un-normalized store path, i.e. that
  asserted the behavior being fixed.
- builds.test.js passes (229), lint clean.
- Verified end to end against a running store that nested paths, multi-byte
  filenames and filenames containing spaces all still download correctly, and
  that a traversal entry stays inside the requested build.

## References

Pairs with screwdriver-cd/store#153, which addresses the same report from
the store side. That PR is the one that closes the underlying issue; this change
prevents the API from being used to reach it and is worth having independently.

## License

I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its
copyright owner.