### PR TITLE
feat(3527): refix error messages when the pipeline has been deleted and no jobs to start message [1]

### DIFF
--- a/plugins/events/create.js
+++ b/plugins/events/create.js
@@ -295,10 +295,6 @@ module.exports = () => ({
 
             const event = await createEvent(payload, request.server);
 
-            if (event.builds === null) {
-                return boom.notFound('No jobs to start.');
-            }
-
             // everything succeeded, inform the user
             const location = urlLib.format({
                 host: request.headers.host,
@@ -306,6 +302,15 @@ module.exports = () => ({
                 protocol: request.server.info.protocol,
                 pathname: `${request.path}/${event.id}`
             });
+
+            if (event.builds === null) {
+                return h
+                    .response(event.toJson())
+                    .header('X-Status-Message', 'No jobs to start.')
+                    .header('Access-Control-Expose-Headers', 'X-Status-Message')
+                    .header('Location', location)
+                    .code(201);
+            }
 
             return h.response(event.toJson()).header('Location', location).code(201);
         },

--- a/test/plugins/events.test.js
+++ b/test/plugins/events.test.js
@@ -1903,12 +1903,13 @@ describe('event plugin test', () => {
             });
         });
 
-        it('returns 404 when event have no builds', () => {
+        it('returns 201 when event have no builds', () => {
             testEvent.builds = null;
             eventFactoryMock.create.resolves(getEventMock(testEvent));
 
             return server.inject(options).then(reply => {
-                assert.equal(reply.statusCode, 404);
+                assert.equal(reply.statusCode, 201);
+                assert.equal(reply.headers['x-status-message'], 'No jobs to start.');
                 delete testEvent.builds;
             });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Fix: https://github.com/screwdriver-cd/ui/pull/1593, https://github.com/screwdriver-cd/ui/pull/1595

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR brings back the fix for deleted repository error messages from #1593 (reverted in #1595).
It also changes the "no jobs to start" behavior, which caused the revert in #1595, as follows:

- API
  - Returns the created event with a 201 status as usual, because the event is actually created.
  - Sends the "no jobs to start" message in a custom header.
- UI
  - Shows the message in a modal if the custom header exists.
  - Moves to the created event page when you click "Close" on the confirmation button.
<img width="877" height="429" alt="スクリーンショット 2026-09-11 16 47 21" src="https://github.com/user-attachments/assets/3a082a74-cdb9-446f-81bb-f0a5a384ba66" />

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

#3527

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
