### PR TITLE
[1]fix(3508): preserve token options and expiration on update and refresh

### DIFF
--- a/plugins/pipelines/tokens/refresh.js
+++ b/plugins/pipelines/tokens/refresh.js
@@ -62,6 +62,10 @@ module.exports = () => ({
                 throw boom.forbidden('Pipeline does not own token');
             }
 
+            if (request.payload && request.payload.expiresAt !== undefined) {
+                token.expiresAt = request.payload.expiresAt;
+            }
+
             logger.info(
                 `[Audit] user ${username}:${scmContext} refreshes the token name:${token.name} for pipelineId:${pipelineId}.`
             );
@@ -73,7 +77,14 @@ module.exports = () => ({
             params: joi.object({
                 pipelineId: pipelineIdSchema,
                 tokenId: tokenIdSchema
-            })
+            }),
+            payload: joi
+                .object({
+                    expiresAt: schema.models.token.update.extract('expiresAt')
+                })
+                .unknown(true)
+                .allow(null)
+                .default({})
         }
     }
 });

--- a/plugins/pipelines/tokens/update.js
+++ b/plugins/pipelines/tokens/update.js
@@ -66,15 +66,20 @@ module.exports = () => ({
                     }
 
                     let payloadOptions;
+
                     if (request.payload && request.payload.options) {
                         payloadOptions = request.payload.options;
                     }
 
                     Object.keys(request.payload).forEach(key => {
                         if (key === 'options') {
+                            const hasResourceUpdates =
+                                payloadOptions.resources && Object.keys(payloadOptions.resources).length > 0;
+
                             token.options = {
                                 ...token.options,
-                                ...payloadOptions
+                                ...payloadOptions,
+                                resources: hasResourceUpdates ? payloadOptions.resources : token.options.resources
                             };
                         } else {
                             token[key] = request.payload[key];

--- a/plugins/pipelines/tokens/update.js
+++ b/plugins/pipelines/tokens/update.js
@@ -65,8 +65,20 @@ module.exports = () => ({
                         throw boom.conflict(`Token ${match.name} already exists`);
                     }
 
+                    let payloadOptions;
+                    if (request.payload && request.payload.options) {
+                        payloadOptions = request.payload.options;
+                    }
+
                     Object.keys(request.payload).forEach(key => {
-                        token[key] = request.payload[key];
+                        if (key === 'options') {
+                            token.options = {
+                                ...token.options,
+                                ...payloadOptions
+                            };
+                        } else {
+                            token[key] = request.payload[key];
+                        }
                     });
 
                     return token.update().then(() => h.response(token.toJson()).code(200));

--- a/plugins/tokens/README.md
+++ b/plugins/tokens/README.md
@@ -69,6 +69,10 @@ Example payload:
 
 `PUT /tokens/{id}/refresh`
 
+**Arguments**
+
+* `expiresAt` - An optional expiration date for the refreshed token.
+
 #### Remove a token
 
 `DELETE /tokens/{id}`

--- a/plugins/tokens/refresh.js
+++ b/plugins/tokens/refresh.js
@@ -35,7 +35,13 @@ module.exports = () => ({
                     }
 
                     return canAccess(credentials, token, request.server.app)
-                        .then(() => token.refresh())
+                        .then(() => {
+                            if (request.payload && request.payload.expiresAt !== undefined) {
+                                token.expiresAt = request.payload.expiresAt;
+                            }
+
+                            return token.refresh();
+                        })
                         .then(() => h.response(token.toJson()).code(200));
                 })
                 .catch(err => {
@@ -45,7 +51,14 @@ module.exports = () => ({
         validate: {
             params: joi.object({
                 id: idSchema
-            })
+            }),
+            payload: joi
+                .object({
+                    expiresAt: schema.models.token.update.extract('expiresAt')
+                })
+                .unknown(true)
+                .allow(null)
+                .default({})
         }
     }
 });

--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -50,8 +50,20 @@ module.exports = () => ({
                             throw boom.conflict(`Token with name ${match.name} already exists`);
                         }
 
+                        let payloadOptions;
+                        if (request.payload && request.payload.options) {
+                            payloadOptions = request.payload.options;
+                        }
+
                         Object.keys(request.payload).forEach(key => {
-                            token[key] = request.payload[key];
+                            if (key === 'options') {
+                                token.options = {
+                                    ...token.options,
+                                    ...payloadOptions
+                                };
+                            } else {
+                                token[key] = request.payload[key];
+                            }
                         });
 
                         return token.update().then(() => h.response(token.toJson()).code(200));

--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -51,15 +51,20 @@ module.exports = () => ({
                         }
 
                         let payloadOptions;
+
                         if (request.payload && request.payload.options) {
                             payloadOptions = request.payload.options;
                         }
 
                         Object.keys(request.payload).forEach(key => {
                             if (key === 'options') {
+                                const hasResourceUpdates =
+                                    payloadOptions.resources && Object.keys(payloadOptions.resources).length > 0;
+
                                 token.options = {
                                     ...token.options,
-                                    ...payloadOptions
+                                    ...payloadOptions,
+                                    resources: hasResourceUpdates ? payloadOptions.resources : token.options.resources
                                 };
                             } else {
                                 token[key] = request.payload[key];

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -4444,6 +4444,39 @@ describe('pipeline plugin test', () => {
                 assert.equal(reply.statusCode, 200);
             }));
 
+        it('merges token options when updating multiple options', () => {
+            const existingOptions = {
+                permission: 'read',
+                resources: {
+                    pipelines: [123]
+                }
+            };
+            const expectedOptions = {
+                permission: 'write',
+                resources: {
+                    organizations: ['example']
+                }
+            };
+
+            tokenMock.options = existingOptions;
+            tokenMock.toJson.returns({ ...testTokens, options: expectedOptions });
+            options.payload = {
+                options: {
+                    permission: 'write',
+                    resources: {
+                        organizations: ['example']
+                    }
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(tokenMock.options, expectedOptions);
+                assert.deepEqual(reply.result.options, expectedOptions);
+                assert.calledOnce(tokenMock.update);
+            });
+        });
+
         it('returns 403 when user does not have admin permission', () => {
             const error = {
                 statusCode: 403,
@@ -4591,6 +4624,19 @@ describe('pipeline plugin test', () => {
             return server.inject(options).then(reply => {
                 assert.equal(reply.statusCode, 200);
                 assert.equal(reply.result, refreshedToken);
+            });
+        });
+
+        it('updates expiresAt when refreshing with an expiration date', () => {
+            const expiresAt = '2030-01-01T00:00:00.000Z';
+
+            options.payload = { expiresAt };
+            tokenMock.refresh.resolves(getTokenMocks({ ...testTokens, value: 'refreshed' }));
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.equal(tokenMock.expiresAt, expiresAt);
+                assert.calledOnce(tokenMock.refresh);
             });
         });
 

--- a/test/plugins/tokens.test.js
+++ b/test/plugins/tokens.test.js
@@ -345,6 +345,70 @@ describe('token plugin test', () => {
             });
         });
 
+        it('updates only the permission and preserves existing resources', () => {
+            const resources = {
+                pipelines: [123],
+                privatePipeline: true,
+                organizations: ['example']
+            };
+            const expectedOptions = {
+                ...testToken.options,
+                resources,
+                permission: 'write'
+            };
+
+            tokenMock.options = {
+                ...testToken.options,
+                resources
+            };
+            tokenMock.toJson.returns({ ...testToken, options: expectedOptions });
+            options.payload = {
+                options: {
+                    permission: 'write'
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(tokenMock.options, expectedOptions);
+                assert.deepEqual(reply.result.options, expectedOptions);
+                assert.calledOnce(tokenMock.update);
+            });
+        });
+
+        it('merges token options when updating multiple options', () => {
+            const existingOptions = {
+                permission: 'read',
+                resources: {
+                    pipelines: [123]
+                }
+            };
+            const expectedOptions = {
+                permission: 'write',
+                resources: {
+                    organizations: ['example']
+                }
+            };
+
+            tokenMock.options = existingOptions;
+            tokenMock.toJson.returns({ ...testToken, options: expectedOptions });
+            options.payload = {
+                options: {
+                    permission: 'write',
+                    resources: {
+                        organizations: ['example']
+                    }
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(tokenMock.options, expectedOptions);
+                assert.deepEqual(reply.result.options, expectedOptions);
+                assert.calledOnce(tokenMock.update);
+            });
+        });
+
         it('returns 403 when the user does not own the token', () => {
             userFactoryMock.get.withArgs({ username, scmContext }).resolves({
                 id: testToken.userId + 1
@@ -409,6 +473,18 @@ describe('token plugin test', () => {
                 assert.equal(reply.statusCode, 200);
                 assert.calledOnce(tokenMock.refresh);
                 assert.deepEqual(reply.result, expected);
+            });
+        });
+
+        it('updates expiresAt when refreshing with an expiration date', () => {
+            const expiresAt = '2030-01-01T00:00:00.000Z';
+
+            options.payload = { expiresAt };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.equal(tokenMock.expiresAt, expiresAt);
+                assert.calledOnce(tokenMock.refresh);
             });
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Updating a token's `options` currently replaces the entire options object, which can unintentionally remove existing permissions or resource settings. In addition, refreshing a token does not allow its expiration date to be updated.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- Preserve existing token options when updating only part of the `options` object.
- Allow the expiration date (`expiresAt`) to be specified when refreshing a token.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#3508 
screwdriver-cd/ui#1594

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
