### PR TITLE
fix: fix recursive stage lock

### DIFF
--- a/plugins/builds/helper/updateBuild.js
+++ b/plugins/builds/helper/updateBuild.js
@@ -459,11 +459,11 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     let stageBuild;
     const isStageTeardown = STAGE_TEARDOWN_PATTERN.test(job.name);
     let stageBuildHasFailure = false;
-    let stageLock;
-    let stageResource;
 
     if (stage) {
-        stageResource = `event:${event.id}:stage:${stage.id}`;
+        const stageResource = `event:${event.id}:stage:${stage.id}`;
+        let stageLock;
+
         try {
             stageLock = await locker.lock(stageResource);
         } catch (err) {
@@ -476,6 +476,11 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
 
         stageBuild = await updateStageBuildStatus({ stageBuild, newStatus: newBuild.status, job });
 
+        try {
+            await locker.unlock(stageLock, stageResource);
+        } catch (err) {
+            // ignore unlock errors for parity with lock helper behavior
+        }
         stageBuildHasFailure = TERMINAL_STATUSES.includes(stageBuild.status);
     }
 
@@ -497,6 +502,15 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
     // (if stage teardown build exists, and stageBuild.status is negative,
     // and there are no active stage builds, and teardown build is not started)
     if (stage && FINISHED_STATUSES.includes(newBuild.status) && !isStageTeardown) {
+        const stageResource = `event:${event.id}:stage:${stage.id}`;
+        let stageLock;
+
+        try {
+            stageLock = await locker.lock(stageResource);
+        } catch (err) {
+            stageLock = null;
+        }
+
         const stageTeardownName = getFullStageJobName({ stageName: stage.name, jobName: 'teardown' });
         const stageTeardownJob = await jobFactory.get({ pipelineId: pipeline.id, name: stageTeardownName });
         let stageTeardownBuild = await buildFactory.get({ eventId: newEvent.id, jobId: stageTeardownJob.id });
@@ -541,8 +555,7 @@ async function updateBuildAndTriggerDownstreamJobs(config, build, server, userna
                 }
             }
         }
-    }
-    if (stageResource) {
+
         try {
             await locker.unlock(stageLock, stageResource);
         } catch (err) {

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -6556,7 +6556,7 @@ describe('build plugin test', () => {
 
                     assert.equal(failureReply.statusCode, 200);
                     assert.equal(successReply.statusCode, 200);
-                    assert.lengthOf(stageLockCalls, 2);
+                    assert.lengthOf(stageLockCalls, 4);
                     assert.calledTwice(stageBuildFactoryMock.get);
                     assert.calledOnce(stageBuildUpdate);
                     assert.equal(stageBuildStore.status, 'FAILURE');


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

fix https://github.com/screwdriver-cd/screwdriver/pull/3519

With the previous change, the subsequent job trigger processing also attempted to acquire the lock, causing the build to be blocked until the locker timed out.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Change minimizes the scope of the lock to prevent the build from being blocked.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/3519

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
