### PR TITLE
fix(3527): fix response code when the repository is not found

### DIFF
--- a/plugins/helper.js
+++ b/plugins/helper.js
@@ -55,6 +55,10 @@ async function getUserPermissions({ user, scmUri, level = 'admin', isAdmin = fal
     try {
         permissions = await user.getPermissions(scmUri);
     } catch (err) {
+        if (err.statusCode === 404) {
+            throw boom.notFound(err);
+        }
+
         permissions = null;
     }
 

--- a/plugins/pipelines/update.js
+++ b/plugins/pipelines/update.js
@@ -178,6 +178,8 @@ module.exports = () => ({
             } catch (err) {
                 if (isScrewdriverAdmin) {
                     oldPermissions = { admin: false };
+                } else if (err.statusCode === 404) {
+                    throw boom.notFound(err);
                 } else {
                     throw boom.forbidden(
                         `User ${user.getFullDisplayName()} does not have admin permission for this repo`

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -2381,6 +2381,18 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('returns 404 when the repository is not found', () => {
+            const error = new Error('Not Found');
+
+            error.statusCode = 404;
+
+            userMock.getPermissions.withArgs(scmUri).rejects(error);
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
         it('returns 404 for updating a pipeline that does not exist', () => {
             pipelineFactoryMock.get.withArgs(id).resolves(null);
 
@@ -3482,6 +3494,19 @@ describe('pipeline plugin test', () => {
             return server.inject(options).then(reply => {
                 assert.notCalled(updatedPipelineMock.addWebhooks);
                 assert.equal(reply.statusCode, 403);
+            });
+        });
+
+        it('returns 404 when get permission throws NotFound error', () => {
+            const error = new Error('Not Found');
+
+            error.statusCode = 404;
+
+            userMock.getPermissions.withArgs(oldScmUri).rejects(error);
+
+            return server.inject(options).then(reply => {
+                assert.notCalled(updatedPipelineMock.addWebhooks);
+                assert.equal(reply.statusCode, 404);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

When the pipeline has already removed, it rejects the request to update or sync the pipeline.
But the status code is not properly.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Return the status code 404 if the repository is not found.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue - https://github.com/screwdriver-cd/screwdriver/issues/3527

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
