### PR TITLE
fix(3508): handle empty token options on update

### DIFF
--- a/plugins/pipelines/tokens/update.js
+++ b/plugins/pipelines/tokens/update.js
@@ -65,21 +65,16 @@ module.exports = () => ({
                         throw boom.conflict(`Token ${match.name} already exists`);
                     }
 
-                    let payloadOptions;
-
-                    if (request.payload && request.payload.options) {
-                        payloadOptions = request.payload.options;
-                    }
-
                     Object.keys(request.payload).forEach(key => {
                         if (key === 'options') {
-                            const hasResourceUpdates =
-                                payloadOptions.resources && Object.keys(payloadOptions.resources).length > 0;
+                            const payloadOptions = request.payload.options || {};
+                            const tokenOptions = token.options || {};
+                            const hasResourceUpdates = Object.keys(payloadOptions.resources || {}).length > 0;
 
                             token.options = {
-                                ...token.options,
+                                ...tokenOptions,
                                 ...payloadOptions,
-                                resources: hasResourceUpdates ? payloadOptions.resources : token.options.resources
+                                resources: hasResourceUpdates ? payloadOptions.resources : tokenOptions.resources || {}
                             };
                         } else {
                             token[key] = request.payload[key];

--- a/plugins/tokens/update.js
+++ b/plugins/tokens/update.js
@@ -50,21 +50,18 @@ module.exports = () => ({
                             throw boom.conflict(`Token with name ${match.name} already exists`);
                         }
 
-                        let payloadOptions;
-
-                        if (request.payload && request.payload.options) {
-                            payloadOptions = request.payload.options;
-                        }
-
                         Object.keys(request.payload).forEach(key => {
                             if (key === 'options') {
-                                const hasResourceUpdates =
-                                    payloadOptions.resources && Object.keys(payloadOptions.resources).length > 0;
+                                const payloadOptions = request.payload.options || {};
+                                const tokenOptions = token.options || {};
+                                const hasResourceUpdates = Object.keys(payloadOptions.resources || {}).length > 0;
 
                                 token.options = {
-                                    ...token.options,
+                                    ...tokenOptions,
                                     ...payloadOptions,
-                                    resources: hasResourceUpdates ? payloadOptions.resources : token.options.resources
+                                    resources: hasResourceUpdates
+                                        ? payloadOptions.resources
+                                        : tokenOptions.resources || {}
                                 };
                             } else {
                                 token[key] = request.payload[key];

--- a/test/plugins/pipelines.test.js
+++ b/test/plugins/pipelines.test.js
@@ -4502,6 +4502,49 @@ describe('pipeline plugin test', () => {
             });
         });
 
+        it('preserves existing resources when options resources are empty', () => {
+            const existingOptions = {
+                permission: 'read',
+                resources: {
+                    pipelines: [123]
+                }
+            };
+
+            tokenMock.options = existingOptions;
+            tokenMock.toJson.returns({ ...testTokens, options: existingOptions });
+            options.payload = {
+                options: {
+                    permission: 'write',
+                    resources: {}
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(tokenMock.options, {
+                    permission: 'write',
+                    resources: existingOptions.resources
+                });
+                assert.calledOnce(tokenMock.update);
+            });
+        });
+
+        it('initializes options when updating a token without existing options', () => {
+            tokenMock.options = undefined;
+            tokenMock.toJson.returns({ ...testTokens, options: { permission: 'write', resources: {} } });
+            options.payload = {
+                options: {
+                    permission: 'write'
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(tokenMock.options, { permission: 'write', resources: {} });
+                assert.calledOnce(tokenMock.update);
+            });
+        });
+
         it('returns 403 when user does not have admin permission', () => {
             const error = {
                 statusCode: 403,

--- a/test/plugins/tokens.test.js
+++ b/test/plugins/tokens.test.js
@@ -409,6 +409,49 @@ describe('token plugin test', () => {
             });
         });
 
+        it('preserves existing resources when options resources are empty', () => {
+            const existingOptions = {
+                permission: 'read',
+                resources: {
+                    pipelines: [123]
+                }
+            };
+
+            tokenMock.options = existingOptions;
+            tokenMock.toJson.returns({ ...testToken, options: existingOptions });
+            options.payload = {
+                options: {
+                    permission: 'write',
+                    resources: {}
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(tokenMock.options, {
+                    permission: 'write',
+                    resources: existingOptions.resources
+                });
+                assert.calledOnce(tokenMock.update);
+            });
+        });
+
+        it('initializes options when updating a token without existing options', () => {
+            tokenMock.options = undefined;
+            tokenMock.toJson.returns({ ...testToken, options: { permission: 'write', resources: {} } });
+            options.payload = {
+                options: {
+                    permission: 'write'
+                }
+            };
+
+            return server.inject(options).then(reply => {
+                assert.equal(reply.statusCode, 200);
+                assert.deepEqual(tokenMock.options, { permission: 'write', resources: {} });
+                assert.calledOnce(tokenMock.update);
+            });
+        });
+
         it('returns 403 when the user does not own the token', () => {
             userFactoryMock.get.withArgs({ username, scmContext }).resolves({
                 id: testToken.userId + 1


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR is follow up for #3529

Token Update could fail when an existing token had empty or undefined options, especially when updating only the token permission without providing resource settings.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Update token options safely even when existing options are empty, while preserving existing resources when no resource changes are provided. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
#3508 

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
